### PR TITLE
fix(registry-cleaner): handle trailing backslashes in value names

### DIFF
--- a/src/main/services/exec-utf8.ts
+++ b/src/main/services/exec-utf8.ts
@@ -226,11 +226,19 @@ export async function execNativeUtf8(
   // appears in the command string.  cmd.exe expands the hardcoded
   // %__KAn% references from the child-process environment at runtime.
   // Embedded double-quotes are escaped as "" to keep cmd.exe quoting intact.
+  // Trailing backslashes are doubled: after cmd.exe expands the value into
+  // "%__KAn%", a single trailing \ would escape the closing " under
+  // CommandLineToArgvW rules and merge this arg with the next one. Doubling
+  // forces an even backslash count so the parser sees N literal backslashes
+  // followed by a closing-delimiter quote.
   const env = { ...process.env } as Record<string, string>
   const refs: string[] = []
   for (let i = 0; i < args.length; i++) {
     const key = `__KA${i}`
-    env[key] = args[i].replace(/"/g, '""')
+    let value = args[i].replace(/"/g, '""')
+    const trailing = value.match(/\\+$/)
+    if (trailing) value += trailing[0]
+    env[key] = value
     refs.push(`"%${key}%"`)
   }
 


### PR DESCRIPTION
## Summary

Registry value names in `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\Folders` end with `\` (e.g. `C:\Program Files\Adobe\Acrobat DC\`). When `execNativeUtf8` packs args via env-var substitution, `cmd.exe` expands `"%__KAn%"` into `"...path\"` — and the trailing `\` escapes the closing `"` under `CommandLineToArgvW` rules, merging the value name with the next arg.

Two consequences for **every** Windows Installer Folders orphan:
1. **Fails to delete** — `reg.exe` sees a malformed value name.
2. **10s per entry** — without `/f`, `reg.exe` prompts `[Y/N]`. There's no console attached, so it hangs until the 10s timeout in `execNativeUtf8`.

Result: a normal scan with ~150 entries took ~25 minutes and deleted nothing.

## Fix

When packing an arg into an env var, double trailing backslashes so the parser sees an even count → N literal backslashes + closing delimiter. The fix is in the shared utility, so any rule that emits trailing-backslash registry value names benefits.

## Test plan

- [x] Manual: scan registry, run fix on Windows Installer Folders entries — entries delete in <1s each instead of hanging
- [ ] Confirm other rules using `execNativeUtf8` (services, scheduled tasks, etc.) still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)