### PR TITLE
fix(main): recover from fatal GPU process launch failure on Windows (#203)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -14,6 +14,7 @@ import { startScheduler, stopScheduler, getNextScanTime, notifyScheduledScanComp
 import { initAutoUpdater } from './services/auto-updater'
 import { attachRendererDiagnostics } from './services/renderer-diagnostics'
 import { cloudAgent } from './services/cloud-agent'
+import { shouldDisableGpu, applyGpuFallbackSwitches, registerGpuCrashRecovery } from './services/gpu-fallback'
 import { runCli } from './cli'
 import { runDaemon } from './daemon'
 
@@ -48,6 +49,19 @@ if (dataDirFlag) {
   if (dir && require('path').isAbsolute(dir)) {
     app.setPath('userData', dir)
   }
+}
+
+// ─── GPU process fallback ───────────────────────────────────
+// disableHardwareAcceleration() still spawns a GPU process; on stripped
+// Windows builds that process fails to launch and Chromium fatally aborts
+// (issue #203).  If a prior launch hit that, or the user opted in, fully
+// disable the GPU process.  Otherwise watch for the failure and recover by
+// relaunching with --disable-gpu.  Placed after the data-dir override so
+// the marker is read from the correct userData path.
+if (shouldDisableGpu()) {
+  applyGpuFallbackSwitches()
+} else {
+  registerGpuCrashRecovery()
 }
 
 // ─── Root detection (macOS + Linux) ─────────────────────────

--- a/src/main/services/gpu-fallback.test.ts
+++ b/src/main/services/gpu-fallback.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const h = vi.hoisted(() => ({
+  switches: [] as string[],
+  listeners: {} as Record<string, Array<(...args: unknown[]) => void>>,
+  relaunch: vi.fn(),
+  exit: vi.fn(),
+  dataDir: { value: '' },
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    commandLine: { appendSwitch: (name: string) => h.switches.push(name) },
+    on: (event: string, cb: (...args: unknown[]) => void) => {
+      ;(h.listeners[event] ??= []).push(cb)
+    },
+    relaunch: h.relaunch,
+    exit: h.exit,
+  },
+}))
+
+vi.mock('./settings-store', () => ({ getDataDir: () => h.dataDir.value }))
+
+const markerPath = () => join(h.dataDir.value, '.disable-gpu')
+
+// Re-import per test so the module-level `attemptedRecovery` flag is fresh.
+async function load() {
+  vi.resetModules()
+  return import('./gpu-fallback')
+}
+
+const fireGpuGone = (reason = 'launch-failed') =>
+  h.listeners['child-process-gone'][0]({}, { type: 'GPU', reason })
+
+describe('gpu-fallback', () => {
+  beforeEach(() => {
+    h.dataDir.value = mkdtempSync(join(tmpdir(), 'kudu-gpu-'))
+    h.switches.length = 0
+    for (const k of Object.keys(h.listeners)) delete h.listeners[k]
+    h.relaunch.mockClear()
+    h.exit.mockClear()
+    process.argv = ['node', 'kudu']
+    delete process.env.KUDU_DISABLE_GPU
+  })
+
+  afterEach(() => {
+    rmSync(h.dataDir.value, { recursive: true, force: true })
+  })
+
+  it('is off by default', async () => {
+    const { shouldDisableGpu } = await load()
+    expect(shouldDisableGpu()).toBe(false)
+  })
+
+  it('honors the --disable-gpu flag', async () => {
+    process.argv = ['node', 'kudu', '--disable-gpu']
+    const { shouldDisableGpu } = await load()
+    expect(shouldDisableGpu()).toBe(true)
+  })
+
+  it('honors the KUDU_DISABLE_GPU env var', async () => {
+    process.env.KUDU_DISABLE_GPU = '1'
+    const { shouldDisableGpu } = await load()
+    expect(shouldDisableGpu()).toBe(true)
+  })
+
+  it('honors a persisted marker file', async () => {
+    writeFileSync(markerPath(), '')
+    const { shouldDisableGpu } = await load()
+    expect(shouldDisableGpu()).toBe(true)
+  })
+
+  it('appends the GPU-disabling switches', async () => {
+    const { applyGpuFallbackSwitches } = await load()
+    applyGpuFallbackSwitches()
+    expect(h.switches).toContain('disable-gpu')
+    expect(h.switches).toContain('disable-gpu-sandbox')
+  })
+
+  it('writes a marker and relaunches on GPU launch failure', async () => {
+    const { registerGpuCrashRecovery } = await load()
+    registerGpuCrashRecovery()
+    fireGpuGone()
+
+    expect(existsSync(markerPath())).toBe(true)
+    expect(h.relaunch).toHaveBeenCalledTimes(1)
+    expect(h.relaunch.mock.calls[0][0].args).toContain('--disable-gpu')
+    expect(h.exit).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores non-GPU process exits', async () => {
+    const { registerGpuCrashRecovery } = await load()
+    registerGpuCrashRecovery()
+    h.listeners['child-process-gone'][0]({}, { type: 'Utility', reason: 'crashed' })
+    expect(h.relaunch).not.toHaveBeenCalled()
+  })
+
+  it('does not relaunch more than once', async () => {
+    const { registerGpuCrashRecovery } = await load()
+    registerGpuCrashRecovery()
+    fireGpuGone()
+    fireGpuGone()
+    expect(h.relaunch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/services/gpu-fallback.ts
+++ b/src/main/services/gpu-fallback.ts
@@ -1,0 +1,82 @@
+import { app } from 'electron'
+import { existsSync, writeFileSync, mkdirSync } from 'fs'
+import { join } from 'path'
+import { getDataDir } from './settings-store'
+
+// ─── GPU fallback ───────────────────────────────────────────
+// `app.disableHardwareAcceleration()` turns off GPU *compositing* but
+// Chromium still spawns a GPU process for rasterization/info probing.
+// On heavily stripped Windows builds (e.g. Ghost Spectre SUPERLITE) that
+// process can't launch at all — Chromium retries, then fatally aborts:
+//   GPU process launch failed: error_code=18
+//   [FATAL] GPU process isn't usable. Goodbye.
+// …and the app dies before any window appears.  See issue #203.
+//
+// Recovery: when we observe a GPU process launch failure, persist a marker
+// and relaunch with --disable-gpu so no GPU process is spawned at all.  The
+// marker means subsequent launches skip the GPU process up front, so the
+// user never has to pass --disable-gpu by hand.
+
+const MARKER_FILENAME = '.disable-gpu'
+
+let attemptedRecovery = false
+
+function markerPath(): string {
+  return join(getDataDir(), MARKER_FILENAME)
+}
+
+/**
+ * Whether the GPU process should be disabled this launch. True when the
+ * user passed --disable-gpu, set KUDU_DISABLE_GPU, or a previous launch
+ * recorded a GPU launch failure.
+ */
+export function shouldDisableGpu(): boolean {
+  if (process.argv.includes('--disable-gpu')) return true
+  if (process.env.KUDU_DISABLE_GPU) return true
+  try {
+    return existsSync(markerPath())
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Append the switches that prevent Chromium from spawning a GPU process.
+ * Must be called before app.whenReady().
+ */
+export function applyGpuFallbackSwitches(): void {
+  app.commandLine.appendSwitch('disable-gpu')
+  // The GPU process sandbox is the part that fails to initialize on
+  // stripped Windows; disable it too so a forced software path still works.
+  app.commandLine.appendSwitch('disable-gpu-sandbox')
+}
+
+function persistMarker(): void {
+  try {
+    const dir = getDataDir()
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+    writeFileSync(markerPath(), '')
+  } catch {
+    // Best effort — recovery still happens this run via relaunch args.
+  }
+}
+
+/**
+ * Listen for GPU process launch failures and recover by relaunching with
+ * the GPU disabled. Registering before whenReady() maximizes the chance of
+ * catching the failure before Chromium's fatal abort.
+ */
+export function registerGpuCrashRecovery(): void {
+  app.on('child-process-gone', (_event, details) => {
+    if (details.type !== 'GPU') return
+    if (details.reason !== 'launch-failed' && details.reason !== 'crashed' && details.reason !== 'abnormal-exit') return
+    // Already running without a GPU process — nothing more we can do, and
+    // relaunching would loop. Leave the marker in place.
+    if (attemptedRecovery || shouldDisableGpu()) return
+    attemptedRecovery = true
+
+    persistMarker()
+    app.relaunch({ args: process.argv.slice(1).concat('--disable-gpu') })
+    app.exit(0)
+  })
+}

--- a/src/main/services/settings-store.ts
+++ b/src/main/services/settings-store.ts
@@ -7,7 +7,7 @@ import type { KuduSettings, AppStats, ScheduleEntry, ScheduleTaskType, MalwareAl
 let _dataDir: string | null = null
 let _configPath: string | null = null
 
-function getDataDir(): string {
+export function getDataDir(): string {
   if (!_dataDir) {
     _dataDir = app.isPackaged
       ? app.getPath('userData')


### PR DESCRIPTION
Fixes #203.

## Problem

`app.disableHardwareAcceleration()` disables GPU *compositing* but Chromium still spawns a GPU process. On heavily stripped Windows builds (e.g. Ghost Spectre SUPERLITE) that process fails to launch:

```
GPU process launch failed: error_code=18
[FATAL] GPU process isn't usable. Goodbye.
```

…and the app dies before any window appears. The reporter could only start Kudu with `--disable-gpu --no-sandbox`.

## Fix

New `src/main/services/gpu-fallback.ts`:

- **Auto-recovery:** listens for `child-process-gone` with a GPU `launch-failed`/`crashed`/`abnormal-exit` reason, persists a `.disable-gpu` marker in `userData`, and relaunches with `--disable-gpu`/`--disable-gpu-sandbox`. Subsequent launches read the marker and skip the GPU process up front, so the user never has to pass a flag by hand.
- **Opt-in:** also honors a `--disable-gpu` CLI arg and the `KUDU_DISABLE_GPU` env var.
- Guarded so it relaunches at most once and never loops when GPU is already disabled.

Wired into `src/main/index.ts` after the `--kudu-data-dir` override so the marker resolves to the correct `userData` path (avoids poisoning the memoized data dir).

Users currently stuck can launch once with `--disable-gpu` to write the marker; it auto-applies thereafter.

## Tests

Added `gpu-fallback.test.ts` (8 cases): default off, flag/env/marker detection, switch application, marker-write + relaunch on failure, non-GPU exits ignored, no double relaunch. Full build (`electron-vite build`) is clean.
