### PR TITLE
fix(linux): resolve grey window when relaunched as root via pkexec

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -59,6 +59,14 @@ const isRoot =
 
 if (isRoot) {
   app.commandLine.appendSwitch('no-sandbox')
+  // On some Linux desktops (e.g. Linux Mint / Cinnamon) the software
+  // compositor still fails to paint when running as root — the window
+  // loads (cursor reacts) but remains grey.  Disabling GPU compositing
+  // forces a fallback path that reliably renders.
+  if (process.platform === 'linux') {
+    app.commandLine.appendSwitch('disable-gpu-compositing')
+    app.commandLine.appendSwitch('in-process-gpu')
+  }
 }
 
 // ─── CLI / Daemon mode ───────────────────────────────────────

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -159,7 +159,7 @@ export function registerCleanerIpc(getWindow: WindowGetter): void {
       // (same pattern as the macOS osascript path).
       const sq = (s: string) => `'${s.replace(/'/g, "'\\''")}'`
       const parts: string[] = []
-      for (const key of ['DISPLAY', 'XAUTHORITY', 'WAYLAND_DISPLAY', 'XDG_RUNTIME_DIR', 'HOME']) {
+      for (const key of ['DISPLAY', 'XAUTHORITY', 'WAYLAND_DISPLAY', 'XDG_RUNTIME_DIR', 'HOME', 'DBUS_SESSION_BUS_ADDRESS']) {
         if (process.env[key]) parts.push(`${key}=${sq(process.env[key])}`)
       }
       parts.push(sq(exePath), '--no-sandbox', `--kudu-data-dir=${sq(userDataDir)}`)


### PR DESCRIPTION
## Summary

- Adds `--disable-gpu-compositing` and `--in-process-gpu` Chromium switches when running as root on Linux, forcing a rendering path that paints reliably even when the software compositor fails
- Forwards `DBUS_SESSION_BUS_ADDRESS` through `pkexec` so GTK/accessibility integration works in the elevated process
- Fixes the grey/blank window reported on Linux Mint after relaunching as administrator

Closes #118

## Test plan

- [ ] Launch Kudu on Linux Mint, click "Relaunch as Administrator", verify the window renders correctly
- [ ] Verify non-elevated launch on Linux is unaffected
- [ ] Verify Windows and macOS elevation paths are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)