### PR TITLE
fix(malware-scanner): drop Heuristic.HiddenADS false positives

### DIFF
--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -19,7 +19,7 @@ import type {
 import type { WindowGetter } from './index'
 import { getPlatform } from '../platform'
 import { validateStringArray } from '../services/ipc-validation'
-import { psUtf8, execNativeUtf8 } from '../services/exec-utf8'
+import { execNativeUtf8 } from '../services/exec-utf8'
 import { getSettings, getMalwareAllowlist, addMalwareAllowlistEntry, removeMalwareAllowlistEntry } from '../services/settings-store'
 import { isExcluded } from '../services/file-utils'
 import { createYaraEngine, yaraMatchToThreatFields, type YaraEngine } from '../services/yara-engine'
@@ -27,10 +27,6 @@ import { getAllRulePaths, getCachedRulePaths, getRulesMetadata, startPeriodicRul
 
 const execFileAsync = promisify(execFile)
 const CLOUD_SERVER_URL = 'https://cloud.usekudu.com'
-
-function psArgs(script: string): string[] {
-  return ['-NoProfile', '-NonInteractive', '-Command', psUtf8(script)]
-}
 
 // ─── Quarantine folder ────────────────────────────────────────
 function getQuarantinePath(): string {
@@ -651,59 +647,6 @@ function analyzeLnkContent(buffer: Buffer): string[] {
   return indicators
 }
 
-// ─── Alternate Data Streams detection (Windows) ─────────────
-// NTFS Alternate Data Streams can hide executables inside innocent files.
-// Uses a single batched PowerShell call instead of per-file invocations.
-// This is completely read-only and safe.
-
-interface AdsResult {
-  path: string
-  stream: string
-}
-
-async function scanAlternateDataStreamsBatch(filePaths: string[]): Promise<AdsResult[]> {
-  if (process.platform !== 'win32' || filePaths.length === 0) return []
-
-  // Build a single PowerShell script that checks all files at once
-  // Escape paths for PowerShell and output "PATH|||STREAMNAME" for each hit
-  const pathArrayLiteral = filePaths
-    .map(p => `'${p.replace(/'/g, "''")}'`)
-    .join(',')
-
-  const script = `
-$paths = @(${pathArrayLiteral})
-foreach ($p in $paths) {
-  try {
-    $streams = Get-Item -LiteralPath $p -Stream * -ErrorAction SilentlyContinue |
-      Where-Object { $_.Stream -ne ':$DATA' -and $_.Stream -ne 'Zone.Identifier' }
-    foreach ($s in $streams) {
-      Write-Output "$p|||$($s.Stream)"
-    }
-  } catch {}
-}
-`.trim()
-
-  try {
-    const { stdout } = await execFileAsync('powershell.exe', psArgs(script), { timeout: 30000, windowsHide: true })
-
-    const results: AdsResult[] = []
-    for (const line of stdout.split('\n')) {
-      const trimmed = line.trim()
-      if (!trimmed) continue
-      const sepIdx = trimmed.indexOf('|||')
-      if (sepIdx === -1) continue
-      results.push({
-        path: trimmed.substring(0, sepIdx),
-        stream: trimmed.substring(sepIdx + 3)
-      })
-    }
-    return results
-  } catch {
-    // PowerShell not available or timed out — skip
-    return []
-  }
-}
-
 // ─── Registry persistence scan (Windows) ─────────────────────
 // Reads standard autostart registry locations (read-only).
 // Only flags entries that point to temp directories, hidden folders,
@@ -1039,23 +982,10 @@ function hashFileSha256(filePath: string): Promise<string> {
   })
 }
 
-// Detection name for hidden Alternate Data Streams. Its `path` is the *base*
-// file, so hashing that path would hash the file's main stream — not the ADS
-// payload that was actually flagged. Such detections can't be allowlisted by
-// content hash, so they're excluded from suppression (see #193 review).
-const ADS_DETECTION_NAME = 'Heuristic.HiddenADS'
-
-/** Whether a detection can be matched against the allowlist by file content
- *  hash. False for ADS detections (path points at the base file, not the
- *  stream) — those are never suppressed via the allowlist. */
-function isHashAllowlistable(threat: MalwareThreat): boolean {
-  return threat.detectionName !== ADS_DETECTION_NAME
-}
-
 /**
  * Drop any detection whose file content hash is on the user's false-positive
- * allowlist. Only real files are hashed (non-file detections — registry, hosts,
- * ADS — can't be allowlisted and are left untouched). Hashing failures are
+ * allowlist. Only real files are hashed (non-file detections — registry, hosts —
+ * can't be allowlisted and are left untouched). Hashing failures are
  * swallowed so an unreadable path never aborts a scan. Returns the surviving
  * threats plus the count suppressed, so the caller can report it (no silent caps).
  */
@@ -1066,12 +996,10 @@ async function filterAllowlistedThreats(threats: MalwareThreat[]): Promise<{ kep
   let suppressed = 0
   for (const threat of threats) {
     let isFile = false
-    if (isHashAllowlistable(threat)) {
-      try {
-        isFile = (await stat(threat.path)).isFile()
-      } catch {
-        isFile = false
-      }
+    try {
+      isFile = (await stat(threat.path)).isFile()
+    } catch {
+      isFile = false
     }
     if (isFile) {
       try {
@@ -1540,35 +1468,6 @@ export async function scanMalware(
       systemThreats++
     }
 
-    // 5b: Alternate Data Streams (Windows only) — single batched PowerShell call
-    if (process.platform === 'win32') {
-      updateCategory('system', { progress: 30 })
-      sendProgress({ step: 'system', stepLabel: 'Scanning for hidden Alternate Data Streams...', progress: 52, engine: 'System Integrity' })
-
-      const adsExts = new Set(['.exe', '.dll', '.scr', '.bat', '.cmd', '.ps1'])
-      const adsCandidates = files.filter(f => adsExts.has(extname(f).toLowerCase())).slice(0, 500)
-      updateCategory('system', { totalItems: adsCandidates.length + 1 })
-
-      const adsResults = await scanAlternateDataStreamsBatch(adsCandidates)
-      for (const ads of adsResults) {
-        if (threats.some(t => t.path === ads.path)) continue
-        const fileStat2 = await stat(ads.path).catch(() => null)
-        threats.push({
-          id: randomUUID(),
-          path: ads.path,
-          fileName: basename(ads.path),
-          size: fileStat2?.size || 0,
-          detectionName: ADS_DETECTION_NAME,
-          severity: 'high',
-          source: 'heuristic',
-          details: `Hidden Alternate Data Stream "${ads.stream}" — may conceal malware payload`,
-          selected: true
-        })
-        systemThreats++
-      }
-      updateCategory('system', { progress: 90, itemsScanned: adsCandidates.length })
-    }
-
     updateCategory('system', { status: 'done', progress: 100, threatsFound: systemThreats })
     completedSteps.push(`System integrity — ${systemThreats} threat${systemThreats !== 1 ? 's' : ''} found`)
 
@@ -1918,9 +1817,6 @@ export async function restoreMalware(quarantinedPath: string, originalPath: stri
  */
 export async function ignoreMalware(path: string, meta?: QuarantineMeta): Promise<MalwareAllowlistEntry | null> {
     if (typeof path !== 'string' || !isPathInAllowedDirs(path, getScanPaths())) return null
-    // ADS detections key off the base file, whose hash doesn't represent the
-    // flagged stream — never allowlist them by content hash (see #193 review).
-    if (meta?.detectionName === ADS_DETECTION_NAME) return null
     try {
       if (!(await stat(path)).isFile()) return null
       const sha256 = await hashFileSha256(path)

--- a/src/main/ipc/malware-scanner.test.ts
+++ b/src/main/ipc/malware-scanner.test.ts
@@ -320,14 +320,10 @@ describe('PE heuristic scoring', () => {
 
 // ─── Allowlist suppression decision (replica) ────────────────────
 // Mirrors filterAllowlistedThreats: a detection is suppressed only when it is
-// hash-allowlistable (not ADS), a real file, and its content hash is on the
-// allowlist. Non-files, ADS, and unreadable files are kept (never silently
-// dropped).
+// a real file whose content hash is on the allowlist. Non-files and unreadable
+// files are kept (never silently dropped).
 
-const ADS_DETECTION_NAME = 'Heuristic.HiddenADS'
-
-function isSuppressed(opts: { detectionName?: string; isFile: boolean; hash: string | null; allowed: Set<string> }): boolean {
-  if (opts.detectionName === ADS_DETECTION_NAME) return false // ADS keys off the base file, not the stream
+function isSuppressed(opts: { isFile: boolean; hash: string | null; allowed: Set<string> }): boolean {
   if (!opts.isFile) return false       // registry/hosts targets can't be allowlisted
   if (opts.hash === null) return false // unreadable file — keep the detection
   return opts.allowed.has(opts.hash)
@@ -352,48 +348,36 @@ describe('allowlist suppression decision', () => {
     expect(isSuppressed({ isFile: true, hash: null, allowed })).toBe(false)
   })
 
-  it('keeps an ADS detection even if the base file hash is allowlisted (#193)', () => {
-    expect(isSuppressed({ detectionName: ADS_DETECTION_NAME, isFile: true, hash: 'abc123', allowed })).toBe(false)
-  })
-
   it('suppresses nothing when the allowlist is empty', () => {
     expect(isSuppressed({ isFile: true, hash: 'abc123', allowed: new Set() })).toBe(false)
   })
 })
 
 // ─── canAllowlistThreat (replica of MalwareScannerPage) ──────────
-// The "Not a virus" action only appears for real-filesystem-path detections
-// that aren't ADS.
+// The "Not a virus" action only appears for real-filesystem-path detections.
 
-function canAllowlistThreat(threat: { path: string; detectionName: string }): boolean {
-  if (threat.detectionName === ADS_DETECTION_NAME) return false
+function canAllowlistThreat(threat: { path: string }): boolean {
   return /^([a-zA-Z]:[\\/]|\\\\|\/)/.test(threat.path)
 }
 
 describe('canAllowlistThreat', () => {
-  const det = 'Heuristic.Suspicious.PE'
-
   it('accepts a Windows drive path', () => {
-    expect(canAllowlistThreat({ path: 'C:\\Games\\Guild Wars\\Gw.exe', detectionName: det })).toBe(true)
+    expect(canAllowlistThreat({ path: 'C:\\Games\\Guild Wars\\Gw.exe' })).toBe(true)
   })
 
   it('accepts a UNC path', () => {
-    expect(canAllowlistThreat({ path: '\\\\server\\share\\app.exe', detectionName: det })).toBe(true)
+    expect(canAllowlistThreat({ path: '\\\\server\\share\\app.exe' })).toBe(true)
   })
 
   it('accepts a POSIX path', () => {
-    expect(canAllowlistThreat({ path: '/usr/local/bin/app', detectionName: det })).toBe(true)
+    expect(canAllowlistThreat({ path: '/usr/local/bin/app' })).toBe(true)
   })
 
   it('rejects a registry key target', () => {
-    expect(canAllowlistThreat({ path: 'HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Run', detectionName: det })).toBe(false)
+    expect(canAllowlistThreat({ path: 'HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Run' })).toBe(false)
   })
 
   it('rejects a scheduled-task path (single leading backslash, not UNC)', () => {
-    expect(canAllowlistThreat({ path: '\\Microsoft\\Windows\\SuspiciousTask', detectionName: det })).toBe(false)
-  })
-
-  it('rejects an ADS detection even with a valid file path (#193)', () => {
-    expect(canAllowlistThreat({ path: 'C:\\Users\\me\\notes.txt', detectionName: ADS_DETECTION_NAME })).toBe(false)
+    expect(canAllowlistThreat({ path: '\\Microsoft\\Windows\\SuspiciousTask' })).toBe(false)
   })
 })

--- a/src/renderer/src/pages/MalwareScannerPage.tsx
+++ b/src/renderer/src/pages/MalwareScannerPage.tsx
@@ -44,15 +44,10 @@ const severityConfig = {
   low: { labelKey: 'severityLow', color: '#6b7280', bg: 'rgba(107,114,128,0.08)', border: 'rgba(107,114,128,0.15)', glow: 'rgba(107,114,128,0.1)' }
 }
 
-// ADS detections point at the base file, not the flagged stream, so they can't
-// be allowlisted by content hash (see #193 review) — hide the action for them.
-const ADS_DETECTION_NAME = 'Heuristic.HiddenADS'
-
 // Only real files can be allowlisted (matched by content hash). Detections
 // whose "path" is a registry key, scheduled task, or other non-file target
-// (e.g. HKLM\..., a task name), or an ADS base file, can't be ignored this way.
-function canAllowlistThreat(threat: { path: string; detectionName: string }): boolean {
-  if (threat.detectionName === ADS_DETECTION_NAME) return false
+// (e.g. HKLM\..., a task name) can't be ignored this way.
+function canAllowlistThreat(threat: { path: string }): boolean {
   return /^([a-zA-Z]:[\\/]|\\\\|\/)/.test(threat.path)
 }
 


### PR DESCRIPTION
## Problem

Multiple users reported Kudu's own updater (`%LocalAppData%\kudu-updater\installer.exe`) — and many other legitimate installers — being flagged as **`Heuristic.HiddenADS`** at **high** severity.

Root cause: the ADS heuristic flagged **any** NTFS alternate data stream other than `:$DATA` and `Zone.Identifier`. Real installers routinely carry benign streams (`SmartScreen`, download-provenance, AV metadata), so they all tripped the detection. Worse, these detections **couldn't be allowlisted** — the allowlist matches by content hash of the *base file*, which doesn't represent the flagged stream — so users had no "Not a virus" escape hatch.

## Fix

Disable the heuristic entirely:
- Remove the ADS scan block (phase 5b) and the batched PowerShell stream probe (`scanAlternateDataStreamsBatch`).
- Remove the `Heuristic.HiddenADS` detection constant and all its allowlist/UI special-casing (now dead code).
- Drop the now-orphaned `psArgs`/`psUtf8` helpers.
- Update tests to match.

## Verification

- `vitest run src/main/ipc/malware-scanner.test.ts` — 44 pass
- `tsc --noEmit` — no errors in touched files