### PR TITLE
feat(malware): surface quarantine reason and add quick access

### DIFF
--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -11,6 +11,7 @@ import type {
   MalwareScanProgress,
   MalwareActionResult,
   QuarantinedItem,
+  QuarantineMeta,
   YaraRulesInfo
 } from '../../shared/types'
 import type { WindowGetter } from './index'
@@ -38,6 +39,10 @@ function getQuarantinePath(): string {
 interface ManifestEntry {
   originalPath: string
   quarantinedAt: number
+  detectionName?: string
+  severity?: 'critical' | 'high' | 'medium' | 'low'
+  source?: 'defender' | 'heuristic' | 'signature'
+  details?: string
 }
 type Manifest = Record<string, ManifestEntry>
 
@@ -1678,11 +1683,21 @@ export async function scanMalware(
     }
 }
 
-export async function quarantineMalware(paths: string[]): Promise<MalwareActionResult> {
+export async function quarantineMalware(paths: string[], meta?: QuarantineMeta[]): Promise<MalwareActionResult> {
     const allowedDirs = getScanPaths()
     const validPaths = Array.isArray(paths)
       ? paths.filter((v): v is string => typeof v === 'string' && isPathInAllowedDirs(v, allowedDirs))
       : []
+
+    // Index detection metadata by path so each quarantined file records why it was flagged.
+    const metaByPath = new Map<string, QuarantineMeta>()
+    if (Array.isArray(meta)) {
+      for (const m of meta) {
+        if (m && typeof m.path === 'string') metaByPath.set(m.path, m)
+      }
+    }
+    const clip = (s: unknown): string | undefined =>
+      typeof s === 'string' && s.length > 0 ? s.slice(0, 500) : undefined
 
     const quarantineDir = getQuarantinePath()
     await mkdir(quarantineDir, { recursive: true })
@@ -1699,7 +1714,15 @@ export async function quarantineMalware(paths: string[]): Promise<MalwareActionR
         const quarantinedName = `${now}_${randomUUID()}_${fileName}.quarantined`
         const destPath = join(quarantineDir, quarantinedName)
         await rename(filePath, destPath)
-        manifest[quarantinedName] = { originalPath: filePath, quarantinedAt: now }
+        const m = metaByPath.get(filePath)
+        manifest[quarantinedName] = {
+          originalPath: filePath,
+          quarantinedAt: now,
+          detectionName: clip(m?.detectionName),
+          severity: m?.severity,
+          source: m?.source,
+          details: clip(m?.details)
+        }
         succeeded++
       } catch (err: any) {
         failed++
@@ -1779,7 +1802,11 @@ export async function listQuarantinedFiles(): Promise<QuarantinedItem[]> {
         originalPath: manifestEntry?.originalPath ?? '',
         originalFileName,
         quarantinedAt: manifestEntry?.quarantinedAt ?? (parsedTimestamp || 0),
-        size
+        size,
+        detectionName: manifestEntry?.detectionName,
+        severity: manifestEntry?.severity,
+        source: manifestEntry?.source,
+        details: manifestEntry?.details
       })
     }
 
@@ -1810,10 +1837,13 @@ export function registerMalwareScannerIpc(getWindow: WindowGetter): void {
     if (win && !win.isDestroyed()) win.webContents.send(IPC.MALWARE_PROGRESS, data)
   }))
 
-  ipcMain.handle(IPC.MALWARE_QUARANTINE, async (_event, paths: string[]) => {
+  ipcMain.handle(IPC.MALWARE_QUARANTINE, async (_event, paths: string[], meta?: QuarantineMeta[]) => {
     const valid = validateStringArray(paths, 5_000)
     if (!valid) return { succeeded: 0, failed: 0, errors: [] }
-    return quarantineMalware(valid)
+    const validMeta = Array.isArray(meta)
+      ? meta.filter((m): m is QuarantineMeta => !!m && typeof m.path === 'string').slice(0, 5_000)
+      : undefined
+    return quarantineMalware(valid, validMeta)
   })
 
   ipcMain.handle(IPC.MALWARE_DELETE, async (_event, paths: string[]) => {

--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -46,6 +46,16 @@ interface ManifestEntry {
 }
 type Manifest = Record<string, ManifestEntry>
 
+// Detection metadata is read back from a JSON manifest on disk (and arrives
+// over IPC), so normalize the enums to known values — an unexpected string
+// would otherwise be passed to the renderer and break severity-keyed lookups.
+const VALID_SEVERITIES = new Set<QuarantinedItem['severity']>(['critical', 'high', 'medium', 'low'])
+const VALID_SOURCES = new Set<QuarantinedItem['source']>(['defender', 'heuristic', 'signature'])
+const asSeverity = (v: unknown): QuarantinedItem['severity'] | undefined =>
+  typeof v === 'string' && VALID_SEVERITIES.has(v as QuarantinedItem['severity']) ? (v as QuarantinedItem['severity']) : undefined
+const asSource = (v: unknown): QuarantinedItem['source'] | undefined =>
+  typeof v === 'string' && VALID_SOURCES.has(v as QuarantinedItem['source']) ? (v as QuarantinedItem['source']) : undefined
+
 function getManifestPath(): string {
   return join(getQuarantinePath(), 'quarantine-manifest.json')
 }
@@ -1719,8 +1729,8 @@ export async function quarantineMalware(paths: string[], meta?: QuarantineMeta[]
           originalPath: filePath,
           quarantinedAt: now,
           detectionName: clip(m?.detectionName),
-          severity: m?.severity,
-          source: m?.source,
+          severity: asSeverity(m?.severity),
+          source: asSource(m?.source),
           details: clip(m?.details)
         }
         succeeded++
@@ -1804,8 +1814,8 @@ export async function listQuarantinedFiles(): Promise<QuarantinedItem[]> {
         quarantinedAt: manifestEntry?.quarantinedAt ?? (parsedTimestamp || 0),
         size,
         detectionName: manifestEntry?.detectionName,
-        severity: manifestEntry?.severity,
-        source: manifestEntry?.source,
+        severity: asSeverity(manifestEntry?.severity),
+        source: asSource(manifestEntry?.source),
         details: manifestEntry?.details
       })
     }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -300,8 +300,8 @@ const api = {
 
   // Malware scanner
   malwareScan: (): Promise<MalwareScanResult> => ipcRenderer.invoke(IPC.MALWARE_SCAN),
-  malwareQuarantine: (paths: string[]): Promise<MalwareActionResult> =>
-    ipcRenderer.invoke(IPC.MALWARE_QUARANTINE, paths),
+  malwareQuarantine: (paths: string[], meta?: import('../shared/types').QuarantineMeta[]): Promise<MalwareActionResult> =>
+    ipcRenderer.invoke(IPC.MALWARE_QUARANTINE, paths, meta),
   malwareDelete: (paths: string[]): Promise<MalwareActionResult> =>
     ipcRenderer.invoke(IPC.MALWARE_DELETE, paths),
   malwareRestore: (quarantinedPath: string, originalPath: string): Promise<boolean> =>

--- a/src/renderer/src/pages/DashboardPage.tsx
+++ b/src/renderer/src/pages/DashboardPage.tsx
@@ -277,7 +277,14 @@ export function DashboardPage() {
       if (result.threats.length === 0) return { found: 0, quarantined: 0 }
       setPhaseLabel(t('phaseLabelQuarantiningThreats'))
       const paths = result.threats.map((t) => t.path)
-      const actionResult = await window.kudu.malwareQuarantine(paths)
+      const meta = result.threats.map((t) => ({
+        path: t.path,
+        detectionName: t.detectionName,
+        severity: t.severity,
+        source: t.source,
+        details: t.details
+      }))
+      const actionResult = await window.kudu.malwareQuarantine(paths, meta)
       return { found: result.threats.length, quarantined: actionResult.succeeded }
     } catch {
       toast.error(t('toastMalwareScanFailed'))
@@ -682,9 +689,15 @@ export function DashboardPage() {
                   {result.registryFixed > 0 && <p className="text-[12px]" style={{ color: 'var(--text-secondary)' }}>{t('resultRegistryFixed', { count: result.registryFixed })}</p>}
                   {result.driversRemoved > 0 && <p className="text-[12px]" style={{ color: 'var(--text-secondary)' }}>{t('resultDriversRemoved', { count: result.driversRemoved })}</p>}
                   {result.threatsFound > 0 && (
-                    <p className="text-[12px]" style={{ color: result.threatsQuarantined > 0 ? '#22c55e' : '#ef4444' }}>
-                      {t(result.threatsQuarantined !== 1 ? 'resultThreatsQuarantinedPlural' : 'resultThreatsQuarantined', { count: result.threatsQuarantined })}
-                    </p>
+                    result.threatsQuarantined > 0 ? (
+                      <button onClick={() => navigate('/malware', { state: { tab: 'quarantine' } })} className="text-[12px] hover:underline" style={{ color: '#22c55e' }}>
+                        {t(result.threatsQuarantined !== 1 ? 'resultThreatsQuarantinedPlural' : 'resultThreatsQuarantined', { count: result.threatsQuarantined })} &rarr;
+                      </button>
+                    ) : (
+                      <p className="text-[12px]" style={{ color: '#ef4444' }}>
+                        {t(result.threatsQuarantined !== 1 ? 'resultThreatsQuarantinedPlural' : 'resultThreatsQuarantined', { count: result.threatsQuarantined })}
+                      </p>
+                    )
                   )}
                   {result.threatsFound === 0 && result.privacyScore > 0 && <p className="text-[12px]" style={{ color: 'var(--text-secondary)' }}>{t('resultNoThreatsFound')}</p>}
                   {result.privacyIssues > 0 && (

--- a/src/renderer/src/pages/MalwareScannerPage.tsx
+++ b/src/renderer/src/pages/MalwareScannerPage.tsx
@@ -1064,6 +1064,9 @@ export function MalwareScannerPage() {
             <div className="space-y-1.5">
               {quarantineItems.map(item => {
                 const checked = quarantineSelectedIds.has(item.quarantinedPath)
+                // Guard against an unexpected severity (e.g. a hand-edited manifest)
+                // so an unknown key never indexes severityConfig to undefined.
+                const sev = item.severity && severityConfig[item.severity] ? severityConfig[item.severity] : null
                 return (
                   <label
                     key={item.quarantinedPath}
@@ -1103,12 +1106,12 @@ export function MalwareScannerPage() {
                         <span className="text-[13px] font-semibold text-zinc-200 truncate">
                           {item.originalFileName}
                         </span>
-                        {item.severity && (
+                        {sev && (
                           <span
                             className="rounded-md px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide shrink-0"
-                            style={{ background: severityConfig[item.severity].bg, color: severityConfig[item.severity].color, border: `1px solid ${severityConfig[item.severity].border}` }}
+                            style={{ background: sev.bg, color: sev.color, border: `1px solid ${sev.border}` }}
                           >
-                            {t(severityConfig[item.severity].labelKey)}
+                            {t(sev.labelKey)}
                           </span>
                         )}
                         {!item.originalPath && (
@@ -1125,7 +1128,7 @@ export function MalwareScannerPage() {
                           <>
                             <span
                               className="text-[11px] font-medium shrink-0"
-                              style={{ color: item.severity ? severityConfig[item.severity].color : 'var(--text-secondary)' }}
+                              style={{ color: sev ? sev.color : 'var(--text-secondary)' }}
                             >
                               {item.detectionName}
                             </span>

--- a/src/renderer/src/pages/MalwareScannerPage.tsx
+++ b/src/renderer/src/pages/MalwareScannerPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useLocation } from 'react-router-dom'
 import {
   Search,
   Shield,
@@ -72,7 +73,9 @@ export function MalwareScannerPage() {
   const actionMode = useMalwareStore(s => s.actionMode)
   const expandedId = useMalwareStore(s => s.expandedId)
 
-  const [viewMode, setViewMode] = useState<'scanner' | 'quarantine' | 'database'>('scanner')
+  const location = useLocation()
+  const initialTab = (location.state as { tab?: 'scanner' | 'quarantine' | 'database' } | null)?.tab
+  const [viewMode, setViewMode] = useState<'scanner' | 'quarantine' | 'database'>(initialTab ?? 'scanner')
   const [showConfirm, setShowConfirm] = useState(false)
   const [quarantineConfirmMode, setQuarantineConfirmMode] = useState<'restore' | 'delete' | null>(null)
   const [yaraInfo, setYaraInfo] = useState<import('@shared/types').YaraRulesInfo | null>(null)
@@ -131,7 +134,13 @@ export function MalwareScannerPage() {
 
     try {
       const result = currentActionMode === 'quarantine'
-        ? await window.kudu.malwareQuarantine(selectedPaths)
+        ? await window.kudu.malwareQuarantine(selectedPaths, selectedThreats.map(t => ({
+            path: t.path,
+            detectionName: t.detectionName,
+            severity: t.severity,
+            source: t.source,
+            details: t.details
+          })))
         : await window.kudu.malwareDelete(selectedPaths)
 
       store.getState().setActionResult(result)
@@ -1058,6 +1067,7 @@ export function MalwareScannerPage() {
                 return (
                   <label
                     key={item.quarantinedPath}
+                    title={item.details || undefined}
                     className="flex cursor-pointer items-center gap-3 rounded-xl px-4 py-3.5 transition-all duration-200"
                     style={{
                       background: checked ? 'var(--accent-muted-bg)' : 'var(--card-bg)',
@@ -1093,6 +1103,14 @@ export function MalwareScannerPage() {
                         <span className="text-[13px] font-semibold text-zinc-200 truncate">
                           {item.originalFileName}
                         </span>
+                        {item.severity && (
+                          <span
+                            className="rounded-md px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide shrink-0"
+                            style={{ background: severityConfig[item.severity].bg, color: severityConfig[item.severity].color, border: `1px solid ${severityConfig[item.severity].border}` }}
+                          >
+                            {t(severityConfig[item.severity].labelKey)}
+                          </span>
+                        )}
                         {!item.originalPath && (
                           <span
                             className="rounded-md px-1.5 py-0.5 text-[10px] shrink-0"
@@ -1102,7 +1120,18 @@ export function MalwareScannerPage() {
                           </span>
                         )}
                       </div>
-                      <div className="flex items-center gap-3">
+                      <div className="flex items-center gap-2 min-w-0">
+                        {item.detectionName && (
+                          <>
+                            <span
+                              className="text-[11px] font-medium shrink-0"
+                              style={{ color: item.severity ? severityConfig[item.severity].color : 'var(--text-secondary)' }}
+                            >
+                              {item.detectionName}
+                            </span>
+                            <span className="text-[11px] shrink-0" style={{ color: 'var(--text-muted)' }}>·</span>
+                          </>
+                        )}
                         <span className="text-[11px] font-mono truncate" style={{ color: 'var(--text-muted)' }}>
                           {item.originalPath || item.quarantinedPath}
                         </span>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -297,6 +297,21 @@ export interface QuarantinedItem {
   originalFileName: string
   quarantinedAt: number
   size: number
+  /** Why the file was flagged — captured at quarantine time (optional for legacy entries). */
+  detectionName?: string
+  severity?: 'critical' | 'high' | 'medium' | 'low'
+  source?: 'defender' | 'heuristic' | 'signature'
+  details?: string
+}
+
+/** Detection metadata passed alongside a path when quarantining, so the
+ *  quarantine list can show why each file was flagged. */
+export interface QuarantineMeta {
+  path: string
+  detectionName?: string
+  severity?: 'critical' | 'high' | 'medium' | 'low'
+  source?: 'defender' | 'heuristic' | 'signature'
+  details?: string
 }
 
 export interface YaraRulesInfo {


### PR DESCRIPTION
## Why

User feedback:

> After a full clean, you say "x threats quarantined". It would be good to have easy access to quarantine so the user can see exactly what Kudu thinks is threatening.

Two gaps:

1. **No path to quarantine at the moment of need.** After a clean, "x threats quarantined" was plain text — a dead end — while the privacy/startup/updates results beside it were all clickable. Users had to independently find Sidebar → Malware Scanner → Quarantine tab.
2. **The list couldn't show *why* a file was flagged.** The quarantine manifest only stored `originalPath` + `quarantinedAt`. The detection name/severity were available at quarantine time but discarded, so the list never showed "what Kudu thinks is threatening."

## What changed

**Quick access**
- The dashboard "x threats quarantined" result is now a link (with `→`) that navigates straight to the quarantine list, shown only when there's something to view.
- The Malware Scanner page reads router state to open directly on the **Quarantine** tab.

**Show the detection reason**
- `QuarantinedItem` gains optional `detectionName` / `severity` / `source` / `details`; new `QuarantineMeta` type.
- `quarantineMalware(paths, meta?)` persists detection metadata into the manifest (strings clipped to 500 chars); `listQuarantinedFiles` returns it.
- Both renderer call sites (dashboard full-clean + manual scanner action) pass the threat metadata they already had.
- Quarantine rows now render a colored **severity badge** and the **detection name**, with `details` on hover.

## Backward compatibility

`meta` is optional, so the CLI and cloud-agent callers compile and run unchanged, and quarantine entries from older builds still display — they simply omit the reason (no badge/name).

## Testing

- `npm test` — all 2098 tests pass.
- `tsc` against the project configs reports zero errors in the changed files. (The repo has a pre-existing baseline of ~193 `tsc` errors, all in test files, since the esbuild build does not type-check; none are introduced here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
