### PR TITLE
fix(diagnostics): log renderer crashes and harden updater broadcast

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -12,6 +12,7 @@ import { registerCleanerIpc } from './ipc'
 import { getSettings } from './services/settings-store'
 import { startScheduler, stopScheduler, getNextScanTime, notifyScheduledScanComplete, completeScheduleRun } from './services/scheduler'
 import { initAutoUpdater } from './services/auto-updater'
+import { attachRendererDiagnostics } from './services/renderer-diagnostics'
 import { cloudAgent } from './services/cloud-agent'
 import { runCli } from './cli'
 import { runDaemon } from './daemon'
@@ -341,6 +342,8 @@ function createWindow(): void {
   // or macOS wasOpenedAtLogin (since macOS 13+ drops argv from login items).
   const isStartupLaunch = process.argv.includes('--startup')
     || (process.platform === 'darwin' && app.getLoginItemSettings().wasOpenedAtLogin)
+
+  attachRendererDiagnostics(mainWindow)
 
   mainWindow.on('ready-to-show', () => {
     // If launched at startup with minimize-to-tray, stay hidden

--- a/src/main/services/auto-updater.ts
+++ b/src/main/services/auto-updater.ts
@@ -19,9 +19,15 @@ function broadcast(s: UpdateStatus): void {
     return
   }
   for (const win of BrowserWindow.getAllWindows()) {
-    if (!win.isDestroyed()) {
+    if (win.isDestroyed()) continue
+    // isDestroyed() returns false while the render frame is mid-teardown,
+    // so .send() still throws "Render frame was disposed before WebFrameMain
+    // could be accessed". Swallow it — there's no recipient anyway, and the
+    // unhandled stack trace was the loudest signal in issue #148, masking
+    // the actual renderer crash.
+    try {
       win.webContents.send(IPC.UPDATER_STATUS, s)
-    }
+    } catch { /* renderer gone — nothing to deliver to */ }
   }
 }
 

--- a/src/main/services/renderer-diagnostics.ts
+++ b/src/main/services/renderer-diagnostics.ts
@@ -1,0 +1,61 @@
+import { app, BrowserWindow } from 'electron'
+import { logError, logInfo } from './logger'
+
+/**
+ * Attaches listeners that record renderer-side failures to the log file.
+ *
+ * Issue #148: a user reported a completely black window on Windows 11 with no
+ * UI ever loading. The packaged app produced zero on-disk evidence — the
+ * borderless frame meant there was no menu to open DevTools, and the only
+ * visible error (in PowerShell) was a downstream "Render frame was disposed"
+ * from the auto-updater trying to push to an already-dead renderer.
+ *
+ * These listeners capture the actual cause (renderer crash, preload throw,
+ * resource load failure, hang) into %APPDATA%/Kudu/logs/kudu.log so future
+ * reports come with diagnostic data attached. In packaged builds we also pop
+ * DevTools detached on a crash so the user can grab the console output.
+ */
+export function attachRendererDiagnostics(win: BrowserWindow): void {
+  const wc = win.webContents
+
+  wc.on('render-process-gone', (_event, details) => {
+    logError(
+      `Renderer process gone: reason=${details.reason} exitCode=${details.exitCode}`
+    )
+    if (app.isPackaged && !wc.isDestroyed() && !wc.isDevToolsOpened()) {
+      try { wc.openDevTools({ mode: 'detach' }) } catch { /* DevTools may be unavailable */ }
+    }
+  })
+
+  wc.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+    // Ignore -3 (ABORTED) — fired routinely when navigation is replaced
+    if (errorCode === -3) return
+    logError(
+      `Renderer load failed: code=${errorCode} desc=${errorDescription} url=${validatedURL} mainFrame=${isMainFrame}`
+    )
+  })
+
+  wc.on('preload-error', (_event, preloadPath, error) => {
+    logError(`Preload error in ${preloadPath}:`, error)
+  })
+
+  wc.on('did-finish-load', () => {
+    logInfo('Renderer finished loading')
+  })
+
+  win.on('unresponsive', () => {
+    logError('Renderer became unresponsive')
+  })
+
+  win.on('responsive', () => {
+    logInfo('Renderer responsive again')
+  })
+
+  // Forward renderer console warnings/errors to the main log. Level: 0=debug,
+  // 1=info, 2=warning, 3=error. We only capture 2+ to avoid drowning the log.
+  wc.on('console-message', (_event, level, message, line, sourceId) => {
+    if (level < 2) return
+    const label = level === 3 ? 'error' : 'warn'
+    logError(`Renderer console.${label}: ${message} (${sourceId}:${line})`)
+  })
+}


### PR DESCRIPTION
## Summary

- Adds `attachRendererDiagnostics()` that records renderer-side failures (`render-process-gone`, `did-fail-load`, `preload-error`, `unresponsive`, warn/error `console-message`) to `%APPDATA%/Kudu/logs/kudu.log`, and auto-opens DevTools detached on crash in packaged builds.
- Wraps `webContents.send` in the auto-updater `broadcast()` so the "Render frame was disposed" exception no longer masks the underlying renderer failure.

## Why

Closes #148 — user reported a fully black window on Windows 11 with no on-disk evidence. The borderless frame hides DevTools, and the only visible signal was a downstream stack trace from the auto-updater, which made the actual cause invisible. With these listeners in place, the next report from the same situation will arrive with the renderer crash reason, failed URL, or preload exception already in the log.

## Test plan

- [x] `npm test` — 2076 tests pass
- [x] `npm run build` — clean
- [ ] Smoke: launch packaged build, confirm `kudu.log` records `Renderer finished loading` on the happy path
- [ ] Force a crash (e.g. throw in renderer entry) — confirm `Renderer process gone` lands in the log and DevTools opens detached

🤖 Generated with [Claude Code](https://claude.com/claude-code)