### PR TITLE
fix(software-updater): resolve brew path on macOS GUI launches

### DIFF
--- a/src/main/services/software-updater.test.ts
+++ b/src/main/services/software-updater.test.ts
@@ -17,6 +17,7 @@ import {
   parseChocoOutdatedOutput,
   parseChocoListOutput,
   isValidAppId,
+  BREW_PATH_CANDIDATES,
 } from './software-updater'
 
 // ─── cleanOutput ────────────────────────────────────────────
@@ -280,6 +281,28 @@ describe('parseBrewInstalledJson', () => {
       casks: [],
     })
     expect(parseBrewInstalledJson(json)).toEqual([])
+  })
+})
+
+// ─── BREW_PATH_CANDIDATES ───────────────────────────────────
+
+describe('BREW_PATH_CANDIDATES', () => {
+  // Regression guard for macOS GUI launches: launchd-inherited PATH does not
+  // include either Homebrew install location, so both absolute paths must be
+  // probed before falling back to a PATH lookup.
+  it('probes both Apple Silicon and Intel brew locations', () => {
+    expect(BREW_PATH_CANDIDATES).toContain('/opt/homebrew/bin/brew')
+    expect(BREW_PATH_CANDIDATES).toContain('/usr/local/bin/brew')
+  })
+
+  it('prefers Apple Silicon over Intel', () => {
+    const arm = BREW_PATH_CANDIDATES.indexOf('/opt/homebrew/bin/brew')
+    const intel = BREW_PATH_CANDIDATES.indexOf('/usr/local/bin/brew')
+    expect(arm).toBeLessThan(intel)
+  })
+
+  it('falls back to PATH lookup last', () => {
+    expect(BREW_PATH_CANDIDATES[BREW_PATH_CANDIDATES.length - 1]).toBe('brew')
   })
 })
 

--- a/src/main/services/software-updater.ts
+++ b/src/main/services/software-updater.ts
@@ -867,13 +867,34 @@ interface BrewInfoJson {
   casks: BrewInfoCask[]
 }
 
-async function isBrewAvailable(): Promise<boolean> {
-  try {
-    await execFileAsync('brew', ['--version'], { timeout: 10_000 })
-    return true
-  } catch {
-    return false
+/**
+ * Brew install locations to probe, in priority order. macOS GUI apps inherit
+ * PATH from launchd (typically just /usr/bin:/bin:/usr/sbin:/sbin) and never
+ * read the user's shell rc files, so a bare `brew` lookup fails even when
+ * brew is installed and on the user's interactive shell PATH. We probe the
+ * standard install locations first, then fall back to a PATH lookup so
+ * non-standard installs still work when the user launched Kudu from a shell.
+ */
+export const BREW_PATH_CANDIDATES = [
+  '/opt/homebrew/bin/brew', // Apple Silicon default
+  '/usr/local/bin/brew',    // Intel default
+  'brew',                   // PATH lookup fallback
+]
+
+let cachedBrewPath: string | null | undefined
+
+/** Resolve the path to the brew executable, or null if brew is not installed. */
+async function resolveBrewPath(): Promise<string | null> {
+  if (cachedBrewPath !== undefined) return cachedBrewPath
+  for (const candidate of BREW_PATH_CANDIDATES) {
+    try {
+      await execFileAsync(candidate, ['--version'], { timeout: 10_000 })
+      cachedBrewPath = candidate
+      return candidate
+    } catch { /* try next candidate */ }
   }
+  cachedBrewPath = null
+  return null
 }
 
 export function parseBrewOutdatedJson(stdout: string): UpdatableApp[] {
@@ -944,8 +965,8 @@ export function parseBrewInstalledJson(stdout: string): UpToDateApp[] {
 }
 
 async function checkForUpdatesBrew(): Promise<UpdateCheckResult> {
-  const available = await isBrewAvailable()
-  if (!available) {
+  const brewPath = await resolveBrewPath()
+  if (!brewPath) {
     return emptyResult(false, 'brew')
   }
 
@@ -954,7 +975,7 @@ async function checkForUpdatesBrew(): Promise<UpdateCheckResult> {
     let outdatedStdout = ''
     try {
       const result = await execFileAsync(
-        'brew',
+        brewPath,
         ['outdated', '--json=v2'],
         { timeout: 60_000, maxBuffer: 10 * 1024 * 1024 },
       )
@@ -975,7 +996,7 @@ async function checkForUpdatesBrew(): Promise<UpdateCheckResult> {
       let infoStdout = ''
       try {
         const infoResult = await execFileAsync(
-          'brew',
+          brewPath,
           ['info', '--json=v2', '--installed'],
           { timeout: 60_000, maxBuffer: 10 * 1024 * 1024 },
         )
@@ -1015,9 +1036,14 @@ async function attemptBrewUpgrade(
     return { success: false, error: 'Invalid package name format' }
   }
 
+  const brewPath = await resolveBrewPath()
+  if (!brewPath) {
+    return { success: false, error: 'brew not found' }
+  }
+
   try {
     await execFileAsync(
-      'brew',
+      brewPath,
       ['upgrade', name],
       { timeout: 10 * 60 * 1000, maxBuffer: 10 * 1024 * 1024 },
     )


### PR DESCRIPTION
## Summary

- macOS GUI apps inherit `PATH` from launchd (just `/usr/bin:/bin:/usr/sbin:/sbin`) and never read `~/.zshrc`, so bare `execFile('brew', ...)` calls fail with "brew not found" even when brew is installed and on the user's interactive shell `PATH` — reported on Apple Silicon where brew lives at `/opt/homebrew/bin`.
- Probe `/opt/homebrew/bin/brew` (Apple Silicon), then `/usr/local/bin/brew` (Intel), then a `PATH` lookup, cache the first that responds to `--version`, and use the resolved path for every brew invocation in the updater (availability check, `outdated`, `info`, `upgrade`).

Closes the user report: "Software Updates says 'brew not found' even though brew is on `$PATH` (zsh)".

## Test plan

- [x] `npm test` — 1942 tests pass, 3 new tests for `BREW_PATH_CANDIDATES` ordering
- [ ] On an Apple Silicon mac, launch Kudu from Finder and open Software → Software Updates; verify it lists brew packages instead of "brew not found"
- [ ] On an Intel mac (or rosetta), same check verifies the `/usr/local/bin/brew` fallback
- [ ] Launch Kudu from a terminal where brew is on `PATH`; verify it still works (covers the bare-`brew` fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)