### PR TITLE
fix(ui): disable hardware acceleration to prevent black window

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,8 +15,16 @@ import { cloudAgent } from './services/cloud-agent'
 import { runCli } from './cli'
 import { runDaemon } from './daemon'
 
+// ─── Disable hardware acceleration ──────────────────────────
+// Must be called before app.whenReady().  On machines with incompatible
+// GPU drivers, broken ANGLE, or certain VM setups, Chromium's GPU
+// compositor silently fails — resulting in a black window that the user
+// can resize but never see content in.  For a system-cleaner utility the
+// visual trade-off (software compositing) is negligible.
+app.disableHardwareAcceleration()
+
 // ─── Headless mode flags ─────────────────────────────────────
-// When running without a GUI (daemon or CLI), disable GPU and sandbox
+// When running without a GUI (daemon or CLI), disable sandbox
 // so Electron works on headless Linux servers without X11/Wayland.
 // IMPORTANT: Clear DISPLAY before Chromium initializes — otherwise the
 // native layer picks the X11 ozone backend before app.commandLine
@@ -24,7 +32,6 @@ import { runDaemon } from './daemon'
 if (process.argv.includes('--daemon') || process.argv.includes('--cli')) {
   delete process.env.DISPLAY
   delete process.env.WAYLAND_DISPLAY
-  app.disableHardwareAcceleration()
   app.commandLine.appendSwitch('no-sandbox')
   app.commandLine.appendSwitch('ozone-platform', 'headless')
 }

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -16,15 +16,17 @@ class ErrorBoundary extends React.Component<
 
   render() {
     if (this.state.error) {
+      // Use hardcoded colors — CSS variables may not be loaded when the
+      // error boundary triggers, which would make the text invisible.
       return (
-        <div style={{ padding: 32, color: 'var(--text-primary)', fontFamily: 'system-ui', background: 'var(--page-bg)', minHeight: '100vh' }}>
+        <div style={{ padding: 32, color: '#fafafa', fontFamily: 'system-ui', background: '#09090b', minHeight: '100vh' }}>
           <h1 style={{ fontSize: 20, marginBottom: 8 }}>Something went wrong</h1>
-          <pre style={{ color: 'var(--text-secondary)', fontSize: 13, whiteSpace: 'pre-wrap' }}>
+          <pre style={{ color: '#a1a1aa', fontSize: 13, whiteSpace: 'pre-wrap' }}>
             {this.state.error.message}
           </pre>
           <button
             onClick={() => window.location.reload()}
-            style={{ marginTop: 16, padding: '8px 16px', background: 'var(--bg-active)', color: 'var(--text-primary)', border: '1px solid var(--border-medium)', borderRadius: 6, cursor: 'pointer' }}
+            style={{ marginTop: 16, padding: '8px 16px', background: '#27272a', color: '#fafafa', border: '1px solid #3f3f46', borderRadius: 6, cursor: 'pointer' }}
           >
             Reload
           </button>


### PR DESCRIPTION
## What does this PR do?

Disables Chromium hardware acceleration unconditionally and fixes the ErrorBoundary to use hardcoded fallback colors instead of CSS variables.

## Why?

Users report a persistent black window they can resize but never see content in. This is a well-known Electron issue on machines with incompatible GPU drivers, broken ANGLE backends, or VM setups — the GPU compositor silently fails and only the window's background color (`#09090b`) shows. Since Kudu is a system-cleaner utility, software compositing has negligible visual trade-off. The ErrorBoundary fix ensures error messages are visible even when stylesheets fail to load (previously black-on-black).

## How to test

1. Build and launch the app — verify the UI renders normally
2. If possible, test in a VM or on a machine with known GPU issues — confirm the black window is gone
3. Trigger an intentional render error (e.g., throw in a component) — verify the ErrorBoundary text is visible

## Checklist

- [x] Tested on my platform (Windows / macOS / Linux)
- [x] `npm test` passes
- [ ] `npm run build` succeeds
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)