### PR TITLE
fix(security): validate cloud remote-access boolean fields in IPC

### DIFF
--- a/src/main/services/ipc-validation.ts
+++ b/src/main/services/ipc-validation.ts
@@ -135,6 +135,11 @@ export function validateSettingsPartial(input: unknown): Record<string, unknown>
     if ('telemetryIntervalSec' in c && (typeof c.telemetryIntervalSec !== 'number' || c.telemetryIntervalSec < 10 || c.telemetryIntervalSec > 3600)) return null
     if ('shareDiskHealth' in c && typeof c.shareDiskHealth !== 'boolean') return null
     if ('shareProcessList' in c && typeof c.shareProcessList !== 'boolean') return null
+    if ('shareThreatMonitor' in c && typeof c.shareThreatMonitor !== 'boolean') return null
+    if ('allowRemotePower' in c && typeof c.allowRemotePower !== 'boolean') return null
+    if ('allowRemoteCleanup' in c && typeof c.allowRemoteCleanup !== 'boolean') return null
+    if ('allowRemoteInstalls' in c && typeof c.allowRemoteInstalls !== 'boolean') return null
+    if ('allowRemoteConfig' in c && typeof c.allowRemoteConfig !== 'boolean') return null
   }
 
   return obj


### PR DESCRIPTION
## Summary
- Add missing type validation for 5 cloud configuration fields in `validateSettingsPartial()` that control sensitive remote-access capabilities: `shareThreatMonitor`, `allowRemotePower`, `allowRemoteCleanup`, `allowRemoteInstalls`, `allowRemoteConfig`
- These fields were in the `allowedCloudKeys` whitelist and accepted without type-checking, meaning a compromised renderer could inject non-boolean values that persist to settings and behave as truthy in downstream boolean checks

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 582/582 passing
- [ ] Verify cloud toggle settings still save correctly in Settings page

🤖 Generated with [Claude Code](https://claude.com/claude-code)