### PR TITLE
ci: automate winget manifest updates on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,3 +215,21 @@ jobs:
           gh release edit "v$version" --repo AdventDevInc/kudu --notes "${existing}
 
           ${vt_report}"
+
+  publish-winget:
+    needs: build
+    runs-on: windows-latest
+
+    steps:
+      - name: Get version from tag
+        id: version
+        shell: bash
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Update winget manifest
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.version }}"
+          $url = "https://github.com/AdventDevInc/kudu/releases/download/v$version/Kudu-Setup-$version.exe"
+          Invoke-WebRequest -Uri "https://aka.ms/wingetcreate/latest" -OutFile wingetcreate.exe
+          .\wingetcreate.exe update AdventDevelopmentInc.Kudu --submit --token "${{ secrets.WINGET_GH_TOKEN }}" --urls $url --version $version


### PR DESCRIPTION
## Summary
- Adds a `publish-winget` job to the release workflow
- After builds complete, downloads `wingetcreate` and submits a PR to microsoft/winget-pkgs with the updated installer URL and version

## Setup required
Add a **`WINGET_GH_TOKEN`** repository secret — a GitHub PAT with `public_repo` scope (needed to submit PRs to winget-pkgs).

## Test plan
- [x] Add `WINGET_GH_TOKEN` secret to the repo
- [ ] Run a patch release and verify the winget PR is created at https://github.com/microsoft/winget-pkgs/pulls

🤖 Generated with [Claude Code](https://claude.com/claude-code)