### PR TITLE
fix: patch 4 high-severity bugs from codebase review

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -129,7 +129,7 @@ async function applyAutoLaunchWin32(enabled: boolean): Promise<void> {
 
     const tmpPath = join(app.getPath('temp'), `${TASK_NAME}.xml`)
     const { writeFile, unlink } = await import('fs/promises')
-    await writeFile(tmpPath, xml, 'utf-16le')
+    await writeFile(tmpPath, '\uFEFF' + xml, 'utf-16le')
 
     try {
       await execFileAsync('schtasks', [

--- a/src/main/ipc/service-manager.ipc.ts
+++ b/src/main/ipc/service-manager.ipc.ts
@@ -213,7 +213,13 @@ export async function applyServiceChanges(
       // Build a single PowerShell script for all changes
       const lines = validChanges.map((c) => {
         const safeName = c.name.replace(/'/g, "''")
-        const safeType = c.targetStartType === 'Manual' ? 'Manual' : 'Disabled'
+        const ALLOWED_TYPES: Record<string, string> = {
+          Manual: 'Manual',
+          Disabled: 'Disabled',
+          Automatic: 'Automatic',
+          AutomaticDelayed: 'AutomaticDelayedStart',
+        }
+        const safeType = ALLOWED_TYPES[c.targetStartType] ?? 'Disabled'
         return `
 try {
   $svc = Get-Service -Name '${safeName}' -ErrorAction Stop

--- a/src/main/services/cloud-agent.ts
+++ b/src/main/services/cloud-agent.ts
@@ -2746,6 +2746,14 @@ class CloudAgentService {
       return
     }
 
+    // DNS rebinding protection: verify the domain doesn't resolve to a private IP
+    try {
+      await assertPublicResolution(url)
+    } catch (err) {
+      await this.postCommandResult(requestId, false, undefined, err instanceof Error ? err.message : 'DNS rebinding check failed')
+      return
+    }
+
     cloudLog('INFO', `Updating threat blacklist from ${url}`)
     const result = await downloadAndUpdateBlacklist(url)
 

--- a/src/main/services/file-utils.ts
+++ b/src/main/services/file-utils.ts
@@ -18,9 +18,12 @@ export interface DeleteResult {
  */
 export function isExcluded(filePath: string, exclusions: string[]): boolean {
   if (exclusions.length === 0) return false
-  const normalized = filePath.toLowerCase().replace(/\//g, '\\')
+  // Only normalize to backslash on Windows; on Linux/macOS forward slash is the separator
+  const toSep = process.platform === 'win32' ? /\//g : /\\/g
+  const sep = process.platform === 'win32' ? '\\' : '/'
+  const normalized = filePath.toLowerCase().replace(toSep, sep)
   for (const exc of exclusions) {
-    const pattern = exc.toLowerCase().replace(/\//g, '\\')
+    const pattern = exc.toLowerCase().replace(toSep, sep)
     if (pattern.startsWith('*.')) {
       // Extension glob: *.log, *.tmp etc.
       if (normalized.endsWith(pattern.substring(1))) return true


### PR DESCRIPTION
## Summary

- **fix(file-utils):** `isExcluded()` hardcoded path normalization to backslash (`\`), completely breaking exclusion matching on Linux and macOS where `/` is the path separator. Now uses platform-aware separator.
- **fix(cloud-agent):** `handleUpdateThreatBlacklist` validated the URL hostname for private IP *literals* but never called `assertPublicResolution()` to check DNS resolution, leaving a DNS rebinding SSRF vector. Now calls the existing `assertPublicResolution()` before downloading.
- **fix(service-manager):** `applyServiceChanges` only allowed `Manual` or `Disabled` start types — any request to restore a service to `Automatic` or `AutomaticDelayed` was silently downgraded to `Disabled`. Now supports all 4 valid start types via an allowlist.
- **fix(index):** Windows Task Scheduler XML was written as UTF-16LE without a BOM. `schtasks /Create` expects a BOM to correctly identify the encoding; without it, auto-launch registration can silently fail (especially with non-ASCII exe paths). Added `\uFEFF` BOM.

## Test plan

- [x] All 779 existing tests pass
- [ ] Verify exclusion rules work on Linux/macOS (e.g. add a path exclusion, run a scan, confirm excluded paths are skipped)
- [ ] Verify service manager can restore a service to Automatic start type on Windows
- [ ] Verify auto-launch registration works on Windows with a path containing spaces
- [ ] Verify threat blacklist update rejects domains resolving to private IPs

🤖 Generated with [Claude Code](https://claude.com/claude-code)