### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   commitlint:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/AdventDevInc/kudu/security/code-scanning/4](https://github.com/AdventDevInc/kudu/security/code-scanning/4)

In general, the fix is to explicitly define a `permissions` block that grants only the minimal required scopes to the `GITHUB_TOKEN`. For this `commitlint` job, the steps only need to check out code and read pull request commit SHAs; no write operations are required. Therefore, setting `contents: read` at minimum is appropriate. Optionally, `pull-requests: read` can be added for clarity, but GitHub Actions workflows can usually access `github.event.pull_request` fields without that scope, since it is part of the event payload.

The best, least-invasive fix is to add a `permissions` block under the `commitlint` job in `.github/workflows/commitlint.yml`, just before `runs-on: ubuntu-latest`. This keeps the change localized to the job CodeQL flagged. The block should look like:

```yaml
permissions:
  contents: read
```

This documents the intended permissions and prevents accidental elevation if organization/repo defaults change later. No imports or additional tooling are required because this is purely a workflow configuration change within the YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
