### PR TITLE
fix(gui): don't let minimize-to-tray block app quit and OS shutdown

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -107,6 +107,9 @@ if (!gotLock) {
 let mainWindow: BrowserWindow | null = null
 let tray: Tray | null = null
 let ipcRegistered = false
+// Set once the app is actually quitting (Cmd+Q, tray Quit, OS shutdown) so the
+// minimize-to-tray close interceptor lets windows close instead of aborting quit
+let isQuitting = false
 
 function getIconPath(): string {
   const ext = process.platform === 'darwin' ? 'icns' : process.platform === 'linux' ? 'png' : 'ico'
@@ -266,10 +269,6 @@ function createTray(): void {
     {
       label: t('quit'),
       click: () => {
-        // Force quit — don't intercept close
-        if (mainWindow && !mainWindow.isDestroyed()) {
-          mainWindow.removeAllListeners('close')
-        }
         app.quit()
       }
     }
@@ -306,9 +305,6 @@ function rebuildTrayMenu(): void {
     {
       label: t('quit'),
       click: () => {
-        if (mainWindow && !mainWindow.isDestroyed()) {
-          mainWindow.removeAllListeners('close')
-        }
         app.quit()
       }
     }
@@ -370,6 +366,7 @@ function createWindow(): void {
 
   // Intercept close to minimize to tray if enabled
   mainWindow.on('close', (e) => {
+    if (isQuitting) return
     const currentSettings = getSettings()
     if (currentSettings.minimizeToTray && mainWindow && !mainWindow.isDestroyed()) {
       e.preventDefault()
@@ -542,6 +539,7 @@ app.on('window-all-closed', () => {
 })
 
 app.on('before-quit', () => {
+  isQuitting = true
   stopScheduler()
   cloudAgent.stop()
   // Kill any active child processes (reg.exe, cmd.exe, etc.) to prevent orphans

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -538,6 +538,12 @@ app.on('window-all-closed', () => {
   }
 })
 
+// On macOS, autoUpdater.quitAndInstall() closes all windows *before* emitting
+// before-quit, so mark quitting from this earlier signal too
+app.on('before-quit-for-update', () => {
+  isQuitting = true
+})
+
 app.on('before-quit', () => {
   isQuitting = true
   stopScheduler()


### PR DESCRIPTION
Fixes #239.

## Problem

With **Minimize to tray** enabled, the main window's `close` handler calls `e.preventDefault()` unconditionally. `app.quit()` closes all windows before quitting, so the prevented close aborts the whole quit flow: Cmd+Q and the menu Quit just hide the window, and on macOS the app blocks system shutdown/restart until it is force-quit. See #239 for full details.

## Fix

The standard Electron pattern for tray apps:

- add a module-level `isQuitting` flag, set in `before-quit` and in `before-quit-for-update` (on macOS `autoUpdater.quitAndInstall()` closes windows *before* `before-quit` fires, so without the latter the interceptor would still block update restarts)
- the `close` interceptor returns early when `isQuitting` is set, so windows close and quit proceeds
- drop the `removeAllListeners('close')` workaround from the two tray Quit items (`createTray` / `rebuildTrayMenu`) — `app.quit()` now works on its own

Behavior is otherwise unchanged: clicking the window's close button with minimize-to-tray enabled still hides to tray.

## Testing

- `electron-vite build` passes
- `vitest run`: 2054 tests pass (the two `electron`-binary-dependent test files don't run in my environment; unrelated to this change)
- Manually verified the quit flow logic against Electron's documented `before-quit` → window `close` ordering; with the flag set the interceptor no longer prevents close, so Cmd+Q, Dock → Quit, tray → Quit, and OS shutdown all proceed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
