### PR TITLE
fix(elevation): share config and fix paste when relaunched as admin

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -29,10 +29,26 @@ if (process.argv.includes('--daemon') || process.argv.includes('--cli')) {
   app.commandLine.appendSwitch('ozone-platform', 'headless')
 }
 
-// ─── Linux root detection ────────────────────────────────────
-// Chromium refuses to run as root without --no-sandbox.  This is hit when
-// the user relaunches via pkexec or runs with sudo for privileged ops.
-if (process.platform === 'linux' && typeof process.getuid === 'function' && process.getuid() === 0) {
+// ─── Data directory override ────────────────────────────────
+// When relaunched as root (macOS/Linux), the elevated process receives
+// --kudu-data-dir=<path> so it reads/writes the original user's config
+// instead of /var/root/... or /root/...
+const dataDirFlag = process.argv.find(a => a.startsWith('--kudu-data-dir='))
+if (dataDirFlag) {
+  const dir = dataDirFlag.slice('--kudu-data-dir='.length)
+  if (dir && require('path').isAbsolute(dir)) {
+    app.setPath('userData', dir)
+  }
+}
+
+// ─── Root detection (macOS + Linux) ─────────────────────────
+// Chromium refuses to run as root without --no-sandbox.  Also required
+// on macOS for clipboard access (paste) in the elevated process.
+if (
+  (process.platform === 'linux' || process.platform === 'darwin') &&
+  typeof process.getuid === 'function' &&
+  process.getuid() === 0
+) {
   app.commandLine.appendSwitch('no-sandbox')
 }
 

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -116,6 +116,7 @@ export function registerCleanerIpc(getWindow: WindowGetter): void {
   ipcMain.handle(IPC.ELEVATION_CHECK, () => isAdmin())
   ipcMain.handle(IPC.ELEVATION_RELAUNCH, () => {
     const exePath = app.getPath('exe')
+    const userDataDir = app.getPath('userData')
 
     if (process.platform === 'win32') {
       // Use execFile so we wait for PowerShell to finish (including the UAC
@@ -129,7 +130,7 @@ export function registerCleanerIpc(getWindow: WindowGetter): void {
         if (!err) app.exit(0)
       })
     } else if (process.platform === 'linux') {
-      const child = spawn('pkexec', [exePath, '--no-sandbox'], {
+      const child = spawn('pkexec', [exePath, '--no-sandbox', `--kudu-data-dir=${userDataDir}`], {
         detached: true,
         stdio: 'ignore',
       })
@@ -143,8 +144,10 @@ export function registerCleanerIpc(getWindow: WindowGetter): void {
       // spawn-and-immediately-exit approach caused a race: the current app
       // would exit before the elevated process started, and macOS could
       // re-open the old registered copy via LaunchServices.
+      // Pass --kudu-data-dir so the elevated process uses the same config.
       const escaped = exePath.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
-      const script = `do shell script quoted form of "${escaped}" & " > /dev/null 2>&1 &" with administrator privileges`
+      const escapedDataDir = userDataDir.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+      const script = `do shell script quoted form of "${escaped}" & " --kudu-data-dir=" & quoted form of "${escapedDataDir}" & " > /dev/null 2>&1 &" with administrator privileges`
       execFile('osascript', ['-e', script], (err) => {
         if (!err) app.exit(0)
       })

--- a/src/main/services/logger.ts
+++ b/src/main/services/logger.ts
@@ -9,19 +9,23 @@ export function setDaemonMode(enabled: boolean): void {
   _daemonMode = enabled
 }
 
-const LOG_DIR = join(app.getPath('userData'), 'logs')
-const LOG_FILE = join(LOG_DIR, 'kudu.log')
-const LOG_FILE_OLD = join(LOG_DIR, 'kudu.old.log')
-const CLOUD_LOG_FILE = join(LOG_DIR, 'cloud-agent.log')
-const CLOUD_LOG_FILE_OLD = join(LOG_DIR, 'cloud-agent.old.log')
 const MAX_LOG_SIZE = 5 * 1024 * 1024 // 5 MB
 const ROTATION_CHECK_INTERVAL_MS = 60_000 // only stat the file every 60s
 
-try {
-  mkdirSync(LOG_DIR, { recursive: true })
-} catch {
-  // Ignore
+// Lazy getters — LOG_DIR must not be resolved at import time because
+// app.setPath('userData', ...) may run later (e.g. elevated relaunch).
+let _logDir: string | null = null
+function logDir(): string {
+  if (!_logDir) {
+    _logDir = join(app.getPath('userData'), 'logs')
+    try { mkdirSync(_logDir, { recursive: true }) } catch { /* ignore */ }
+  }
+  return _logDir
 }
+function logFile(): string { return join(logDir(), 'kudu.log') }
+function logFileOld(): string { return join(logDir(), 'kudu.old.log') }
+function cloudLogFile(): string { return join(logDir(), 'cloud-agent.log') }
+function cloudLogFileOld(): string { return join(logDir(), 'cloud-agent.old.log') }
 
 const lastRotationCheck = new Map<string, number>()
 
@@ -49,8 +53,8 @@ function timestamp(): string {
 export function logInfo(message: string): void {
   const line = `[${timestamp()}] INFO: ${message}\n`
   try {
-    rotateIfNeeded(LOG_FILE, LOG_FILE_OLD)
-    appendFileSync(LOG_FILE, line)
+    rotateIfNeeded(logFile(), logFileOld())
+    appendFileSync(logFile(), line)
   } catch {
     // Ignore
   }
@@ -60,8 +64,8 @@ export function logError(message: string, error?: unknown): void {
   const errStr = error instanceof Error ? error.message : String(error ?? '')
   const line = `[${timestamp()}] ERROR: ${message} ${errStr}\n`
   try {
-    rotateIfNeeded(LOG_FILE, LOG_FILE_OLD)
-    appendFileSync(LOG_FILE, line)
+    rotateIfNeeded(logFile(), logFileOld())
+    appendFileSync(logFile(), line)
   } catch {
     // Ignore
   }
@@ -71,8 +75,8 @@ export function logDebug(message: string, data?: unknown): void {
   const extra = data !== undefined ? ` ${JSON.stringify(data)}` : ''
   const line = `[${timestamp()}] DEBUG: ${message}${extra}\n`
   try {
-    rotateIfNeeded(LOG_FILE, LOG_FILE_OLD)
-    appendFileSync(LOG_FILE, line)
+    rotateIfNeeded(logFile(), logFileOld())
+    appendFileSync(logFile(), line)
   } catch {
     // Ignore
   }
@@ -82,8 +86,8 @@ export function cloudLog(level: 'INFO' | 'ERROR' | 'DEBUG', message: string, dat
   const extra = data !== undefined ? ` ${JSON.stringify(data)}` : ''
   const line = `[${timestamp()}] ${level}: ${message}${extra}\n`
   try {
-    rotateIfNeeded(CLOUD_LOG_FILE, CLOUD_LOG_FILE_OLD)
-    appendFileSync(CLOUD_LOG_FILE, line)
+    rotateIfNeeded(cloudLogFile(), cloudLogFileOld())
+    appendFileSync(cloudLogFile(), line)
   } catch {
     // Ignore
   }


### PR DESCRIPTION
## What does this PR do?

Fixes two bugs when relaunching as admin on macOS (and Linux):

1. **Broken paste**: Extends the `--no-sandbox` Chromium flag from Linux-only to also cover macOS root, restoring clipboard/Cmd+V functionality in the elevated process.
2. **Two separate configs**: Passes `--kudu-data-dir=<path>` to the elevated process so it calls `app.setPath('userData', ...)` on startup, ensuring it reads/writes the original user's config instead of `/var/root/...`.
3. **Logger eagerly resolved paths**: Converts `LOG_DIR` and related constants in `logger.ts` from eager top-level evaluation to lazy getters, so the `userData` override takes effect before any path is resolved.

## Why?

When the app relaunches as root via `osascript` (macOS) or `pkexec` (Linux), `app.getPath('userData')` resolves to root's home directory. This causes a fresh config to be used and, on macOS, Chromium's sandbox prevents clipboard access.

## How to test

1. Launch the app on macOS
2. Configure some settings (e.g. change theme)
3. Click "Relaunch as Admin" and enter password
4. Verify settings persist after elevation
5. Verify Cmd+V (paste) works in text fields

## Checklist

- [x] Tested on my platform (Windows / macOS / Linux)
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)