### PR TITLE
fix(cli): keep stdout parseable in JSON mode

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -82,6 +82,14 @@ When `--json` is passed, output is a single JSON object:
 
 The `clean` key is only present when `--clean` is used.
 
+With `--json`, stdout carries nothing but the JSON document — progress lines and verbose
+diagnostics are written to stderr instead, so output can be piped straight into a parser:
+
+```bash
+kudu --cli programs list --json | jq '.count'   # stdout is pure JSON
+kudu --cli programs list --json 2>/dev/null     # discard progress entirely
+```
+
 ## Prometheus Metrics
 
 Print metrics in Prometheus text format (useful for `node_exporter` textfile collector):

--- a/src/main/cli.test.ts
+++ b/src/main/cli.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { parseCliArgs, ExitCode } from './cli'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { parseCliArgs, ExitCode, cliLog, cliVerbose } from './cli'
 
 describe('parseCliArgs', () => {
   it('parses --json flag', () => {
@@ -107,5 +107,61 @@ describe('ExitCode', () => {
     for (const code of Object.values(ExitCode)) {
       expect(code).toBeLessThan(128)
     }
+  })
+})
+
+describe('JSON stdout purity', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function captureStreams(): { out: string[]; err: string[] } {
+    const out: string[] = []
+    const err: string[] = []
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk: any) => {
+      out.push(String(chunk))
+      return true
+    })
+    vi.spyOn(process.stderr, 'write').mockImplementation((chunk: any) => {
+      err.push(String(chunk))
+      return true
+    })
+    return { out, err }
+  }
+
+  it('cliLog writes progress to stderr in JSON mode, keeping stdout parseable', () => {
+    const { out, err } = captureStreams()
+    cliLog({ json: true, verbosity: 'normal' }, 'Loading installed programs...')
+    expect(out).toEqual([])
+    expect(err).toEqual(['Loading installed programs...\n'])
+  })
+
+  it('cliLog writes to stdout in human mode', () => {
+    const { out, err } = captureStreams()
+    cliLog({ json: false, verbosity: 'normal' }, 'Scanning network...')
+    expect(out).toEqual(['Scanning network...\n'])
+    expect(err).toEqual([])
+  })
+
+  it('cliLog stays silent in quiet mode regardless of json', () => {
+    const { out, err } = captureStreams()
+    cliLog({ json: true, verbosity: 'quiet' }, 'noise')
+    cliLog({ json: false, verbosity: 'quiet' }, 'noise')
+    expect(out).toEqual([])
+    expect(err).toEqual([])
+  })
+
+  it('cliVerbose writes to stderr in JSON mode', () => {
+    const { out, err } = captureStreams()
+    cliVerbose({ json: true, verbosity: 'verbose' }, 'took 12ms')
+    expect(out).toEqual([])
+    expect(err).toEqual(['  [verbose] took 12ms\n'])
+  })
+
+  it('cliVerbose writes to stdout in human mode', () => {
+    const { out, err } = captureStreams()
+    cliVerbose({ json: false, verbosity: 'verbose' }, 'took 12ms')
+    expect(out).toEqual(['  [verbose] took 12ms\n'])
+    expect(err).toEqual([])
   })
 })

--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -53,14 +53,21 @@ function formatBytes(bytes: number): string {
   return `${(bytes / Math.pow(1024, i)).toFixed(2)} ${units[i]}`
 }
 
-function cliLog(ctx: CliContext, msg: string): void {
+/**
+ * Human-facing progress output. In JSON mode this goes to stderr so that
+ * stdout stays a single parseable JSON document for scripted consumers.
+ */
+export function cliLog(ctx: CliContext, msg: string): void {
   if (ctx.verbosity === 'quiet') return
-  process.stdout.write(msg + '\n')
+  const stream = ctx.json ? process.stderr : process.stdout
+  stream.write(msg + '\n')
 }
 
-function cliVerbose(ctx: CliContext, msg: string): void {
+/** Verbose diagnostics. Also kept off stdout in JSON mode. */
+export function cliVerbose(ctx: CliContext, msg: string): void {
   if (ctx.verbosity !== 'verbose') return
-  process.stdout.write(`  [verbose] ${msg}\n`)
+  const stream = ctx.json ? process.stderr : process.stdout
+  stream.write(`  [verbose] ${msg}\n`)
 }
 
 function cliOut(ctx: CliContext, data: unknown): void {

--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -153,7 +153,8 @@ async function _initYaraEngine(): Promise<YaraEngine | null> {
     })
 
     _yaraCompileProgress = null
-    console.log(`[yara] Loaded ${result.loaded} rule files (${result.errors.length} errors)`)
+    // Diagnostics go to stderr so the CLI's --json mode keeps stdout parseable.
+    console.error(`[yara] Loaded ${result.loaded} rule files (${result.errors.length} errors)`)
     if (result.errors.length > 0) {
       console.warn('[yara] Rule load warnings:', result.errors.slice(0, 20))
     }

--- a/src/main/services/yara-engine.ts
+++ b/src/main/services/yara-engine.ts
@@ -117,7 +117,8 @@ export class YaraEngine {
       sources.push({ name: `source-${i}`, content: extraSources[i] })
     }
     if (skippedPlatform > 0) {
-      console.log(`[yara] Skipped ${skippedPlatform} rule files for other platforms`)
+      // stderr, not stdout — keeps the CLI's --json output parseable.
+      console.error(`[yara] Skipped ${skippedPlatform} rule files for other platforms`)
     }
 
     if (sources.length === 0) {


### PR DESCRIPTION
## What does this PR do?

Routes CLI progress output to stderr when `--json` is passed, so stdout contains nothing but the JSON document.

## Why?

`--json` is documented as *"Output results as JSON instead of human-readable text"*, but several commands print a progress line to stdout ahead of the JSON, which breaks any consumer that pipes stdout into a parser:

```console
$ kudu --cli programs list --json
Loading installed programs...
{
  "programs": [ ...

$ kudu --cli network scan --json
Scanning network...
{
  "items": [ ...
```

The behaviour was inconsistent, which is what suggested an oversight rather than a deliberate choice — `perf info` and `startup list` already emitted clean JSON, while `programs list` and `network scan` did not.

`cliLog()` and `cliVerbose()` are fixed at the source instead of at their ~116 call sites, so every command benefits and no future call site can reintroduce it. Progress isn't lost — it moves to stderr, so it still shows in a terminal and can be captured (`2>progress.log`) or dropped (`2>/dev/null`).

`showProgress()` already suppressed carriage-return progress in JSON mode, so that path was unaffected.

## How to test

```bash
npm install && npm run build

# Before: fails to parse. After: prints a count.
npx electron . --cli programs list --json | jq '.count'
npx electron . --cli network scan --json | jq '.count'

# Progress is preserved on stderr:
npx electron . --cli programs list --json 2>&1 >/dev/null
# → Loading installed programs...

# Human mode is unchanged:
npx electron . --cli programs list
```

Unit tests cover both streams across JSON/human/quiet modes in `src/main/cli.test.ts`.

## Checklist

- [x] Tested on my platform (Windows / macOS / Linux) — verified on Windows 11
- [x] `npm test` passes — 2167 tests, 93 files
- [x] `npm run build` succeeds
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
