### PR TITLE
feat(firewall,context-menu): hide built-in Windows entries by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,13 +52,13 @@
       }
     },
     "node_modules/@axe-core/react": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/@axe-core/react/-/react-4.11.2.tgz",
-      "integrity": "sha512-+bQ5yO9FAU4hfZRJXi81Eiv5bd53BrsjAEFoE6QlMkqKOoIq4wC15a9d8kRHs4i5dgLqD8S9NW5qWkiFVsV3/g==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/react/-/react-4.11.3.tgz",
+      "integrity": "sha512-G7TrxptKNFfrQZ+Iygb8nGx5w8Su0jIjwmtVN/9Jc4G6RumCh1rD3pZRT2NzZKjT70q4BReuWVwEazS3HxFfjg==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "axe-core": "~4.11.3",
+        "axe-core": "~4.11.4",
         "requestidlecallback": "^0.3.0"
       }
     },
@@ -78,9 +78,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -269,9 +269,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -390,15 +390,15 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "20.5.2",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.5.2.tgz",
-      "integrity": "sha512-IXr5xd3IX8SEG936P8gcpozRplkDeDSwJlt8UvoY1winwIy2udTbQ/cOCgbaaxcjdDqVoS29VUcz/wkwnSozbA==",
+      "version": "20.5.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.5.3.tgz",
+      "integrity": "sha512-OJdL0EXWD5y9LPa0nr/geOwzaS8BsdaybKkcloB0JgsguGxNv2R+hC2FTPqrAcprg35zF33KOQerY0x8W1aesA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@commitlint/format": "^20.5.0",
-        "@commitlint/lint": "^20.5.0",
-        "@commitlint/load": "^20.5.2",
+        "@commitlint/lint": "^20.5.3",
+        "@commitlint/load": "^20.5.3",
         "@commitlint/read": "^20.5.0",
         "@commitlint/types": "^20.5.0",
         "tinyexec": "^1.0.0",
@@ -412,9 +412,9 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.5.0.tgz",
-      "integrity": "sha512-t3Ni88rFw1XMa4nZHgOKJ8fIAT9M2j5TnKyTqJzsxea7FUetlNdYFus9dz+MhIRZmc16P0PPyEfh6X2d/qw8SA==",
+      "version": "20.5.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.5.3.tgz",
+      "integrity": "sha512-j34Qqeaa152chJgz2ysyk0BCpHenJn1lV0Rx0VXf8k3ccQcED+48EZrzMvo9jLmJUyBrrBwvu89I+2er4gW7QQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -440,18 +440,14 @@
       }
     },
     "node_modules/@commitlint/ensure": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.5.0.tgz",
-      "integrity": "sha512-IpHqAUesBeW1EDDdjzJeaOxU9tnogLAyXLRBn03SHlj1SGENn2JGZqSWGkFvBJkJzfXAuCNtsoYzax+ZPS+puw==",
+      "version": "20.5.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.5.3.tgz",
+      "integrity": "sha512-4i4AgNvH62owG9MwSiWKrle7HGNpBHHdLnWFIp5fTsHUYe5kRuh15t08L/0pdbbrRk8JKXQxxN4hZQcn+szkrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@commitlint/types": "^20.5.0",
-        "lodash.camelcase": "^4.3.0",
-        "lodash.kebabcase": "^4.1.1",
-        "lodash.snakecase": "^4.1.1",
-        "lodash.startcase": "^4.4.0",
-        "lodash.upperfirst": "^4.3.1"
+        "es-toolkit": "^1.46.0"
       },
       "engines": {
         "node": ">=v18"
@@ -496,15 +492,15 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.5.0.tgz",
-      "integrity": "sha512-jiM3hNUdu04jFBf1VgPdjtIPvbuVfDTBAc6L98AWcoLjF5sYqkulBHBzlVWll4rMF1T5zeQFB6r//a+s+BBKlA==",
+      "version": "20.5.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.5.3.tgz",
+      "integrity": "sha512-M7JbWBNr2gXKaPc4i/KipsuW1gkDHpj35KPjWtKy3Z+2AQw5wu1gBi1LIO0uoaij67CqY4K8PxPZSGens4evCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@commitlint/is-ignored": "^20.5.0",
         "@commitlint/parse": "^20.5.0",
-        "@commitlint/rules": "^20.5.0",
+        "@commitlint/rules": "^20.5.3",
         "@commitlint/types": "^20.5.0"
       },
       "engines": {
@@ -512,20 +508,20 @@
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "20.5.2",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.5.2.tgz",
-      "integrity": "sha512-zmr0RGDz7vThxW1I8ohb9yBjnGuH9mqwJpn21hInjGla+IlLOkS9ey0+dD5HlkzFlY0lX2NYdA2lDW6/0rO7Gw==",
+      "version": "20.5.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.5.3.tgz",
+      "integrity": "sha512-1FDZWuKyu98Myb8i7Tp31jPU2rZpOwAdYRyJcy2KoGg7Xk2A+bgHN8smhMaaNSNkmE8fwt53BokywZq8Gv/5XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@commitlint/config-validator": "^20.5.0",
         "@commitlint/execute-rule": "^20.0.0",
-        "@commitlint/resolve-extends": "^20.5.2",
+        "@commitlint/resolve-extends": "^20.5.3",
         "@commitlint/types": "^20.5.0",
         "cosmiconfig": "^9.0.1",
         "cosmiconfig-typescript-loader": "^6.1.0",
+        "es-toolkit": "^1.46.0",
         "is-plain-obj": "^4.1.0",
-        "lodash.mergewith": "^4.6.2",
         "picocolors": "^1.1.1"
       },
       "engines": {
@@ -575,17 +571,17 @@
       }
     },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "20.5.2",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.5.2.tgz",
-      "integrity": "sha512-8EhSCU9eNos/5cI1yg64GW79UH1c64O69AfStCsj4zqy6An/qIphVEXj4/+2M6056T8coz00f+UXFn4WUUP1HQ==",
+      "version": "20.5.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.5.3.tgz",
+      "integrity": "sha512-+ogW9v/u9JqpvAgTrLra/YTFo0KkjU6iNblF89pPsj4NebNc+DAWctsludwezI8YnsjBmfHpApSwcXprN/f/ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@commitlint/config-validator": "^20.5.0",
         "@commitlint/types": "^20.5.0",
+        "es-toolkit": "^1.46.0",
         "global-directory": "^5.0.0",
         "import-meta-resolve": "^4.0.0",
-        "lodash.mergewith": "^4.6.2",
         "resolve-from": "^5.0.0"
       },
       "engines": {
@@ -593,13 +589,13 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.5.0.tgz",
-      "integrity": "sha512-5NdQXQEdnDPT5pK8O39ZA7HohzPRHEsDGU23cyVCNPQy4WegAbAwrQk3nIu7p2sl3dutPk8RZd91yKTrMTnRkQ==",
+      "version": "20.5.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.5.3.tgz",
+      "integrity": "sha512-MPlMnb9D3wbszYMp+1hPtuhtPJndRo6I6yfkZVA4+jR8w7Kqp0u2u/Y+gzbaItx5Lltq5rw7FSZQWJMoXUC4NQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/ensure": "^20.5.0",
+        "@commitlint/ensure": "^20.5.3",
         "@commitlint/message": "^20.4.3",
         "@commitlint/to-lines": "^20.0.0",
         "@commitlint/types": "^20.5.0"
@@ -1679,26 +1675,26 @@
       }
     },
     "node_modules/@litko/yara-x": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@litko/yara-x/-/yara-x-0.5.0.tgz",
-      "integrity": "sha512-mK46LZwhenZnLEJXvU5+cO36iwQRdJRzLM/xD1PYpFbQO5o/IqXf7r4nqRxjQZp9WcR5qpby3Kdv3mzcyspuIQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@litko/yara-x/-/yara-x-0.5.1.tgz",
+      "integrity": "sha512-r653nhAxP+/zJ7m85cpCwrYSICRcpVBgFlxoy0oXnBIK1jmvtbo/M9RTdAypJETRx4kB9USxSxdKar8+CGsbXw==",
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@litko/yara-x-darwin-arm64": "0.5.0",
-        "@litko/yara-x-darwin-x64": "0.5.0",
-        "@litko/yara-x-linux-arm64-gnu": "0.5.0",
-        "@litko/yara-x-linux-x64-gnu": "0.5.0",
-        "@litko/yara-x-win32-arm64-msvc": "0.5.0",
-        "@litko/yara-x-win32-x64-msvc": "0.5.0"
+        "@litko/yara-x-darwin-arm64": "0.5.1",
+        "@litko/yara-x-darwin-x64": "0.5.1",
+        "@litko/yara-x-linux-arm64-gnu": "0.5.1",
+        "@litko/yara-x-linux-x64-gnu": "0.5.1",
+        "@litko/yara-x-win32-arm64-msvc": "0.5.1",
+        "@litko/yara-x-win32-x64-msvc": "0.5.1"
       }
     },
     "node_modules/@litko/yara-x-darwin-arm64": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@litko/yara-x-darwin-arm64/-/yara-x-darwin-arm64-0.5.0.tgz",
-      "integrity": "sha512-Og7Phjx8UaALDJHgcX7UaRToiR+Jzpiq+h7d6RQde7AdhMZcunYsiEc47UVJAJ5Kqi1vD4dpyczTT0kvugGj5g==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@litko/yara-x-darwin-arm64/-/yara-x-darwin-arm64-0.5.1.tgz",
+      "integrity": "sha512-Kr3uYMgJq1kRVAxrAh0PhqbN7972lxsKTb9naNKyhgLRyQykYvbKkFJx5ykjZnDsBCriTCDlaHzBj1FVJHQE9g==",
       "cpu": [
         "arm64"
       ],
@@ -1712,9 +1708,9 @@
       }
     },
     "node_modules/@litko/yara-x-darwin-x64": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@litko/yara-x-darwin-x64/-/yara-x-darwin-x64-0.5.0.tgz",
-      "integrity": "sha512-1X2TGdWAF2oQ+PT+5zPSvPUmtRmGRtNi/JI6+LzyFOccrZJRD7sinyscg5ABqXUV8n9IcVCjcCHyFzCoG1ofoA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@litko/yara-x-darwin-x64/-/yara-x-darwin-x64-0.5.1.tgz",
+      "integrity": "sha512-23OK2FNK1Pu6oAhKj5MYRuBfi7Z36yqp05SUKACD/BTT/pbHDrWxfpf6VsvEG4Jz2GmTFmsMleNpNabFLDG+KQ==",
       "cpu": [
         "x64"
       ],
@@ -1728,9 +1724,9 @@
       }
     },
     "node_modules/@litko/yara-x-linux-arm64-gnu": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@litko/yara-x-linux-arm64-gnu/-/yara-x-linux-arm64-gnu-0.5.0.tgz",
-      "integrity": "sha512-DCfJZxXgSOUHFRmsO/O5x+wFl0tpxRqhcJY1M4wR577Q0KJiQFfqwch1bmqC6YABjezaJCY8RSAWUo33W0TB1w==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@litko/yara-x-linux-arm64-gnu/-/yara-x-linux-arm64-gnu-0.5.1.tgz",
+      "integrity": "sha512-kF9Obc6a8pKuJO7sSGuEKvcS/POb7E/FMrl7p0hMr6xgCYCX4qXFXdiAVu/WEt6cjEugRp7KSRD4dla6lB1nsw==",
       "cpu": [
         "arm64"
       ],
@@ -1744,9 +1740,9 @@
       }
     },
     "node_modules/@litko/yara-x-linux-x64-gnu": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@litko/yara-x-linux-x64-gnu/-/yara-x-linux-x64-gnu-0.5.0.tgz",
-      "integrity": "sha512-fZelUMMLg6Lfcb2SYrkbKvd8ntHqTNBPOypJRkj+dab9w5BPAO1o8Npa2zvzjT7w3VWmncUudhTLqUAWcAvRwA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@litko/yara-x-linux-x64-gnu/-/yara-x-linux-x64-gnu-0.5.1.tgz",
+      "integrity": "sha512-H7DEQCXDOwYlKZUC4StvoTuM6DxqrtuSo6kidTcZlOiLT2Nfjmbrm0vuqRQt25XKui+cNmOw0RZKtl/HyFByGg==",
       "cpu": [
         "x64"
       ],
@@ -1760,9 +1756,9 @@
       }
     },
     "node_modules/@litko/yara-x-win32-arm64-msvc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@litko/yara-x-win32-arm64-msvc/-/yara-x-win32-arm64-msvc-0.5.0.tgz",
-      "integrity": "sha512-FLtMXyGdyuXdY9h79c1W0DEAst8eiri1AIiVLVTDOqq1pNSgphDmtq2xDZNgntLnrswR7iit9it4ynGt4MvphQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@litko/yara-x-win32-arm64-msvc/-/yara-x-win32-arm64-msvc-0.5.1.tgz",
+      "integrity": "sha512-sLXsyObxaBu2WFXPFRck66BVPuuzxZDurYHqULV+qGIsf9KSoXlxWZ2JhhMidutJMbA1WCHSYywDH/RFbfB9GQ==",
       "cpu": [
         "arm64"
       ],
@@ -1776,9 +1772,9 @@
       }
     },
     "node_modules/@litko/yara-x-win32-x64-msvc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@litko/yara-x-win32-x64-msvc/-/yara-x-win32-x64-msvc-0.5.0.tgz",
-      "integrity": "sha512-7hpMrTGY6m/Fx+2DJjcBmwW8fzbtm77JUE5sC9AbGozd/rfnW43EF7QyJ0RVhSgHp1x8izJkTWje/y4wyGWSiQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@litko/yara-x-win32-x64-msvc/-/yara-x-win32-x64-msvc-0.5.1.tgz",
+      "integrity": "sha512-0OIzJKnSB29kNxtVphdjI607cJ8ZmPiczZ+ze93kSxWgvJpso14Hi3iWy7N6jSgcaT9PE5xkPvrL2rPuTOKkrQ==",
       "cpu": [
         "x64"
       ],
@@ -3445,9 +3441,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
-      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -3485,9 +3481,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.23",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.23.tgz",
-      "integrity": "sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==",
+      "version": "2.10.25",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.25.tgz",
+      "integrity": "sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4850,9 +4846,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "41.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.3.0.tgz",
-      "integrity": "sha512-2Q5aeocmFdeheZGDUTrAvSR3t+n0c3d104AJWWEnt7syJU0tE4VdibMYaPtQ47QuXSoUf0/xSsfUUvu/uSXIfg==",
+      "version": "41.5.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.5.0.tgz",
+      "integrity": "sha512-x9j9//PubUA4EjDtQbZhtk3prolandqCKgit0uCIqc1jb8FTskPbnJtxcDFB1aejczJcuERgjPixBUaMwoWyJg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -5001,9 +4997,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.344",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
-      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "version": "1.5.348",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.348.tgz",
+      "integrity": "sha512-QC2X59nRlycQQMc4ZXjSVBX+tSgJfgRtcrYHbIZLgOV2dCvefoQGegLR7lLXKgpPpSuVmJU19LMzGrSa2C7k3Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -5257,9 +5253,9 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.0.tgz",
-      "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==",
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
       "license": "MIT",
       "workspaces": [
         "docs",
@@ -6791,13 +6787,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
@@ -6809,41 +6798,6 @@
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
       "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
-      "license": "MIT"
-    },
-    "node_modules/lodash.kebabcase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
-      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.mergewith": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.snakecase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.startcase": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
-      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.upperfirst": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
-      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lowercase-keys": {
@@ -7072,9 +7026,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -7104,9 +7058,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.28.0.tgz",
-      "integrity": "sha512-Qfp5XZL1cJDOabOT8H5gnqMTmM4NjvYzHp4I/Kt/Sl76OVkOBBHRFlPspGV0hYvMoqQsypFjT/Yp7Km0beXW9g==",
+      "version": "4.29.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.29.0.tgz",
+      "integrity": "sha512-bGc7hHz6lrdpMqH3XqfiHc5PKzEhjgUj6OLpTXynkLi9JZKyMByI/tdpm4Liu6O2BjtE1lakBWXjOQS1EnSQLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7510,9 +7464,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {
@@ -7596,9 +7550,9 @@
       }
     },
     "node_modules/prebuild-install/node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "version": "3.90.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.90.0.tgz",
+      "integrity": "sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -8829,9 +8783,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/main/ipc/firewall-audit.ipc.test.ts
+++ b/src/main/ipc/firewall-audit.ipc.test.ts
@@ -28,6 +28,25 @@ function parseSignature(raw: string): FirewallSignatureStatus {
   }
 }
 
+const MUI_RESOURCE_RE = /^@[^,]+\.(?:dll|exe|mui),-\d+(?:;.*)?$/i
+const APPX_RESOURCE_RE = /^@\{[^}]+\?ms-resource:\/\/[^}]+\}$/i
+
+function looksLikeResourceRef(s: string): boolean {
+  const t = s.trim()
+  return MUI_RESOURCE_RE.test(t) || APPX_RESOURCE_RE.test(t)
+}
+
+function isBuiltinRule(args: {
+  description: string
+  group: string
+  isManaged: boolean
+  isSystemPath: boolean
+}): boolean {
+  if (args.isSystemPath) return true
+  if (args.isManaged) return true
+  return looksLikeResourceRef(args.description) || looksLikeResourceRef(args.group)
+}
+
 function classifyRule(raw: {
   programResolved: string
   programExists: boolean
@@ -35,10 +54,18 @@ function classifyRule(raw: {
   profiles: FirewallProfile[]
   localPort: string
   remoteAddress: string
+  builtin: boolean
 }): { issues: FirewallIssue[]; risk: FirewallRiskLevel } {
   const issues: FirewallIssue[] = []
   const hasProgram = !!raw.programResolved
   if (hasProgram && !raw.programExists) issues.push('stale')
+
+  if (raw.builtin) {
+    let risk: FirewallRiskLevel = 'low'
+    if (issues.includes('stale')) risk = 'high'
+    return { issues, risk }
+  }
+
   if (hasProgram && raw.programExists && raw.signature === 'unsigned') issues.push('unsigned')
 
   const isAnyRemote = !raw.remoteAddress || raw.remoteAddress.toLowerCase() === 'any'
@@ -113,6 +140,50 @@ describe('parseSignature', () => {
   })
 })
 
+describe('isBuiltinRule', () => {
+  const empty = { description: '', group: '', isManaged: false, isSystemPath: false }
+
+  it('detects MUI resource description (FirewallAPI.dll)', () => {
+    expect(isBuiltinRule({ ...empty, description: '@FirewallAPI.dll,-25000' })).toBe(true)
+  })
+  it('detects MUI resource description with trailing semicolon segment', () => {
+    expect(isBuiltinRule({ ...empty, description: '@%SystemRoot%\\system32\\firewallapi.dll,-25000;remarks' })).toBe(true)
+  })
+  it('detects MUI resource for an exe path (Hyper-V vmms.exe)', () => {
+    expect(isBuiltinRule({ ...empty, description: '@%systemroot%\\system32\\vmms.exe,-210' })).toBe(true)
+  })
+  it('detects AppX resource description (Desktop App Web Viewer)', () => {
+    const description = '@{Microsoft.Win32WebViewHost_10.0.26100.1_neutral_neutral_cw5n1h2txyewy?ms-resource://Windows.Win32WebViewHost/resources/DisplayName}'
+    expect(isBuiltinRule({ ...empty, description })).toBe(true)
+  })
+  it('detects AppX resource description (Windows Feature Experience Pack)', () => {
+    const description = '@{MicrosoftWindows.Client.OOBE_1000.26100.40.0_x64__cw5n1h2txyewy?ms-resource://MicrosoftWindows.Client.OOBE/resources/ProductPkgDisplayName}'
+    expect(isBuiltinRule({ ...empty, description })).toBe(true)
+  })
+  it('treats system-path binaries as built-in even without resource description', () => {
+    expect(isBuiltinRule({ ...empty, description: 'Lets stuff through', isSystemPath: true })).toBe(true)
+  })
+  it('treats managed rules as built-in (Package or Owner SID set — Game Bar / Microsoft Store)', () => {
+    // Both Game Bar and Microsoft Store have description resolved to a
+    // literal display name. PS sets isManaged=true when the rule has either
+    // a non-empty Package SID on the application filter or a non-empty
+    // Owner SID on the rule itself — every Store-installed app does.
+    expect(isBuiltinRule({ ...empty, description: 'Game Bar', isManaged: true })).toBe(true)
+    expect(isBuiltinRule({ ...empty, description: 'Microsoft Store', isManaged: true })).toBe(true)
+  })
+  it('detects resource ref in Group when description is a resolved literal', () => {
+    expect(isBuiltinRule({ ...empty, description: 'Game Bar', group: '@FirewallAPI.dll,-25000' })).toBe(true)
+  })
+  it('does not match user-installed app descriptions', () => {
+    expect(isBuiltinRule({ ...empty, description: 'Steam game server traffic' })).toBe(false)
+    expect(isBuiltinRule(empty)).toBe(false)
+  })
+  it('does not match descriptions that merely start with @ or @{', () => {
+    expect(isBuiltinRule({ ...empty, description: '@some random text' })).toBe(false)
+    expect(isBuiltinRule({ ...empty, description: '@{not a real resource ref}' })).toBe(false)
+  })
+})
+
 describe('classifyRule', () => {
   it('flags stale program as high risk', () => {
     const { issues, risk } = classifyRule({
@@ -122,6 +193,7 @@ describe('classifyRule', () => {
       profiles: ['Domain'],
       localPort: '443',
       remoteAddress: 'LocalSubnet',
+      builtin: false,
     })
     expect(issues).toContain('stale')
     expect(risk).toBe('high')
@@ -135,6 +207,7 @@ describe('classifyRule', () => {
       profiles: ['Private'],
       localPort: '8080',
       remoteAddress: 'LocalSubnet',
+      builtin: false,
     })
     expect(issues).toEqual(['unsigned'])
     expect(risk).toBe('medium')
@@ -148,6 +221,7 @@ describe('classifyRule', () => {
       profiles: ['Public'],
       localPort: 'Any',
       remoteAddress: 'Any',
+      builtin: false,
     })
     expect(issues).toContain('broad-scope')
     expect(risk).toBe('high')
@@ -161,6 +235,7 @@ describe('classifyRule', () => {
       profiles: ['Private'],
       localPort: 'Any',
       remoteAddress: 'Any',
+      builtin: false,
     })
     expect(issues).toEqual(['any-remote'])
     expect(risk).toBe('medium')
@@ -174,6 +249,7 @@ describe('classifyRule', () => {
       profiles: ['Any'],
       localPort: 'Any',
       remoteAddress: 'Any',
+      builtin: false,
     })
     expect(issues).toContain('broad-scope')
     expect(risk).toBe('high')
@@ -187,6 +263,7 @@ describe('classifyRule', () => {
       profiles: ['Domain'],
       localPort: '445',
       remoteAddress: 'LocalSubnet',
+      builtin: true,
     })
     expect(issues).toEqual([])
     expect(risk).toBe('low')
@@ -200,6 +277,7 @@ describe('classifyRule', () => {
       profiles: ['Private'],
       localPort: '443',
       remoteAddress: 'LocalSubnet',
+      builtin: false,
     })
     expect(issues).toContain('stale')
     expect(issues).not.toContain('unsigned')
@@ -213,7 +291,53 @@ describe('classifyRule', () => {
       profiles: ['Domain'],
       localPort: '80',
       remoteAddress: '10.0.0.0/8',
+      builtin: false,
     })
     expect(issues).toEqual([])
+  })
+
+  // Built-in / Microsoft-shipped rules — these are the rules whose default
+  // shape (Public + Any/Any) used to produce broad-scope high-risk findings
+  // even though removing them breaks Wi-Fi Direct, Core Networking, etc.
+  it('does not flag broad-scope on built-in rules', () => {
+    const { issues, risk } = classifyRule({
+      programResolved: 'C:\\Windows\\System32\\spoolsv.exe',
+      programExists: true,
+      signature: 'signed',
+      profiles: ['Public'],
+      localPort: 'Any',
+      remoteAddress: 'Any',
+      builtin: true,
+    })
+    expect(issues).toEqual([])
+    expect(risk).toBe('low')
+  })
+
+  it('does not flag any-remote on built-in port-only rules (e.g. IPv6-In)', () => {
+    const { issues, risk } = classifyRule({
+      programResolved: '',
+      programExists: false,
+      signature: 'not-applicable',
+      profiles: ['Public'],
+      localPort: 'Any',
+      remoteAddress: 'Any',
+      builtin: true,
+    })
+    expect(issues).toEqual([])
+    expect(risk).toBe('low')
+  })
+
+  it('still flags stale on built-in rules (uninstalled feature leftover)', () => {
+    const { issues, risk } = classifyRule({
+      programResolved: 'C:\\Windows\\System32\\removed.exe',
+      programExists: false,
+      signature: 'not-applicable',
+      profiles: ['Public'],
+      localPort: 'Any',
+      remoteAddress: 'Any',
+      builtin: true,
+    })
+    expect(issues).toEqual(['stale'])
+    expect(risk).toBe('high')
   })
 })

--- a/src/main/ipc/firewall-audit.ipc.ts
+++ b/src/main/ipc/firewall-audit.ipc.ts
@@ -52,7 +52,42 @@ function parseSignature(raw: string): FirewallSignatureStatus {
   }
 }
 
-function classifyRule(
+// Built-in Windows rules carry one of two unresolved resource references in
+// their description or group field (Windows tried to resolve via MUI and
+// failed, so we see the raw reference string). Either form is a reliable
+// Microsoft/packaged-app signal even when the rule has no program filter:
+//
+//   1. Classic MUI resource: "@FirewallAPI.dll,-25000",
+//      "@%systemroot%\system32\vmms.exe,-210" — used by Win32 system rules.
+//   2. AppX/UWP package resource: "@{Pkg_Ver_arch__pub?ms-resource://...}" —
+//      used by packaged apps (Desktop App Web Viewer, OOBE, etc.). UWP apps
+//      run inside an AppContainer sandbox so "broad-scope" doesn't apply
+//      the same way as for unrestricted Win32 binaries.
+//
+// We also check the Group field because some rules (e.g. "Game Bar") have
+// the resolved literal description but still carry a resource-reference
+// Group, and we trust the AppX `Package` field on the application filter
+// when set — that means a sandboxed packaged app, regardless of description.
+const MUI_RESOURCE_RE = /^@[^,]+\.(?:dll|exe|mui),-\d+(?:;.*)?$/i
+const APPX_RESOURCE_RE = /^@\{[^}]+\?ms-resource:\/\/[^}]+\}$/i
+
+function looksLikeResourceRef(s: string): boolean {
+  const t = s.trim()
+  return MUI_RESOURCE_RE.test(t) || APPX_RESOURCE_RE.test(t)
+}
+
+export function isBuiltinRule(args: {
+  description: string
+  group: string
+  isManaged: boolean
+  isSystemPath: boolean
+}): boolean {
+  if (args.isSystemPath) return true
+  if (args.isManaged) return true
+  return looksLikeResourceRef(args.description) || looksLikeResourceRef(args.group)
+}
+
+export function classifyRule(
   raw: {
     program: string
     programResolved: string
@@ -61,12 +96,26 @@ function classifyRule(
     profiles: FirewallProfile[]
     localPort: string
     remoteAddress: string
+    builtin: boolean
   }
 ): { issues: FirewallIssue[]; risk: FirewallRiskLevel } {
   const issues: FirewallIssue[] = []
 
   const hasProgram = !!raw.programResolved
+
+  // Stale (program path no longer exists) is a real finding even for built-ins —
+  // a Windows feature was uninstalled but the firewall rule wasn't cleaned up.
   if (hasProgram && !raw.programExists) issues.push('stale')
+
+  if (raw.builtin) {
+    // Microsoft-shipped rules are designed to accept Any remote / Any port on
+    // Public profiles (IPv6 routing, Wi-Fi Direct, CDP, etc.). Flagging these
+    // as high-risk produces guidance that breaks features when followed.
+    let risk: FirewallRiskLevel = 'low'
+    if (issues.includes('stale')) risk = 'high'
+    return { issues, risk }
+  }
+
   if (hasProgram && raw.programExists && raw.signature === 'unsigned') issues.push('unsigned')
 
   const isAnyRemote = !raw.remoteAddress || raw.remoteAddress.toLowerCase() === 'any'
@@ -85,22 +134,27 @@ function classifyRule(
 
 // Parse a single RULE| line from the PowerShell scanner.  Exported for tests.
 export function parseRuleLine(line: string): FirewallRule | null {
-  // Format: RULE|name|display|description|group|profiles|protocol|localPort|remoteAddress|program|programResolved|exists|signature|enabled
+  // Format: RULE|name|display|description|group|profiles|protocol|localPort|remoteAddress|program|programResolved|exists|signature|isSystemPath|isManaged|enabled
   if (!line.startsWith('RULE|')) return null
   const parts = line.split('|')
-  if (parts.length < 14) return null
+  if (parts.length < 16) return null
 
   const name = parts[1]
   if (!name) return null
 
+  const description = parts[3] || ''
+  const group = parts[4] || ''
   const profiles = parseProfiles(parts[5])
   const programResolved = parts[10]
   const programExists = parts[11].trim().toLowerCase() === 'true'
   const signature = parseSignature(parts[12].trim().toLowerCase())
-  const enabled = parts[13].trim().toLowerCase() === 'true'
+  const isSystemPath = parts[13].trim().toLowerCase() === 'true'
+  const isManaged = parts[14].trim().toLowerCase() === 'true'
+  const enabled = parts[15].trim().toLowerCase() === 'true'
 
   const localPort = parts[7] || 'Any'
   const remoteAddress = parts[8] || 'Any'
+  const builtin = isBuiltinRule({ description, group, isManaged, isSystemPath })
 
   const { issues, risk } = classifyRule({
     program: parts[9],
@@ -110,13 +164,14 @@ export function parseRuleLine(line: string): FirewallRule | null {
     profiles,
     localPort,
     remoteAddress,
+    builtin,
   })
 
   return {
     name,
     displayName: parts[2] || name,
-    description: parts[3] || '',
-    group: parts[4] || '',
+    description,
+    group,
     profiles,
     protocol: parts[6] || 'Any',
     localPort,
@@ -125,6 +180,7 @@ export function parseRuleLine(line: string): FirewallRule | null {
     programResolved,
     programExists,
     signature,
+    builtin,
     enabled,
     issues,
     risk,
@@ -169,6 +225,17 @@ export async function scanFirewallRules(
       } catch { continue }
 
       $programRaw = if ($app -and $app.Program) { [string]$app.Program } else { '' }
+      # Package SID for AppX/UWP rules (e.g. "S-1-15-2-..."). When set, the
+      # rule applies to a sandboxed packaged app — Game Bar, Microsoft Store,
+      # and similar Win32WebViewHost / OOBE rules all have this populated even
+      # when the description is the resolved literal display name.
+      $packageRaw = if ($app -and $app.Package) { ([string]$app.Package) -replace '\|', ' ' } else { '' }
+      # Owner SID falls back when Package is missing — every Store-installed
+      # AppX rule has an Owner set, while manually-created rules (Defender
+      # Firewall GUI / netsh) typically don't. We collapse to a single
+      # "managed/packaged" boolean to keep the output line format tight.
+      $ownerRaw = if ($r.Owner) { [string]$r.Owner } else { '' }
+      $isManaged = ($packageRaw -ne '') -or ($ownerRaw -ne '')
       $localPort  = if ($port -and $port.LocalPort) { (@($port.LocalPort) -join ',') } else { 'Any' }
       $protocol   = if ($port -and $port.Protocol) { [string]$port.Protocol } else { 'Any' }
       $remoteAddr = if ($addr -and $addr.RemoteAddress) { (@($addr.RemoteAddress) -join ',') } else { 'Any' }
@@ -176,11 +243,11 @@ export async function scanFirewallRules(
       $programResolved = ''
       $exists = $false
       $signed = ''
+      $isSystemPath = $false
       if ($programRaw -and $programRaw -ne 'Any' -and $programRaw -ne 'System') {
         try { $programResolved = [System.Environment]::ExpandEnvironmentVariables($programRaw) } catch { $programResolved = $programRaw }
         if (Test-Path -LiteralPath $programResolved -PathType Leaf) {
           $exists = $true
-          $isSystemPath = $false
           if ($sysRoot -and $programResolved.StartsWith($sysRoot, 'OrdinalIgnoreCase')) { $isSystemPath = $true }
           if (-not $isSystemPath -and $pf -and $programResolved.StartsWith($pf, 'OrdinalIgnoreCase')) { $isSystemPath = $true }
           if (-not $isSystemPath -and $pfx86 -and $programResolved.StartsWith($pfx86, 'OrdinalIgnoreCase')) { $isSystemPath = $true }
@@ -204,7 +271,7 @@ export async function scanFirewallRules(
       $grp  = if ($r.Group) { ([string]$r.Group) -replace '\|', ' ' } else { '' }
       $prof = [string]$r.Profile
 
-      Write-Output "RULE|$name|$disp|$desc|$grp|$prof|$protocol|$localPort|$remoteAddr|$programRaw|$programResolved|$exists|$signed|true"
+      Write-Output "RULE|$name|$disp|$desc|$grp|$prof|$protocol|$localPort|$remoteAddr|$programRaw|$programResolved|$exists|$signed|$isSystemPath|$isManaged|true"
 
       if (($i % 25) -eq 0) {
         Write-Output "PROG|$i|$total|$disp"

--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -101,7 +101,6 @@ const navGroups: NavGroup[] = [
     items: [
       { icon: Sparkles, labelKey: 'cleaner', path: '/cleaner' },
       { icon: Database, labelKey: 'registry', path: '/registry' },
-      { icon: MousePointerClick, labelKey: 'contextMenu', path: '/context-menu' },
       { icon: Zap, labelKey: 'startup', path: '/startup' },
       { icon: Wifi, labelKey: 'network', path: '/network' },
       {
@@ -111,6 +110,7 @@ const navGroups: NavGroup[] = [
           { icon: Cpu, label: 'Driver Updates', path: '/drivers' },
           { icon: Trash2, label: 'Uninstaller', path: '/uninstaller' },
           { icon: PackageMinus, label: 'Bloatware Remover', path: '/debloater' },
+          { icon: MousePointerClick, labelKey: 'contextMenu', path: '/context-menu' },
         ]
       },
       { icon: CalendarClock, labelKey: 'schedules', path: '/schedules' }
@@ -208,7 +208,6 @@ export function Sidebar() {
     ...group,
     items: group.items.filter((item) => {
       if (item.path === '/registry' && !features.registry) return false
-      if (item.path === '/context-menu' && !features.contextMenu) return false
       if (item.path === '/game-mode' && !features.gameMode) return false
       return true
     }).map((item) => {
@@ -216,6 +215,7 @@ export function Sidebar() {
       const filtered = item.children.filter((child) => {
         if (child.path === '/debloater' && !features.debloater) return false
         if (child.path === '/drivers' && !features.drivers) return false
+        if (child.path === '/context-menu' && !features.contextMenu) return false
         if (child.path === '/firewall' && !features.firewallAudit) return false
         if (child.path === '/threat-monitor' && !(threatMonitorLoaded && threatBlacklistActive)) return false
         if (child.path === '/cve' && !cloudConnected) return false

--- a/src/renderer/src/pages/ContextMenuCleanerPage.tsx
+++ b/src/renderer/src/pages/ContextMenuCleanerPage.tsx
@@ -39,6 +39,28 @@ const SOURCE_PILL_COLOR: Record<ContextMenuSource, { bg: string; text: string }>
   'Unknown':      { bg: 'var(--bg-hover)',        text: 'var(--text-muted)' },
 }
 
+// Sources we hide from the list unconditionally — these are first-party Windows
+// pieces that the user almost never wants to disable, and showing them buries
+// the third-party noise the page is actually for.
+const HIDDEN_SOURCES: ReadonlySet<ContextMenuSource> = new Set(['Microsoft', 'Windows', 'Defender'])
+
+const GROUP_PALETTE: ReadonlyArray<{ bg: string; text: string }> = [
+  { bg: 'rgba(59,130,246,0.10)',  text: '#60a5fa' },
+  { bg: 'rgba(168,85,247,0.10)',  text: '#c084fc' },
+  { bg: 'rgba(14,165,233,0.10)',  text: '#38bdf8' },
+  { bg: 'rgba(34,197,94,0.10)',   text: '#4ade80' },
+  { bg: 'rgba(99,102,241,0.10)',  text: '#818cf8' },
+  { bg: 'rgba(244,114,22,0.10)',  text: '#fb923c' },
+  { bg: 'rgba(245,158,11,0.10)',  text: '#fbbf24' },
+  { bg: 'rgba(20,184,166,0.10)',  text: '#2dd4bf' },
+]
+
+function colorForBinary(name: string): { bg: string; text: string } {
+  let hash = 0
+  for (let i = 0; i < name.length; i++) hash = (hash * 31 + name.charCodeAt(i)) >>> 0
+  return GROUP_PALETTE[hash % GROUP_PALETTE.length]
+}
+
 const SCOPE_LABEL_KEY: Record<ContextMenuScope, string> = {
   AllFiles:             'scopeAllFiles',
   Directory:            'scopeDirectory',
@@ -128,23 +150,49 @@ function ContextMenuCleanerPageContent() {
     setShowWin11(false)
   }, [])
 
+  // Always strip Microsoft/Windows/Defender + protected entries before any
+  // user-controlled filtering — those are first-party / safelisted and we never
+  // want to surface them in the list (or in the filter dropdowns). Also hide
+  // HKCR entries with no command and no DLL path (e.g. HKCR\*\shell\removeproperties),
+  // which tend to be Windows built-in verbs that resolve via MUIVerb resources —
+  // we can't tell what they do and they're machine-wide, so hide for safety.
+  // Finally, hide entries whose registry key name contains a cmd.exe shell
+  // metacharacter (e.g. WizTree's `Wi&zTree`): writes to those HKCR paths
+  // routinely fail with "key not found" because the key only exists via the
+  // HKCU\Software\Classes mirror, and a click would just produce a confusing
+  // reg.exe error.
+  const baseEntries = useMemo(
+    () => entries.filter((e) => {
+      if (e.protected) return false
+      if (HIDDEN_SOURCES.has(e.source)) return false
+      if (e.hive === 'HKCR' && !e.command && !e.dllPath) return false
+      if (/[&|<>^]/.test(e.name)) return false
+      return true
+    }),
+    [entries]
+  )
+
   // Filtered list
-  const visible = useMemo(() => filterEntries(entries, filters), [entries, filters])
+  const visible = useMemo(() => filterEntries(baseEntries, filters), [baseEntries, filters])
 
-  // Group by source then scope.
-  const groups = useMemo(() => groupBySource(visible), [visible])
+  // Group by binary name (executable / DLL) — most third-party entries land in
+  // the 'Unknown' source bucket, so source-based grouping collapsed everything
+  // into one giant group.
+  const groups = useMemo(() => groupByBinary(visible), [visible])
 
-  // Available filter options derived from entries.
+  // Available filter options derived from the post-hidden list, so the source
+  // dropdown doesn't offer Microsoft/Windows/Defender (which would filter to
+  // an empty list).
   const availableSources = useMemo(() => {
     const set = new Set<ContextMenuSource>()
-    for (const e of entries) set.add(e.source)
+    for (const e of baseEntries) set.add(e.source)
     return Array.from(set).sort()
-  }, [entries])
+  }, [baseEntries])
   const availableScopes = useMemo(() => {
     const set = new Set<ContextMenuScope>()
-    for (const e of entries) set.add(e.scope)
+    for (const e of baseEntries) set.add(e.scope)
     return Array.from(set).sort()
-  }, [entries])
+  }, [baseEntries])
 
   const selectedRequests = useMemo(
     () => entries.filter((e) => e.selected && !e.protected),
@@ -334,12 +382,12 @@ function ContextMenuCleanerPageContent() {
       {scanned && groups.length > 0 && (
         <div className="grid grid-cols-1 gap-3" style={{ paddingBottom: selectedCount > 0 ? 90 : 0 }}>
           {groups.map((group) => {
-            const groupKey = `src:${group.source}`
+            const groupKey = `bin:${group.binary}`
             const isExpanded = expanded.has(groupKey)
             const eligibleIds = group.entries.filter((e) => !e.protected).map((e) => e.id)
             const allSelected = eligibleIds.length > 0
               && eligibleIds.every((id) => entries.find((e) => e.id === id)?.selected)
-            const pill = SOURCE_PILL_COLOR[group.source]
+            const pill = colorForBinary(group.binary)
             return (
               <div key={groupKey} className="overflow-hidden rounded-2xl"
                 style={{ border: '1px solid var(--border-default)', opacity: applying ? 0.5 : 1, pointerEvents: applying ? 'none' : 'auto' }}>
@@ -351,7 +399,7 @@ function ContextMenuCleanerPageContent() {
                   </div>
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2.5">
-                      <span className="text-[14px] font-semibold text-zinc-200">{group.source}</span>
+                      <span className="truncate font-mono text-[13px] font-semibold text-zinc-200">{group.binary}</span>
                       <span className="rounded-full px-2 py-0.5 text-[11px] font-medium"
                         style={{ background: 'var(--bg-hover)', color: 'var(--text-secondary)' }}>
                         {group.entries.length}
@@ -478,14 +526,37 @@ function filterEntries(entries: ContextMenuEntry[], filters: { search: string; s
   })
 }
 
-function groupBySource(entries: ContextMenuEntry[]): { source: ContextMenuSource; entries: ContextMenuEntry[] }[] {
-  const map = new Map<ContextMenuSource, ContextMenuEntry[]>()
-  for (const e of entries) {
-    const list = map.get(e.source) ?? []
-    list.push(e)
-    map.set(e.source, list)
+/**
+ * Pull the executable / DLL basename out of a verb's command line or a
+ * handler's resolved DLL path. Falls back to the registry key name when
+ * neither is available (e.g. a handler whose CLSID couldn't be resolved).
+ */
+function binaryNameOf(entry: ContextMenuEntry): string {
+  if (entry.command) {
+    // command may be `"C:\path\bin.exe" "%1"` or bare `C:\path\bin.exe %1`.
+    const m = entry.command.match(/^\s*"([^"]+)"|^\s*(\S+)/)
+    const path = (m?.[1] ?? m?.[2] ?? '').trim()
+    const base = path.split(/[\\/]/).pop()?.trim()
+    if (base) return base
   }
-  return Array.from(map.entries()).map(([source, list]) => ({ source, entries: list }))
+  if (entry.dllPath) {
+    const base = entry.dllPath.split(/[\\/]/).pop()?.trim()
+    if (base) return base
+  }
+  return entry.name || '(unknown)'
+}
+
+function groupByBinary(entries: ContextMenuEntry[]): { binary: string; entries: ContextMenuEntry[] }[] {
+  const map = new Map<string, ContextMenuEntry[]>()
+  for (const e of entries) {
+    const key = binaryNameOf(e)
+    const list = map.get(key) ?? []
+    list.push(e)
+    map.set(key, list)
+  }
+  return Array.from(map.entries())
+    .map(([binary, list]) => ({ binary, entries: list }))
+    .sort((a, b) => a.binary.localeCompare(b.binary))
 }
 
 interface EntryRowProps {

--- a/src/renderer/src/pages/FirewallAuditPage.tsx
+++ b/src/renderer/src/pages/FirewallAuditPage.tsx
@@ -60,6 +60,7 @@ export function FirewallAuditPage() {
   const searchQuery = useFirewallStore((s) => s.searchQuery)
   const riskFilter = useFirewallStore((s) => s.riskFilter)
   const programFilter = useFirewallStore((s) => s.programFilter)
+  const showBuiltin = useFirewallStore((s) => s.showBuiltin)
 
   const [pendingAction, setPendingAction] = useState<FirewallAction | null>(null)
   const isBusy = scanning || applying
@@ -119,8 +120,16 @@ export function FirewallAuditPage() {
       if (result.succeeded > 0) toast.success(`${result.succeeded} rule${result.succeeded === 1 ? '' : 's'} ${verb}`)
       if (result.failed > 0) toast.error(`${result.failed} rule${result.failed === 1 ? '' : 's'} failed`)
 
-      const scanResult = await window.kudu.firewallScan()
-      useFirewallStore.getState().setRules(scanResult.rules)
+      // The scan only enumerates enabled rules, so both delete and disable
+      // mean the rule should disappear from the list. Prune locally instead
+      // of re-scanning — the full re-scan takes 30-90s on a typical system.
+      const failedNames = new Set(result.errors.map((e) => e.name).filter(Boolean))
+      const requestedNames = new Set(selected.map((r) => r.name))
+      useFirewallStore.getState().setRules(
+        useFirewallStore.getState().rules.filter(
+          (r) => !requestedNames.has(r.name) || failedNames.has(r.name)
+        )
+      )
     } catch (err) {
       toast.error('Failed to update firewall rules')
       useFirewallStore
@@ -138,6 +147,11 @@ export function FirewallAuditPage() {
   const filteredRules = useMemo(() => {
     let result = rules
 
+    // Built-in / Microsoft / AppX rules are hidden by default. Stale built-ins
+    // are still surfaced because a leftover rule pointing at a removed Windows
+    // feature is genuinely worth cleaning up — toggle handles only the noise.
+    if (!showBuiltin) result = result.filter((r) => !r.builtin || r.issues.includes('stale'))
+
     if (searchQuery) {
       const q = searchQuery.toLowerCase()
       result = result.filter(
@@ -154,7 +168,12 @@ export function FirewallAuditPage() {
     else if (programFilter === 'stale') result = result.filter((r) => r.issues.includes('stale'))
 
     return result
-  }, [rules, searchQuery, riskFilter, programFilter])
+  }, [rules, searchQuery, riskFilter, programFilter, showBuiltin])
+
+  const builtinCount = useMemo(
+    () => rules.filter((r) => r.builtin && !r.issues.includes('stale')).length,
+    [rules]
+  )
 
   const selectedCount = rules.filter((r) => r.selected).length
   const staleCount = rules.filter((r) => r.issues.includes('stale')).length
@@ -369,6 +388,21 @@ export function FirewallAuditPage() {
                 { value: 'stale', label: 'Stale only' },
               ]}
             />
+            {builtinCount > 0 && (
+              <label
+                className="flex cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-[13px]"
+                style={{ background: 'var(--card-bg)', border: '1px solid var(--border-medium)', color: 'var(--text-secondary)' }}
+                title={`${builtinCount} Microsoft / system / packaged-app rule${builtinCount === 1 ? '' : 's'} hidden by default — these ship with Windows and shouldn't be removed.`}
+              >
+                <input
+                  type="checkbox"
+                  checked={showBuiltin}
+                  onChange={(e) => useFirewallStore.getState().setShowBuiltin(e.target.checked)}
+                  className="h-3.5 w-3.5 cursor-pointer accent-amber-500"
+                />
+                Show built-in ({builtinCount})
+              </label>
+            )}
           </div>
 
           {filteredRules.length === 0 ? (

--- a/src/renderer/src/stores/firewall-store.ts
+++ b/src/renderer/src/stores/firewall-store.ts
@@ -21,6 +21,7 @@ interface FirewallState {
   searchQuery: string
   riskFilter: RiskFilter
   programFilter: ProgramFilter
+  showBuiltin: boolean
 
   setRules: (rules: FirewallRule[]) => void
   setScanning: (scanning: boolean) => void
@@ -33,6 +34,7 @@ interface FirewallState {
   setSearchQuery: (query: string) => void
   setRiskFilter: (filter: RiskFilter) => void
   setProgramFilter: (filter: ProgramFilter) => void
+  setShowBuiltin: (show: boolean) => void
 
   toggleRule: (name: string) => void
   selectRecommended: () => void
@@ -53,6 +55,9 @@ export const useFirewallStore = create<FirewallState>((set) => ({
   searchQuery: '',
   riskFilter: 'all',
   programFilter: 'all',
+  // Hide Microsoft/system/AppX rules by default — they shouldn't be touched
+  // and they bury actionable third-party entries. Toggle to inspect them.
+  showBuiltin: false,
 
   setRules: (rules) => set({ rules }),
   setScanning: (scanning) => set({ scanning }),
@@ -65,6 +70,7 @@ export const useFirewallStore = create<FirewallState>((set) => ({
   setSearchQuery: (searchQuery) => set({ searchQuery }),
   setRiskFilter: (riskFilter) => set({ riskFilter }),
   setProgramFilter: (programFilter) => set({ programFilter }),
+  setShowBuiltin: (showBuiltin) => set({ showBuiltin }),
 
   toggleRule: (name) =>
     set((s) => ({
@@ -94,5 +100,6 @@ export const useFirewallStore = create<FirewallState>((set) => ({
       searchQuery: '',
       riskFilter: 'all',
       programFilter: 'all',
+      showBuiltin: false,
     }),
 }))

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -791,6 +791,11 @@ export interface FirewallRule {
   programResolved: string
   programExists: boolean
   signature: FirewallSignatureStatus
+  // Microsoft-shipped rule: program lives under Windows/Program Files OR the
+  // description is an MUI resource reference (e.g. "@FirewallAPI.dll,-25000").
+  // We suppress broad-scope/any-remote findings on these — they're default
+  // system rules and removing them tends to break Windows features.
+  builtin: boolean
   enabled: boolean
   issues: FirewallIssue[]
   risk: FirewallRiskLevel


### PR DESCRIPTION
## Summary

Polish for the recently-shipped firewall-audit (#149) and context-menu cleaner (#151) — both were surfacing first-party Windows entries as actionable noise, which buried the third-party items the pages exist for.

- **Firewall audit** — detect built-in rules via MUI/AppX resource references, system-path binaries, and AppX Package / Owner SIDs. Suppress broad-scope and any-remote findings on those (Wi-Fi Direct, Core Networking, etc. *ship* as Any/Any on Public). Hide built-ins by default with a "Show built-in (N)" toggle. Stale built-ins still surface — a leftover rule for an uninstalled feature is worth cleaning up.
- **Firewall audit** — after delete/disable, prune the affected rules locally instead of running a full re-scan (the rescan takes 30–90s on a typical machine).
- **Context-menu cleaner** — unconditionally hide `Microsoft` / `Windows` / `Defender` source entries, hide HKCR entries with no command and no DLL (built-in MUIVerb verbs we can't classify), and hide entries whose registry key name contains a shell metacharacter (e.g. WizTree's `Wi&zTree`, where the HKCR write fails). Group by binary name with a hash-derived color instead of by source, so third-party items stop collapsing into one giant "Unknown" bucket.
- **Sidebar** — move "Context Menu" into the "More Tools" submenu next to Uninstaller / Bloatware Remover.
- **package-lock.json** — incidental transitive dep refresh; `package.json` is unchanged.

## Test plan

- [ ] `npm test` — new `isBuiltinRule` tests + updated `classifyRule` cases pass
- [ ] Run a firewall scan on Windows: built-in rules are hidden by default, "Show built-in (N)" reveals them, stale built-ins remain visible without the toggle
- [ ] Delete or disable a firewall rule and confirm it disappears immediately without the long re-scan delay
- [ ] Run the context-menu cleaner: no Microsoft/Windows/Defender entries appear, groups are labelled by binary basename, third-party entries (Steam, WizTree, etc.) are still listed
- [ ] Sidebar: Context Menu link now lives under More Tools, with feature-flag gating intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)