### PR TITLE
fix(drivers): skip driver scans on non-Windows platforms

### DIFF
--- a/src/main/ipc/driver-manager.ipc.ts
+++ b/src/main/ipc/driver-manager.ipc.ts
@@ -226,6 +226,10 @@ async function getActiveDriverNames(): Promise<Set<string>> {
 export async function scanDrivers(
   onProgress?: (data: DriverScanProgress) => void
 ): Promise<DriverScanResult> {
+    if (process.platform !== 'win32') {
+      return { packages: [], totalStaleSize: 0, totalStaleCount: 0, totalCurrentCount: 0 }
+    }
+
     onProgress?.({
       phase: 'enumerating',
       current: 0,
@@ -339,6 +343,10 @@ export async function scanDrivers(
 }
 
 export async function cleanDrivers(publishedNames: string[]): Promise<DriverCleanResult> {
+      if (process.platform !== 'win32') {
+        return { removed: 0, failed: 0, spaceRecovered: 0, errors: [] }
+      }
+
       let removed = 0
       let failed = 0
       let spaceRecovered = 0
@@ -386,6 +394,10 @@ export async function scanDriverUpdates(
   onProgress?: (data: DriverUpdateProgress) => void
 ): Promise<DriverUpdateScanResult> {
     const startTime = Date.now()
+
+    if (process.platform !== 'win32') {
+      return { updates: [], totalAvailable: 0, scanDuration: Date.now() - startTime }
+    }
 
     onProgress?.({
       phase: 'checking',
@@ -536,6 +548,10 @@ export async function installDriverUpdates(
   wuUpdateIds: string[],
   onProgress?: (data: DriverUpdateProgress) => void
 ): Promise<DriverUpdateInstallResult> {
+      if (process.platform !== 'win32') {
+        return { installed: 0, failed: 0, rebootRequired: false, errors: [] }
+      }
+
       let installed = 0
       let failed = 0
       let rebootRequired = false


### PR DESCRIPTION
## Summary
- Fixes `spawn powershell ENOENT` error on Linux/macOS when the background driver-update scan runs at app launch (reported against v1.34.0 on Fedora 43).
- Adds a `process.platform !== 'win32'` guard to `scanDrivers`, `cleanDrivers`, `scanDriverUpdates`, and `installDriverUpdates` so they return empty results on unsupported platforms instead of invoking PowerShell.
- Matches the existing pattern used by the debloater IPC handlers.

## Test plan
- [ ] On Linux (Fedora), launch the AppImage and confirm no `Driver update scan failed: spawn powershell ENOENT` appears in stderr.
- [ ] On Windows, confirm driver scan / update scan / clean / install still work end-to-end.
- [ ] On macOS, confirm app launch does not log any driver-scan errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)