### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,5 +1,9 @@
 name: License Check
 
+permissions:
+  contents: read
+  packages: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/AdventDevInc/kudu/security/code-scanning/5](https://github.com/AdventDevInc/kudu/security/code-scanning/5)

In general, the fix is to explicitly restrict the `GITHUB_TOKEN` permissions for this workflow to the minimal set required. This workflow only needs to read repository contents (for checkout) and read packages (for installing dependencies), and does not need any write permissions.

The best minimal fix without changing existing functionality is to add a `permissions` block at the workflow root (top level), so it applies to all jobs. Insert it after the `name:` line and before the `on:` block. Set it to `contents: read` and `packages: read`, which matches a safe read-only default for the operations performed here. No other parts of the workflow need to change.

Concretely, in `.github/workflows/license-check.yml`, add:

```yaml
permissions:
  contents: read
  packages: read
```

on new lines after line 1. No imports or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
