### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/AdventDevInc/kudu/security/code-scanning/1](https://github.com/AdventDevInc/kudu/security/code-scanning/1)

In general, fix this by explicitly specifying a `permissions` block for the workflow or for the individual job, granting the least privileges required (typically `contents: read` for basic CI that only needs to read the repo).

For this workflow, the simplest and safest change without altering existing functionality is to add a `permissions` block at the job level (under `build:` and aligned with `strategy:`). Since the steps only check out code and run local Node.js commands, `contents: read` is sufficient. No other scopes (like `pull-requests: write`) are needed based on the provided steps.

Concretely, in `.github/workflows/ci.yml`, add:

```yaml
    permissions:
      contents: read
```

between `build:` and `strategy:`. No imports or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
