### PR TITLE
refactor(powershell): replace -EncodedCommand with -Command

### DIFF
--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -307,9 +307,8 @@ async function scanRecycleBin(): Promise<ScanResult[]> {
   const execFileAsync = promisify(execFile)
   try {
     const rbScript = `$shell = New-Object -ComObject Shell.Application; $rb = $shell.NameSpace(0x0a); $items = $rb.Items(); $count = $items.Count; $size = ($items | Measure-Object -Property Size -Sum).Sum; Write-Output "$count|$size"`
-    const encoded = Buffer.from(rbScript, 'utf16le').toString('base64')
     const { stdout } = await execFileAsync('powershell.exe', [
-      '-NoProfile', '-EncodedCommand', encoded
+      '-NoProfile', '-Command', rbScript
     ], { windowsHide: true })
     const [countStr, sizeStr] = stdout.trim().split('|')
     const count = parseInt(countStr) || 0
@@ -406,9 +405,8 @@ async function cleanRecycleBin(sizeBytes: number = 0): Promise<CleanResult> {
   const execFileAsync = promisify(execFile)
   try {
     const cleanScript = `$shell = New-Object -ComObject Shell.Application; $shell.NameSpace(0x0a).Items() | ForEach-Object { Remove-Item $_.Path -Recurse -Force -ErrorAction SilentlyContinue }; Clear-RecycleBin -Force -Confirm:$false -ErrorAction SilentlyContinue`
-    const cleanEncoded = Buffer.from(cleanScript, 'utf16le').toString('base64')
     await execFileAsync('powershell.exe', [
-      '-NoProfile', '-EncodedCommand', cleanEncoded
+      '-NoProfile', '-Command', cleanScript
     ], { windowsHide: true })
     return { totalCleaned: sizeBytes, filesDeleted: 1, filesSkipped: 0, errors: [], needsElevation: false }
   } catch (err: any) {

--- a/src/main/ipc/debloater.ipc.ts
+++ b/src/main/ipc/debloater.ipc.ts
@@ -9,8 +9,8 @@ import { validateStringArray } from '../services/ipc-validation'
 
 const execFileAsync = promisify(execFile)
 
-function psEncoded(script: string): string[] {
-  return ['-NoProfile', '-NonInteractive', '-EncodedCommand', Buffer.from(script, 'utf16le').toString('base64')]
+function psArgs(script: string): string[] {
+  return ['-NoProfile', '-NonInteractive', '-Command', script]
 }
 
 // Known bloatware packages with metadata
@@ -152,7 +152,7 @@ export async function scanBloatware(): Promise<BloatwareApp[]> {
         }
         [PSCustomObject]@{ Name = $_.Name; PackageFullName = $_.PackageFullName; InstallLocation = $_.InstallLocation; Size = $size }
       } | ConvertTo-Json -Compress`
-    const { stdout } = await execFileAsync('powershell', psEncoded(appxScript), { timeout: 60000, windowsHide: true })
+    const { stdout } = await execFileAsync('powershell', psArgs(appxScript), { timeout: 60000, windowsHide: true })
 
     let installedPackages: { Name: string; PackageFullName: string; InstallLocation: string; Size: number }[] = []
     try {
@@ -214,14 +214,14 @@ export async function removeBloatware(
     const safeName = pkgName.replace(/'/g, "''")
     onProgress?.(i + 1, validNames.length, pkgName, 'removing')
     try {
-      await execFileAsync('powershell', psEncoded(
+      await execFileAsync('powershell', psArgs(
         `Get-AppxPackage '${safeName}' | Remove-AppxPackage -ErrorAction Stop`
       ), { timeout: 30000, windowsHide: true })
       removed++
       onProgress?.(i + 1, validNames.length, pkgName, 'done')
 
       try {
-        await execFileAsync('powershell', psEncoded(
+        await execFileAsync('powershell', psArgs(
           `Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -eq '${safeName}' } | Remove-AppxProvisionedPackage -Online -ErrorAction SilentlyContinue`
         ), { timeout: 15000, windowsHide: true })
       } catch {

--- a/src/main/ipc/disk-analyzer.ipc.ts
+++ b/src/main/ipc/disk-analyzer.ipc.ts
@@ -138,9 +138,8 @@ export async function getDrives(): Promise<DriveInfo[]> {
   if (process.platform === 'win32') {
     try {
       const driveScript = `$fixed = (Get-WmiObject Win32_LogicalDisk | Where-Object { $_.DriveType -eq 3 }).DeviceID -replace ':',''; Get-PSDrive -PSProvider FileSystem | Where-Object { $_.Used -ne $null -and $fixed -contains $_.Name } | ForEach-Object { "$($_.Name)|$($_.Description)|$($_.Used)|$($_.Free)" }`
-      const driveEncoded = Buffer.from(driveScript, 'utf16le').toString('base64')
       const { stdout } = await execFileAsync('powershell.exe', [
-        '-NoProfile', '-EncodedCommand', driveEncoded
+        '-NoProfile', '-Command', driveScript
       ], { timeout: 10000, windowsHide: true })
 
       const drives: DriveInfo[] = []

--- a/src/main/ipc/driver-manager.ipc.ts
+++ b/src/main/ipc/driver-manager.ipc.ts
@@ -20,8 +20,8 @@ import type {
 
 const execFileAsync = promisify(execFile)
 
-function psEncoded(script: string): string[] {
-  return ['-NoProfile', '-NonInteractive', '-EncodedCommand', Buffer.from(script, 'utf16le').toString('base64')]
+function psArgs(script: string): string[] {
+  return ['-NoProfile', '-NonInteractive', '-Command', script]
 }
 
 const DRIVER_STORE = join(
@@ -172,7 +172,7 @@ async function getOemFolderMap(): Promise<Map<string, string[]>> {
           }
         }
     `
-    const { stdout } = await execFileAsync('powershell', psEncoded(script), { timeout: 15000, windowsHide: true })
+    const { stdout } = await execFileAsync('powershell', psArgs(script), { timeout: 15000, windowsHide: true })
 
     for (const line of stdout.trim().split('\n')) {
       const trimmed = line.trim()
@@ -199,7 +199,7 @@ async function getActiveDriverNames(): Promise<Set<string>> {
         Select-Object -ExpandProperty InfName |
         Sort-Object -Unique
     `
-    const { stdout } = await execFileAsync('powershell', psEncoded(script), { timeout: 30000, windowsHide: true })
+    const { stdout } = await execFileAsync('powershell', psArgs(script), { timeout: 30000, windowsHide: true })
 
     for (const line of stdout.trim().split('\n')) {
       const name = line.trim().toLowerCase()
@@ -463,7 +463,7 @@ export async function scanDriverUpdates(
         }
       `
 
-      const { stdout } = await execFileAsync('powershell', psEncoded(script), { timeout: 120000, maxBuffer: 10 * 1024 * 1024, windowsHide: true })
+      const { stdout } = await execFileAsync('powershell', psArgs(script), { timeout: 120000, maxBuffer: 10 * 1024 * 1024, windowsHide: true })
 
       const lines = stdout.trim().split('\n').map((l: string) => l.trim()).filter(Boolean)
 
@@ -611,7 +611,7 @@ export async function installDriverUpdates(
           Write-Output "RESULT|$ok|$fail|$reboot"
         `
 
-        const { stdout } = await execFileAsync('powershell', psEncoded(script), { timeout: 600000, maxBuffer: 10 * 1024 * 1024, windowsHide: true })
+        const { stdout } = await execFileAsync('powershell', psArgs(script), { timeout: 600000, maxBuffer: 10 * 1024 * 1024, windowsHide: true })
 
         const lines = stdout.trim().split('\n').map((l: string) => l.trim()).filter(Boolean)
 

--- a/src/main/ipc/game-mode.ipc.ts
+++ b/src/main/ipc/game-mode.ipc.ts
@@ -186,9 +186,8 @@ const PROTECTED_PROCESSES = new Set([
 // ── Helper: run PowerShell ───────────────────────────────────
 
 async function ps(script: string, timeout = 15000): Promise<string> {
-  const encoded = Buffer.from(script, 'utf16le').toString('base64')
   const { stdout } = await execFileAsync('powershell.exe', [
-    '-NoProfile', '-NonInteractive', '-EncodedCommand', encoded,
+    '-NoProfile', '-NonInteractive', '-Command', script,
   ], { timeout, windowsHide: true })
   return stdout.trim()
 }

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -118,9 +118,8 @@ export function registerCleanerIpc(getWindow: WindowGetter): void {
       // declines UAC, then returns.  If the user declines, PowerShell exits
       // with an error and we don't quit.
       const psScript = `Start-Process -FilePath '${exePath.replace(/'/g, "''")}' -Verb RunAs`
-      const encoded = Buffer.from(psScript, 'utf16le').toString('base64')
       execFile('powershell.exe', [
-        '-NoProfile', '-EncodedCommand', encoded,
+        '-NoProfile', '-Command', psScript,
       ], { windowsHide: true }, (err) => {
         if (!err) app.exit(0)
       })

--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -17,8 +17,8 @@ import { validateStringArray } from '../services/ipc-validation'
 
 const execFileAsync = promisify(execFile)
 
-function psEncoded(script: string): string[] {
-  return ['-NoProfile', '-NonInteractive', '-EncodedCommand', Buffer.from(script, 'utf16le').toString('base64')]
+function psArgs(script: string): string[] {
+  return ['-NoProfile', '-NonInteractive', '-Command', script]
 }
 
 // ─── Quarantine folder ────────────────────────────────────────
@@ -669,7 +669,7 @@ foreach ($p in $paths) {
 `.trim()
 
   try {
-    const { stdout } = await execFileAsync('powershell.exe', psEncoded(script), { timeout: 30000, windowsHide: true })
+    const { stdout } = await execFileAsync('powershell.exe', psArgs(script), { timeout: 30000, windowsHide: true })
 
     const results: AdsResult[] = []
     for (const line of stdout.split('\n')) {

--- a/src/main/ipc/recycle-bin.ipc.ts
+++ b/src/main/ipc/recycle-bin.ipc.ts
@@ -12,8 +12,8 @@ import { cacheItems } from '../services/scan-cache'
 
 const execFileAsync = promisify(execFile)
 
-function psEncoded(script: string): string[] {
-  return ['-NoProfile', '-NonInteractive', '-EncodedCommand', Buffer.from(script, 'utf16le').toString('base64')]
+function psArgs(script: string): string[] {
+  return ['-NoProfile', '-NonInteractive', '-Command', script]
 }
 
 // Windows: track last scanned size (virtual items have no real path)
@@ -43,7 +43,7 @@ export function registerRecycleBinIpc(): void {
 
     // Windows: COM-based recycle bin
     try {
-      const { stdout } = await execFileAsync('powershell.exe', psEncoded(
+      const { stdout } = await execFileAsync('powershell.exe', psArgs(
         `$shell = New-Object -ComObject Shell.Application; $rb = $shell.NameSpace(0x0a); $items = $rb.Items(); $count = $items.Count; $size = ($items | Measure-Object -Property Size -Sum).Sum; Write-Output "$count|$size"`
       ), { windowsHide: true })
 
@@ -93,12 +93,12 @@ export function registerRecycleBinIpc(): void {
     const sizeBeforeClean = lastScannedSize
     try {
       // Flags: SHERB_NOCONFIRMATION(1) | SHERB_NOPROGRESSUI(2) | SHERB_NOSOUND(4) = 7
-      await execFileAsync('powershell.exe', psEncoded(
+      await execFileAsync('powershell.exe', psArgs(
         `Add-Type -TypeDefinition 'using System; using System.Runtime.InteropServices; public class RecycleBin { [DllImport("Shell32.dll", CharSet = CharSet.Unicode)] public static extern uint SHEmptyRecycleBin(IntPtr hwnd, string pszRootPath, uint dwFlags); }'; [RecycleBin]::SHEmptyRecycleBin([IntPtr]::Zero, $null, 7)`
       ), { windowsHide: true })
 
       // Verify the bin is actually empty
-      const { stdout } = await execFileAsync('powershell.exe', psEncoded(
+      const { stdout } = await execFileAsync('powershell.exe', psArgs(
         `$shell = New-Object -ComObject Shell.Application; $rb = $shell.NameSpace(0x0a); $items = $rb.Items(); Write-Output $items.Count`
       ), { windowsHide: true })
       const remaining = parseInt(stdout.trim()) || 0

--- a/src/main/ipc/registry-cleaner.ipc.ts
+++ b/src/main/ipc/registry-cleaner.ipc.ts
@@ -1453,9 +1453,8 @@ export async function scanRegistry(): Promise<RegistryEntry[]> {
         let isSSD = false
         try {
           const diskScript = `$disk = Get-PhysicalDisk | Where-Object { $_.DeviceID -eq (Get-Partition -DriveLetter C | Get-Disk).Number }; $disk.MediaType`
-          const diskEncoded = Buffer.from(diskScript, 'utf16le').toString('base64')
           const { stdout: driveInfo } = await execFileAsync('powershell', [
-            '-NoProfile', '-EncodedCommand', diskEncoded
+            '-NoProfile', '-Command', diskScript
           ], { timeout: 10000, windowsHide: true })
           isSSD = driveInfo.trim().toUpperCase() === 'SSD'
         } catch { /* Assume HDD if detection fails — safer to leave SysMain enabled */ }
@@ -1742,9 +1741,8 @@ export async function fixRegistryEntries(
             const safeDisablePath = disableParts.path.replace(/'/g, "''")
             const safeDisableName = disableParts.name.replace(/'/g, "''")
             const disableScript = `Disable-ScheduledTask -TaskPath '${safeDisablePath}' -TaskName '${safeDisableName}' -ErrorAction Stop`
-            const disableEncoded = Buffer.from(disableScript, 'utf16le').toString('base64')
             await execFileAsync('powershell', [
-              '-NoProfile', '-NonInteractive', '-EncodedCommand', disableEncoded
+              '-NoProfile', '-NonInteractive', '-Command', disableScript
             ], { timeout: 10000, windowsHide: true })
             break
           }
@@ -1755,9 +1753,8 @@ export async function fixRegistryEntries(
             const safeDeletePath = deleteParts.path.replace(/'/g, "''")
             const safeDeleteName = deleteParts.name.replace(/'/g, "''")
             const deleteScript = `Unregister-ScheduledTask -TaskPath '${safeDeletePath}' -TaskName '${safeDeleteName}' -Confirm:$false -ErrorAction Stop`
-            const deleteEncoded = Buffer.from(deleteScript, 'utf16le').toString('base64')
             await execFileAsync('powershell', [
-              '-NoProfile', '-NonInteractive', '-EncodedCommand', deleteEncoded
+              '-NoProfile', '-NonInteractive', '-Command', deleteScript
             ], { timeout: 10000, windowsHide: true })
             break
           }

--- a/src/main/ipc/service-manager.ipc.ts
+++ b/src/main/ipc/service-manager.ipc.ts
@@ -16,8 +16,8 @@ import { getPlatform } from '../platform'
 
 const execFileAsync = promisify(execFile)
 
-function psEncoded(script: string): string[] {
-  return ['-NoProfile', '-NonInteractive', '-EncodedCommand', Buffer.from(script, 'utf16le').toString('base64')]
+function psArgs(script: string): string[] {
+  return ['-NoProfile', '-NonInteractive', '-Command', script]
 }
 const PS_OPTS = { timeout: 60_000, maxBuffer: 10 * 1024 * 1024, windowsHide: true }
 
@@ -81,7 +81,7 @@ export async function scanServices(
       }
     `
 
-    const { stdout } = await execFileAsync('powershell', psEncoded(script), PS_OPTS)
+    const { stdout } = await execFileAsync('powershell', psArgs(script), PS_OPTS)
 
     const lines = stdout.split('\n').filter((l) => l.startsWith('SVC|'))
     const serviceNames: string[] = []
@@ -127,7 +127,7 @@ export async function scanServices(
 
     let depMap: Record<string, { dependsOn: string[]; dependents: string[] }> = {}
     try {
-      const { stdout: depOut } = await execFileAsync('powershell', psEncoded(depScript), PS_OPTS)
+      const { stdout: depOut } = await execFileAsync('powershell', psArgs(depScript), PS_OPTS)
       for (const line of depOut.split('\n').filter((l) => l.startsWith('DEP|'))) {
         const parts = line.trim().split('|')
         if (parts.length >= 4) {
@@ -235,7 +235,7 @@ try {
       const errors: { name: string; displayName: string; reason: string }[] = []
 
       try {
-        const { stdout } = await execFileAsync('powershell', psEncoded(script), {
+        const { stdout } = await execFileAsync('powershell', psArgs(script), {
           ...PS_OPTS,
           timeout: validChanges.length * 10_000 + 30_000 // generous timeout
         })

--- a/src/main/ipc/shortcut-cleaner.ipc.ts
+++ b/src/main/ipc/shortcut-cleaner.ipc.ts
@@ -39,9 +39,8 @@ Get-ChildItem -Path '${dir.replace(/'/g, "''")}' -Filter '*.lnk' -Recurse -Error
     "$($_.FullName)|$($sc.TargetPath)"
   } catch { "$($_.FullName)|" }
 }`
-    const encoded = Buffer.from(psScript, 'utf16le').toString('base64')
     const { stdout } = await execFileAsync('powershell.exe', [
-      '-NoProfile', '-EncodedCommand', encoded,
+      '-NoProfile', '-Command', psScript,
     ], { timeout: 30000, windowsHide: true })
 
     const results: ShortcutInfo[] = []

--- a/src/main/ipc/startup-manager.ipc.ts
+++ b/src/main/ipc/startup-manager.ipc.ts
@@ -10,8 +10,8 @@ import { getPlatform } from '../platform'
 
 const execFileAsync = promisify(execFile)
 
-function psEncoded(script: string): string[] {
-  return ['-NoProfile', '-NonInteractive', '-EncodedCommand', Buffer.from(script, 'utf16le').toString('base64')]
+function psArgs(script: string): string[] {
+  return ['-NoProfile', '-NonInteractive', '-Command', script]
 }
 
 interface DisabledEntry {
@@ -237,7 +237,7 @@ async function getScheduledLogonTasks(): Promise<StartupItem[]> {
       }
     `
 
-    const { stdout } = await execFileAsync('powershell', psEncoded(script), { timeout: 15000, windowsHide: true })
+    const { stdout } = await execFileAsync('powershell', psArgs(script), { timeout: 15000, windowsHide: true })
 
     const lines = stdout.trim().split('\n').map((l: string) => l.trim()).filter(Boolean)
     for (const line of lines) {
@@ -372,7 +372,7 @@ export async function toggleStartupItem(
         // Enable/disable scheduled tasks via PowerShell
         try {
           const action = enabled ? 'Enable-ScheduledTask' : 'Disable-ScheduledTask'
-          await execFileAsync('powershell', psEncoded(
+          await execFileAsync('powershell', psArgs(
             `${action} -TaskName '${name.replace(/'/g, "''")}' -ErrorAction Stop`
           ), { timeout: 10000, windowsHide: true })
         } catch {
@@ -467,7 +467,7 @@ export async function deleteStartupItem(
       try {
         if (source === 'task-scheduler') {
           if (!isSafeTaskName(name)) return false
-          await execFileAsync('powershell', psEncoded(
+          await execFileAsync('powershell', psArgs(
             `Unregister-ScheduledTask -TaskName '${name.replace(/'/g, "''")}' -Confirm:$false -ErrorAction Stop`
           ), { timeout: 10000, windowsHide: true })
           deletedSource = true
@@ -632,7 +632,7 @@ export async function getBootTrace(): Promise<StartupBootTrace> {
       } catch {}
     `
 
-    const { stdout } = await execFileAsync('powershell', psEncoded(bootScript), { timeout: 15000, windowsHide: true })
+    const { stdout } = await execFileAsync('powershell', psArgs(bootScript), { timeout: 15000, windowsHide: true })
 
     const lines = stdout.trim().split('\n').map((l: string) => l.trim()).filter(Boolean)
 

--- a/src/main/services/cloud-agent.ts
+++ b/src/main/services/cloud-agent.ts
@@ -1890,9 +1890,8 @@ class CloudAgentService {
         // Windows: COM-based recycle bin query
         try {
           const rbScript = `$shell = New-Object -ComObject Shell.Application; $rb = $shell.NameSpace(0x0a); $items = $rb.Items(); $count = $items.Count; $size = ($items | Measure-Object -Property Size -Sum).Sum; Write-Output "$count|$size"`
-          const rbEncoded = Buffer.from(rbScript, 'utf16le').toString('base64')
           const { stdout } = await execFileAsync('powershell.exe', [
-            '-NoProfile', '-EncodedCommand', rbEncoded
+            '-NoProfile', '-Command', rbScript
           ], { windowsHide: true })
           const [countStr, sizeStr] = stdout.trim().split('|')
           const count = parseInt(countStr) || 0

--- a/src/main/services/perf-monitor.ts
+++ b/src/main/services/perf-monitor.ts
@@ -184,9 +184,8 @@ export class PerfMonitorService {
 
     try {
       const script = 'Get-PhysicalDisk | ForEach-Object { $disk = $_; $rel = $_ | Get-StorageReliabilityCounter; [PSCustomObject]@{ DeviceId = $disk.DeviceId; Temperature = $rel.Temperature; PowerOnHours = $rel.PowerOnHours; ReadErrorsTotal = $rel.ReadErrorsTotal; WriteErrorsTotal = $rel.WriteErrorsTotal; Wear = $rel.Wear } } | ConvertTo-Json -Compress'
-      const encoded = Buffer.from(script, 'utf16le').toString('base64')
 
-      const { stdout } = await execFileAsync('powershell.exe', ['-NoProfile', '-EncodedCommand', encoded], {
+      const { stdout } = await execFileAsync('powershell.exe', ['-NoProfile', '-Command', script], {
         timeout: 10000, windowsHide: true
       })
 

--- a/src/main/services/program-uninstaller.ts
+++ b/src/main/services/program-uninstaller.ts
@@ -389,9 +389,8 @@ async function hasRunningProcesses(folderPaths: string[]): Promise<Set<string>> 
 
   try {
     const procScript = 'Get-Process | Where-Object { $_.Path } | Select-Object -ExpandProperty Path -Unique'
-    const procEncoded = Buffer.from(procScript, 'utf16le').toString('base64')
     const { stdout } = await execFileAsync('powershell', [
-      '-NoProfile', '-NoLogo', '-EncodedCommand', procEncoded,
+      '-NoProfile', '-NoLogo', '-Command', procScript,
     ], { timeout: 10000, windowsHide: true })
 
     const processPaths = stdout.split(/\r?\n/).map((p) => p.trim().toLowerCase()).filter(Boolean)

--- a/src/main/services/uninstall-leftovers.ts
+++ b/src/main/services/uninstall-leftovers.ts
@@ -186,9 +186,8 @@ async function hasRunningProcesses(folderPaths: string[]): Promise<Set<string>> 
   try {
     // Get all running process paths in one call
     const procScript = 'Get-Process | Where-Object { $_.Path } | Select-Object -ExpandProperty Path -Unique'
-    const procEncoded = Buffer.from(procScript, 'utf16le').toString('base64')
     const { stdout } = await execFileAsync('powershell', [
-      '-NoProfile', '-NoLogo', '-EncodedCommand', procEncoded,
+      '-NoProfile', '-NoLogo', '-Command', procScript,
     ], { timeout: 10000, windowsHide: true })
 
     const processPaths = stdout


### PR DESCRIPTION
## Summary
- Replaced all 19 `-EncodedCommand` + base64 encoding call sites with plain `-Command` across 16 files
- Renamed `psEncoded()` helpers to `psArgs()` in 6 IPC files
- Eliminates false positives from Sigma security rules (Emotet detection, encoded PowerShell patterns) and EDR/antivirus alerts

All call sites use `execFile`/`execFileAsync` (no shell interpolation), so `-Command` works identically without the security tool noise.

## Test plan
- [ ] Verify app launches and elevates correctly (UAC prompt via `index.ts`)
- [ ] Test recycle bin scan + clean (cli.ts, recycle-bin.ipc.ts, cloud-agent.ts)
- [ ] Test bloatware scan + removal (debloater.ipc.ts)
- [ ] Test driver scan + cleanup (driver-manager.ipc.ts)
- [ ] Test disk analyzer drive detection (disk-analyzer.ipc.ts)
- [ ] Test game mode optimizations (game-mode.ipc.ts)
- [ ] Test malware scanner (malware-scanner.ipc.ts)
- [ ] Test registry cleaner including SSD detection and scheduled tasks (registry-cleaner.ipc.ts)
- [ ] Test service manager scan + apply (service-manager.ipc.ts)
- [ ] Test startup manager scan + toggle + delete (startup-manager.ipc.ts)
- [ ] Test shortcut cleaner (shortcut-cleaner.ipc.ts)
- [ ] Test perf monitor storage reliability (perf-monitor.ts)
- [ ] Test program uninstaller process detection (program-uninstaller.ts, uninstall-leftovers.ts)
- [ ] Confirm no Sigma/EDR alerts on the built binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)