### PR TITLE
fix(shortcuts): don't flag File Explorer / shell-namespace .lnk files as dead

### DIFF
--- a/src/main/ipc/shortcut-cleaner.ipc.test.ts
+++ b/src/main/ipc/shortcut-cleaner.ipc.test.ts
@@ -14,13 +14,12 @@ interface ShortcutInfo {
 // Simplified replica without existsSync (tests parsing/regex logic only).
 
 const WIN_SYSTEM_SUBDIRS = /\\(System Tools|Administrative Tools|Accessibility|Windows PowerShell|Windows System|Windows Accessories)\\/i
-const WIN_TASKBAR_DIR = /\\User Pinned\\TaskBar\\/i
 
 function isTargetBrokenLogic(info: ShortcutInfo, platform: string, targetExists: boolean): boolean {
   if (platform === 'win32') {
     if (WIN_SYSTEM_SUBDIRS.test(info.path)) return false
-    if (WIN_TASKBAR_DIR.test(info.path) && !info.targetPath) return false
-    if (info.targetPath && /\\Windows\\/i.test(info.targetPath)) return false
+    if (!info.targetPath) return false
+    if (/\\Windows\\/i.test(info.targetPath)) return false
   }
   if (!info.targetPath) return true
   if (info.targetPath.trim() === '') return true
@@ -53,6 +52,15 @@ describe('isTargetBroken logic', () => {
   it('does not flag shortcuts in Accessibility', () => {
     expect(isTargetBrokenLogic({
       path: 'C:\\Start Menu\\Programs\\Accessibility\\magnify.lnk',
+      targetPath: null
+    }, 'win32', false)).toBe(false)
+  })
+
+  it('does not flag Windows shortcuts with no resolvable target (shell namespace targets)', () => {
+    // Regression: issue #169 — "File Explorer.lnk" uses a shell ID list target,
+    // so WScript.Shell returns an empty TargetPath. It must not be flagged as dead.
+    expect(isTargetBrokenLogic({
+      path: 'C:\\Users\\User\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\File Explorer.lnk',
       targetPath: null
     }, 'win32', false)).toBe(false)
   })
@@ -127,11 +135,14 @@ describe('isTargetBroken logic', () => {
 
   // ── Null and empty targets ──
 
-  it('flags null target as broken (non-system path)', () => {
+  it('on Linux, flags null target as broken', () => {
+    // On Linux, a null target means the .desktop file had no Exec line or was
+    // unreadable, which we treat as broken. On Windows, null instead means a
+    // shell-namespace target that we cannot verify (handled above).
     expect(isTargetBrokenLogic({
-      path: 'C:\\Desktop\\broken.lnk',
+      path: '/home/user/Desktop/broken.desktop',
       targetPath: null
-    }, 'win32', false)).toBe(true)
+    }, 'linux', false)).toBe(true)
   })
 
   it('flags empty string target as broken', () => {

--- a/src/main/ipc/shortcut-cleaner.ipc.ts
+++ b/src/main/ipc/shortcut-cleaner.ipc.ts
@@ -170,19 +170,17 @@ function getShortcutDirs(): { path: string; subcategory: string }[] {
 /** Windows Start Menu subdirectories that contain built-in OS shortcuts */
 const WIN_SYSTEM_SUBDIRS = /\\(System Tools|Administrative Tools|Accessibility|Windows PowerShell|Windows System|Windows Accessories)\\/i
 
-/** Taskbar pinned shortcuts directory — shortcuts here were explicitly pinned by the user */
-const WIN_TASKBAR_DIR = /\\User Pinned\\TaskBar\\/i
-
 function isTargetBroken(info: ShortcutInfo): boolean {
   if (process.platform === 'win32') {
     // Never flag shortcuts in built-in Windows Start Menu subdirectories
     if (WIN_SYSTEM_SUBDIRS.test(info.path)) return false
-    // Never flag taskbar shortcuts with unresolvable targets — many system
-    // shortcuts (e.g. File Explorer) use shell extensions that WScript.Shell
-    // cannot resolve, returning an empty TargetPath despite being valid
-    if (WIN_TASKBAR_DIR.test(info.path) && !info.targetPath) return false
+    // A .lnk with a stored filesystem path returns it from WScript.Shell even
+    // when the file is gone, so an empty TargetPath means the shortcut targets
+    // a shell namespace item (File Explorer, This PC, Recycle Bin, etc.) which
+    // we can't verify via the filesystem — leave it alone.
+    if (!info.targetPath) return false
     // Never flag shortcuts pointing to Windows system executables
-    if (info.targetPath && /\\Windows\\/i.test(info.targetPath)) return false
+    if (/\\Windows\\/i.test(info.targetPath)) return false
   }
   // If we couldn't resolve the target at all, consider it broken
   if (!info.targetPath) return true


### PR DESCRIPTION
## Summary
- Closes #169 — "File Explorer.lnk" (and other shell-namespace shortcuts like This PC, Recycle Bin, Control Panel) were being flagged as dead by the Shortcuts scanner.
- These shortcuts store a `LinkTargetIDList` instead of a filesystem path, so `WScript.Shell.CreateShortcut(...).TargetPath` returns empty. The old rule only forgave empty targets inside `\User Pinned\TaskBar\`, so the same shortcut sitting in a Start Menu pinned folder got flagged.
- A normal `.lnk` to a deleted file still returns its stored path from `WScript.Shell`, so on Windows an empty `TargetPath` specifically means "shell-namespace target we can't verify via the filesystem" — now treated as such across all directories.
- Linux/macOS behavior unchanged (null target there still indicates a real problem).

## Test plan
- [x] `npm test -- shortcut-cleaner` — 44/44 passing
- [x] Added a regression test naming issue #169 that pins `File Explorer.lnk` in a Start Menu directory with `targetPath: null` and asserts it is **not** flagged
- [ ] Manual smoke on Windows 11: run Cleaner > System Cleaner > Shortcuts and confirm `File Explorer.lnk` no longer appears
- [ ] Confirm a genuinely broken Desktop `.lnk` (e.g. shortcut to a deleted `.exe`) is still flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)