### PR TITLE
fix(registry): stop deleting whole registry branches on a failed key parse

### DIFF
--- a/src/main/ipc/registry-cleaner.ipc.ts
+++ b/src/main/ipc/registry-cleaner.ipc.ts
@@ -402,27 +402,37 @@ export async function scanRegistry(signal?: AbortSignal): Promise<RegistryEntry[
       const blocks = stdout.split(/\r?\n\r?\n/)
       for (const block of blocks) {
         const keyMatch = block.match(/^(HKCU\\[^\r\n]+\\OpenWithList)/m)
-        const appMatch = block.match(/REG_SZ\s+(.+\.exe)/i)
-        if (keyMatch && appMatch) {
-          const appName = appMatch[1].trim()
+        if (!keyMatch) continue
+        // OpenWithList stores the app in the value *data* under an ordinal value
+        // *name*: `a REG_SZ firefox.exe`. Deleting requires the name, so parse
+        // the two separately — matching REG_SZ alone yields "firefox.exe" and a
+        // `reg delete /v firefox.exe` that can only fail. Every value is checked
+        // rather than just the block's first, and MRUList is left alone since it
+        // is the ordering index, not an app reference.
+        for (const line of block.split(/\r?\n/)) {
+          const valueMatch = line.match(/^\s+(\S+)\s+REG_SZ\s+(.+?)\s*$/i)
+          if (!valueMatch) continue
+          const valueName = valueMatch[1].trim()
+          const appName = valueMatch[2].trim()
+          if (valueName.toLowerCase() === 'mrulist') continue
+          if (!appName.toLowerCase().endsWith('.exe')) continue
+          if (appName.includes('\\') || appName.includes('/')) continue
           try {
             await execReg([
               'query',
               `HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\${appName}`
             ], { timeout: 5000, signal })
           } catch {
-            if (!appName.includes('\\') && !appName.includes('/')) {
-              entries.push({
-                id: randomUUID(),
-                type: 'obsolete',
-                keyPath: keyMatch[1],
-                valueName: appName,
-                issue: `File association references unregistered app: ${appName}`,
-                risk: 'low',
-                selected: UNVALIDATED_SCAN_SELECTED,
-                fix: { op: 'delete-value' }
-              })
-            }
+            entries.push({
+              id: randomUUID(),
+              type: 'obsolete',
+              keyPath: keyMatch[1],
+              valueName,
+              issue: `File association references unregistered app: ${appName}`,
+              risk: 'low',
+              selected: UNVALIDATED_SCAN_SELECTED,
+              fix: { op: 'delete-value' }
+            })
           }
         }
       }
@@ -665,12 +675,17 @@ export async function scanRegistry(signal?: AbortSignal): Promise<RegistryEntry[
       let tlbCount = 0
       for (const block of blocks) {
         if (tlbCount >= 30) break
-        const keyMatch = block.match(/^(HKCR\\TypeLib\\(\{[^}]+\})[^\r\n]*)/m)
+        // Group 3 is everything below the GUID, e.g. `\2.0\0\win32`. A GUID node
+        // holds every registered version and architecture of the type library
+        // ({00000300-…} carries both 2.8 and 6.0 on a stock machine), so the
+        // stale platform key is deleted on its own — deleting the GUID parent
+        // because one win32 file is missing would take the surviving versions
+        // with it.
+        const keyMatch = block.match(/^(HKCR\\TypeLib\\(\{[^}]+\})(\\[^\r\n]+))/m)
         const valMatch = block.match(/\(Default\)\s+REG_SZ\s+(.+)/i)
         if (keyMatch && valMatch) {
           const tlbPath = valMatch[1].trim().replace(/"/g, '')
           if (tlbPath && tlbPath.includes('\\') && !tlbPath.startsWith('%') && !existsSync(tlbPath)) {
-            const parentTypeLibKey = `HKCR\\TypeLib\\${keyMatch[2]}`
             entries.push({
               id: randomUUID(),
               type: 'orphaned',
@@ -679,7 +694,7 @@ export async function scanRegistry(signal?: AbortSignal): Promise<RegistryEntry[
               issue: `Type library file missing: ${tlbPath}`,
               risk: 'low',
               selected: UNVALIDATED_SCAN_SELECTED,
-              fix: { op: 'delete-key', key: parentTypeLibKey }
+              fix: { op: 'delete-key' }
             })
             tlbCount++
           }

--- a/src/main/ipc/registry-cleaner.ipc.ts
+++ b/src/main/ipc/registry-cleaner.ipc.ts
@@ -16,9 +16,42 @@ import { execNativeUtf8, execTracked, psUtf8 } from '../services/exec-utf8'
 
 const execFileAsync = promisify(execFile)
 
+/** Long-form hive names as printed by reg.exe, mapped to the short form used throughout this file. */
+const HIVE_ALIASES: Record<string, string> = {
+  HKEY_LOCAL_MACHINE: 'HKLM',
+  HKEY_CURRENT_USER: 'HKCU',
+  HKEY_CLASSES_ROOT: 'HKCR',
+  HKEY_USERS: 'HKU',
+  HKEY_CURRENT_CONFIG: 'HKCC'
+}
+
+/**
+ * Rewrite the long-form hive names in reg.exe's key headers to their short form.
+ *
+ * `reg query HKLM\...` echoes its results as `HKEY_LOCAL_MACHINE\...`, but every
+ * scan below matches key headers against — and every fix below deletes — short
+ * forms like `HKLM\...`. Without this the header patterns never match, which
+ * silently disables most scans and, worse, makes the App Paths scan fall back to
+ * its container key (see the `keyPath` guard there).
+ *
+ * Only line-leading hive names are rewritten: value lines are indented by four
+ * spaces, so registry *data* containing a hive name is left untouched.
+ */
+export function normalizeHiveNames(stdout: string): string {
+  return stdout.replace(/^(HKEY_[A-Z_]+)/gm, (match) => HIVE_ALIASES[match] ?? match)
+}
+
+/** Convert a single key path's hive to short form (`HKEY_LOCAL_MACHINE\Foo` → `HKLM\Foo`). */
+function normalizeKeyPath(key: string): string {
+  const idx = key.indexOf('\\')
+  if (idx < 0) return HIVE_ALIASES[key] ?? key
+  return (HIVE_ALIASES[key.substring(0, idx)] ?? key.substring(0, idx)) + key.substring(idx)
+}
+
 /** Run reg.exe with UTF-8 code page so accented characters decode correctly */
 async function execReg(args: string[], opts?: { timeout?: number; signal?: AbortSignal }): Promise<{ stdout: string; stderr: string }> {
-  return execNativeUtf8('reg', args, opts)
+  const result = await execNativeUtf8('reg', args, opts)
+  return { ...result, stdout: normalizeHiveNames(result.stdout) }
 }
 
 // ── Active AbortControllers for cancellable operations ──
@@ -84,6 +117,19 @@ function splitTaskPath(fullPath: string): { path: string; name: string } | null 
 
 // Session-scoped scan results keyed by scan ID to prevent race conditions
 const scanSessions = new Map<string, Map<string, RegistryEntry>>()
+
+/**
+ * Pre-selection state for scans that were unreachable until hive-name
+ * normalization landed.
+ *
+ * Their key-header patterns only ever matched short-form hives (`HKCR\…`),
+ * which reg.exe never prints, so `keyMatch` was always null and every one of
+ * them was silently dead. Now that they parse, they are reported but left
+ * unticked: none has ever run against a real machine, and several delete whole
+ * COM registration keys. The user opts in per finding rather than having an
+ * unvalidated heuristic pre-selected for deletion.
+ */
+const UNVALIDATED_SCAN_SELECTED = false
 
 /** Expand common Windows environment variables in a registry path. */
 function expandEnvVars(path: string): string {
@@ -245,17 +291,21 @@ export async function scanRegistry(signal?: AbortSignal): Promise<RegistryEntry[
         '/s'
       ], { timeout: 15000, signal })
 
+      const appPathsRoot = 'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths'
       const blocks = stdout.split(/\r?\n\r?\n/)
       for (const block of blocks) {
         const keyMatch = block.match(/^(HKLM\\[^\r\n]+)/m)
         const valMatch = block.match(/\(Default\)\s+REG_SZ\s+(.+)/i)
-        if (valMatch) {
+        // Never fall back to the container key: the fix is delete-key, so a
+        // failed header parse would wipe every App Paths registration on the
+        // machine rather than the one stale entry.
+        if (valMatch && keyMatch && keyMatch[1].trim() !== appPathsRoot) {
           const exePath = valMatch[1].trim().replace(/"/g, '')
           if (exePath && !existsSync(exePath)) {
             entries.push({
               id: randomUUID(),
               type: 'invalid',
-              keyPath: keyMatch?.[1] || 'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths',
+              keyPath: keyMatch[1].trim(),
               valueName: '(Default)',
               issue: `App path points to missing file: ${exePath}`,
               risk: 'low',
@@ -369,7 +419,7 @@ export async function scanRegistry(signal?: AbortSignal): Promise<RegistryEntry[
                 valueName: appName,
                 issue: `File association references unregistered app: ${appName}`,
                 risk: 'low',
-                selected: true,
+                selected: UNVALIDATED_SCAN_SELECTED,
                 fix: { op: 'delete-value' }
               })
             }
@@ -501,11 +551,15 @@ export async function scanRegistry(signal?: AbortSignal): Promise<RegistryEntry[
           if (clsidMatch) {
             const clsid = clsidMatch[1]
             const keyMatch = block.match(/^(HK[^\r\n]+)/m)
+            const handlerKey = keyMatch?.[1]?.trim()
+            // As with App Paths: the fix is delete-key, so falling back to the
+            // ContextMenuHandlers container would remove every handler at once.
+            if (!handlerKey || handlerKey === shellKey) continue
             if (!await clsidExists(clsid, signal)) {
               entries.push({
                 id: randomUUID(),
                 type: 'orphaned',
-                keyPath: keyMatch?.[1]?.trim() || shellKey,
+                keyPath: handlerKey,
                 valueName: clsid,
                 issue: `Context menu handler references missing COM object: ${clsid}`,
                 risk: 'low',
@@ -518,7 +572,7 @@ export async function scanRegistry(signal?: AbortSignal): Promise<RegistryEntry[
                 entries.push({
                   id: randomUUID(),
                   type: 'broken',
-                  keyPath: keyMatch?.[1]?.trim() || shellKey,
+                  keyPath: handlerKey,
                   valueName: clsid,
                   issue: missingDll === 'no-inproc'
                     ? `Context menu handler has broken COM registration: ${clsid}`
@@ -590,7 +644,7 @@ export async function scanRegistry(signal?: AbortSignal): Promise<RegistryEntry[
               valueName: '(Default)',
               issue: `COM object DLL missing: ${dllPath}`,
               risk: 'medium',
-              selected: true,
+              selected: UNVALIDATED_SCAN_SELECTED,
               fix: { op: 'delete-key', key: parentClsidKey }
             })
             comCount++
@@ -624,7 +678,7 @@ export async function scanRegistry(signal?: AbortSignal): Promise<RegistryEntry[
               valueName: '(Default)',
               issue: `Type library file missing: ${tlbPath}`,
               risk: 'low',
-              selected: true,
+              selected: UNVALIDATED_SCAN_SELECTED,
               fix: { op: 'delete-key', key: parentTypeLibKey }
             })
             tlbCount++
@@ -884,7 +938,7 @@ export async function scanRegistry(signal?: AbortSignal): Promise<RegistryEntry[
               valueName: 'CLSID',
               issue: `MIME type "${mimeType}" references missing handler: ${clsid}`,
               risk: 'low',
-              selected: true,
+              selected: UNVALIDATED_SCAN_SELECTED,
               fix: { op: 'delete-value' }
             })
           }
@@ -920,7 +974,7 @@ export async function scanRegistry(signal?: AbortSignal): Promise<RegistryEntry[
                 valueName: 'ProgID',
                 issue: `AutoPlay handler "${handlerName}" references missing ProgID: ${progId}`,
                 risk: 'low',
-                selected: true,
+                selected: UNVALIDATED_SCAN_SELECTED,
                 fix: { op: 'delete-key' }
               })
             }
@@ -1022,7 +1076,7 @@ export async function scanRegistry(signal?: AbortSignal): Promise<RegistryEntry[
               valueName: clsid,
               issue: `Browser Helper Object references missing COM object: ${clsid}`,
               risk: 'low',
-              selected: true,
+              selected: UNVALIDATED_SCAN_SELECTED,
               fix: { op: 'delete-key' }
             })
           } else {
@@ -1037,7 +1091,7 @@ export async function scanRegistry(signal?: AbortSignal): Promise<RegistryEntry[
                   ? `Browser Helper Object has broken COM registration: ${clsid}`
                   : `Browser Helper Object DLL missing: ${missingDll}`,
                 risk: 'low',
-                selected: true,
+                selected: UNVALIDATED_SCAN_SELECTED,
                 fix: { op: 'delete-key' }
               })
             }
@@ -1105,7 +1159,7 @@ export async function scanRegistry(signal?: AbortSignal): Promise<RegistryEntry[
                   valueName: 'EventMessageFile',
                   issue: `Event log source "${sourceName}" — all message files missing`,
                   risk: 'low',
-                  selected: true,
+                  selected: UNVALIDATED_SCAN_SELECTED,
                   fix: { op: 'delete-key' }
                 })
               }
@@ -1146,7 +1200,7 @@ export async function scanRegistry(signal?: AbortSignal): Promise<RegistryEntry[
               valueName: proxyClsid,
               issue: `COM interface references missing proxy stub: ${proxyClsid}`,
               risk: 'medium',
-              selected: true,
+              selected: UNVALIDATED_SCAN_SELECTED,
               fix: { op: 'delete-key', key: parentIfaceKey }
             })
             ifaceCount++
@@ -1164,7 +1218,7 @@ export async function scanRegistry(signal?: AbortSignal): Promise<RegistryEntry[
                   ? `COM interface proxy stub has broken registration: ${proxyClsid}`
                   : `COM interface proxy stub DLL missing: ${missingDll}`,
                 risk: 'medium',
-                selected: true,
+                selected: UNVALIDATED_SCAN_SELECTED,
                 fix: { op: 'delete-key', key: parentIfaceKey }
               })
               ifaceCount++
@@ -1207,7 +1261,7 @@ export async function scanRegistry(signal?: AbortSignal): Promise<RegistryEntry[
               valueName: 'ProgId',
               issue: `Default app for "${ext}" references removed program: ${progId}`,
               risk: 'low',
-              selected: true,
+              selected: UNVALIDATED_SCAN_SELECTED,
               fix: { op: 'delete-key' }
             })
           }
@@ -1834,6 +1888,64 @@ async function createTargetedBackup(
   }
 }
 
+/**
+ * Container keys that `delete-key` must never target.
+ *
+ * Every scan above enumerates one of these and reports a finding about a *subkey*.
+ * If a fix ever resolves to the container itself, the scan failed to parse the
+ * subkey path — applying it would delete the entire branch instead of one stale
+ * entry. That is how a "clean up 3 leftover registry entries" click turns into a
+ * machine-wide outage, so it is refused at the point of execution regardless of
+ * how the entry was produced.
+ */
+const PROTECTED_DELETE_KEYS = new Set([
+  'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths',
+  'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\SharedDLLs',
+  'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run',
+  'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\RunOnce',
+  'HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run',
+  'HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\RunOnce',
+  'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall',
+  'HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall',
+  'HKLM\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall',
+  'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Installer\\Folders',
+  'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\AutoplayHandlers\\Handlers',
+  'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Browser Helper Objects',
+  'HKLM\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Browser Helper Objects',
+  'HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts',
+  'HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts',
+  'HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\Layers',
+  'HKCU\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\Layers',
+  'HKCU\\SOFTWARE\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\MuiCache',
+  'HKLM\\SYSTEM\\CurrentControlSet\\Services',
+  'HKLM\\SYSTEM\\CurrentControlSet\\Services\\EventLog\\Application',
+  'HKLM\\SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\FirewallRules',
+  'HKLM\\SOFTWARE\\Clients',
+  'HKLM\\SOFTWARE\\WOW6432Node\\Clients',
+  'HKCU\\SOFTWARE\\Clients',
+  'HKCR\\CLSID',
+  'HKCR\\WOW6432Node\\CLSID',
+  'HKCR\\TypeLib',
+  'HKCR\\Interface',
+  'HKCR\\MIME',
+  'HKCR\\MIME\\Database\\Content Type',
+  'HKCR\\*\\shellex\\ContextMenuHandlers',
+  'HKCR\\Directory\\shellex\\ContextMenuHandlers',
+  'HKCR\\Folder\\shellex\\ContextMenuHandlers'
+].map(k => k.toLowerCase()))
+
+/**
+ * True when `key` is a hive root or one of the container keys above, in either
+ * long or short hive form. Exported for tests.
+ */
+export function isProtectedDeleteKey(key: string): boolean {
+  const normalized = normalizeKeyPath(key.trim()).replace(/\\+$/, '')
+  if (!normalized) return true
+  // A hive with no subkey ("HKLM", "HKEY_LOCAL_MACHINE") is always the whole hive.
+  if (!normalized.includes('\\')) return true
+  return PROTECTED_DELETE_KEYS.has(normalized.toLowerCase())
+}
+
 export async function fixRegistryEntries(
   entries: RegistryEntry[],
   onProgress?: (current: number, total: number, label: string) => void,
@@ -1884,6 +1996,9 @@ export async function fixRegistryEntries(
             break
 
           case 'delete-key':
+            if (isProtectedDeleteKey(key)) {
+              throw new Error(`Refusing to delete protected registry key: ${key}`)
+            }
             await execReg(['delete', key, '/f'], { timeout: 10000, signal })
             break
 

--- a/src/main/ipc/registry-cleaner.scan.test.ts
+++ b/src/main/ipc/registry-cleaner.scan.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { promisify } from 'util'
+
+// ── Mocks ───────────────────────────────────────────────────────────
+// These tests drive the real scan/fix code against realistic reg.exe
+// output. The pure-helper tests in registry-cleaner.ipc.test.ts use
+// replicas, which cannot catch a mismatch between a scan's regex and
+// what reg.exe actually prints — the defect this file guards against.
+
+const mockExecNative = vi.fn()
+
+function createExecFileMock() {
+  const fn = (...args: unknown[]) => (args[args.length - 1] as any)?.(null, '', '')
+  ;(fn as any)[promisify.custom] = () => Promise.resolve({ stdout: '', stderr: '' })
+  return fn
+}
+
+vi.mock('child_process', () => ({ execFile: createExecFileMock() }))
+
+vi.mock('electron', () => ({ ipcMain: { handle: vi.fn() } }))
+
+vi.mock('../services/exec-utf8', () => ({
+  execNativeUtf8: (tool: string, args: string[], opts?: any) => mockExecNative(tool, args, opts),
+  execTracked: vi.fn(async () => ({ stdout: '', stderr: '' })),
+  psUtf8: (cmd: string) => cmd,
+}))
+
+const mockExistsSync = vi.fn((_p: string): boolean => true)
+
+vi.mock('fs', () => ({
+  existsSync: (p: string) => mockExistsSync(p),
+  statSync: () => ({ isFile: () => true }),
+  readdirSync: () => [],
+  unlinkSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  mkdtempSync: () => 'C:\\temp\\kudu-test',
+  readFileSync: () => '',
+  writeFileSync: vi.fn(),
+  rmSync: vi.fn(),
+}))
+
+vi.mock('../services/backup-dir', () => ({ getBackupDir: () => 'C:\\temp\\backups' }))
+
+vi.mock('../services/settings-store', () => ({
+  getSettings: () => ({}),
+  updateRegistryIgnoredTweaks: vi.fn(),
+}))
+
+vi.mock('../services/ipc-validation', () => ({ validateStringArray: (a: string[]) => a }))
+
+import {
+  scanRegistry,
+  fixRegistryEntries,
+  normalizeHiveNames,
+  isProtectedDeleteKey,
+} from './registry-cleaner.ipc'
+
+const APP_PATHS_ROOT = 'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths'
+
+/** Verbatim `reg query "HKLM\...\App Paths" /s` output — note the long hive names. */
+const APP_PATHS_OUTPUT = [
+  'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.exe',
+  '    (Default)    REG_SZ    C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+  '    Path    REG_SZ    C:\\Program Files\\Google\\Chrome\\Application',
+  '',
+  'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\ghost.exe',
+  '    (Default)    REG_SZ    C:\\Program Files\\Uninstalled\\ghost.exe',
+  '',
+].join('\r\n')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockExistsSync.mockImplementation(() => true)
+  mockExecNative.mockImplementation(async () => ({ stdout: '', stderr: '' }))
+})
+
+describe('normalizeHiveNames', () => {
+  it('rewrites long-form hive names in key headers to short form', () => {
+    expect(normalizeHiveNames('HKEY_LOCAL_MACHINE\\SOFTWARE\\Foo')).toBe('HKLM\\SOFTWARE\\Foo')
+    expect(normalizeHiveNames('HKEY_CURRENT_USER\\SOFTWARE\\Foo')).toBe('HKCU\\SOFTWARE\\Foo')
+    expect(normalizeHiveNames('HKEY_CLASSES_ROOT\\CLSID\\{abc}')).toBe('HKCR\\CLSID\\{abc}')
+  })
+
+  it('leaves indented value lines untouched', () => {
+    const input = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Foo\r\n    Data    REG_SZ    HKEY_LOCAL_MACHINE\\Bar\r\n'
+    expect(normalizeHiveNames(input)).toBe('HKLM\\SOFTWARE\\Foo\r\n    Data    REG_SZ    HKEY_LOCAL_MACHINE\\Bar\r\n')
+  })
+
+  it('leaves already-short and unknown hives alone', () => {
+    expect(normalizeHiveNames('HKLM\\SOFTWARE\\Foo')).toBe('HKLM\\SOFTWARE\\Foo')
+    expect(normalizeHiveNames('HKEY_MADE_UP\\Foo')).toBe('HKEY_MADE_UP\\Foo')
+  })
+})
+
+describe('scanRegistry — App Paths', () => {
+  function stubAppPaths(): void {
+    mockExecNative.mockImplementation(async (tool: string, args: string[]) => {
+      if (tool === 'reg' && args[0] === 'query' && args[1] === APP_PATHS_ROOT) {
+        return { stdout: APP_PATHS_OUTPUT, stderr: '' }
+      }
+      if (tool === 'schtasks') throw new Error('no tasks')
+      return { stdout: '', stderr: '' }
+    })
+    mockExistsSync.mockImplementation((p: string) => !String(p).includes('Uninstalled'))
+  }
+
+  it('targets the stale subkey, never the App Paths container', async () => {
+    stubAppPaths()
+    const entries = await scanRegistry()
+    const appPathFindings = entries.filter(e => e.issue.startsWith('App path points to missing file'))
+
+    expect(appPathFindings).toHaveLength(1)
+    expect(appPathFindings[0].keyPath).toBe(`${APP_PATHS_ROOT}\\ghost.exe`)
+    // The regression: a failed header parse used to fall back to the container,
+    // so applying the fix deleted every App Paths registration on the machine.
+    expect(appPathFindings[0].keyPath).not.toBe(APP_PATHS_ROOT)
+  })
+
+  it('does not flag app paths whose executable still exists', async () => {
+    stubAppPaths()
+    const entries = await scanRegistry()
+    expect(entries.some(e => e.issue.includes('chrome.exe'))).toBe(false)
+  })
+
+  it('emits nothing for App Paths when the key header cannot be parsed', async () => {
+    mockExecNative.mockImplementation(async (tool: string, args: string[]) => {
+      if (tool === 'reg' && args[0] === 'query' && args[1] === APP_PATHS_ROOT) {
+        // Header line missing entirely — the scan must not guess a key.
+        return { stdout: '    (Default)    REG_SZ    C:\\Gone\\gone.exe\r\n', stderr: '' }
+      }
+      if (tool === 'schtasks') throw new Error('no tasks')
+      return { stdout: '', stderr: '' }
+    })
+    mockExistsSync.mockImplementation(() => false)
+
+    const entries = await scanRegistry()
+    expect(entries.some(e => e.issue.startsWith('App path points to missing file'))).toBe(false)
+  })
+})
+
+describe('previously-dead scans ship unticked', () => {
+  const TYPELIB_OUTPUT = [
+    'HKEY_CLASSES_ROOT\\TypeLib\\{11111111-2222-3333-4444-555555555555}\\1.0\\0\\win32',
+    '    (Default)    REG_SZ    C:\\Program Files\\Gone\\gone.tlb',
+    '',
+  ].join('\r\n')
+
+  it('reports a revived finding but leaves it deselected', async () => {
+    mockExecNative.mockImplementation(async (tool: string, args: string[]) => {
+      if (tool === 'reg' && args[0] === 'query' && args[1] === 'HKCR\\TypeLib') {
+        return { stdout: TYPELIB_OUTPUT, stderr: '' }
+      }
+      if (tool === 'schtasks') throw new Error('no tasks')
+      return { stdout: '', stderr: '' }
+    })
+    mockExistsSync.mockImplementation((p: string) => !String(p).includes('Gone'))
+
+    const entries = await scanRegistry()
+    const tlb = entries.filter(e => e.issue.startsWith('Type library file missing'))
+
+    expect(tlb).toHaveLength(1)
+    // These scans never executed before hive normalization landed, so a finding
+    // must not arrive pre-ticked for deletion.
+    expect(tlb[0].selected).toBe(false)
+    expect(tlb[0].keyPath).toContain('{11111111-2222-3333-4444-555555555555}')
+  })
+})
+
+describe('isProtectedDeleteKey', () => {
+  it('blocks bare hive roots in both forms', () => {
+    for (const k of ['HKLM', 'HKCU', 'HKCR', 'HKEY_LOCAL_MACHINE', 'HKEY_CLASSES_ROOT']) {
+      expect(isProtectedDeleteKey(k)).toBe(true)
+    }
+  })
+
+  it('blocks the container keys the scans enumerate', () => {
+    for (const k of [
+      APP_PATHS_ROOT,
+      'HKLM\\SYSTEM\\CurrentControlSet\\Services',
+      'HKCR\\CLSID',
+      'HKCR\\Interface',
+      'HKCR\\TypeLib',
+      'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall',
+      'HKCR\\*\\shellex\\ContextMenuHandlers',
+    ]) {
+      expect(isProtectedDeleteKey(k)).toBe(true)
+    }
+  })
+
+  it('matches regardless of hive form, casing, or trailing slash', () => {
+    expect(isProtectedDeleteKey('HKEY_CLASSES_ROOT\\CLSID')).toBe(true)
+    expect(isProtectedDeleteKey('hkcr\\clsid')).toBe(true)
+    expect(isProtectedDeleteKey('HKCR\\CLSID\\')).toBe(true)
+  })
+
+  it('allows genuine leaf keys', () => {
+    expect(isProtectedDeleteKey(`${APP_PATHS_ROOT}\\ghost.exe`)).toBe(false)
+    expect(isProtectedDeleteKey('HKCR\\CLSID\\{abc-def}')).toBe(false)
+    expect(isProtectedDeleteKey('HKLM\\SYSTEM\\CurrentControlSet\\Services\\SomeApp')).toBe(false)
+  })
+})
+
+describe('fixRegistryEntries — protected key guard', () => {
+  const entry = (keyPath: string) => ({
+    id: 'e1',
+    type: 'invalid' as const,
+    keyPath,
+    valueName: '(Default)',
+    issue: 'test',
+    risk: 'low' as const,
+    selected: true,
+    fix: { op: 'delete-key' as const },
+  })
+
+  it('refuses to delete a container key and reports it as a failure', async () => {
+    const result = await fixRegistryEntries([entry(APP_PATHS_ROOT)] as any)
+
+    expect(result.fixed).toBe(0)
+    expect(result.failed).toBe(1)
+    expect(result.failures[0].reason).toContain('protected registry key')
+
+    const deletes = mockExecNative.mock.calls.filter(c => c[0] === 'reg' && c[1][0] === 'delete')
+    expect(deletes).toHaveLength(0)
+  })
+
+  it('still deletes a genuine leaf key', async () => {
+    const target = `${APP_PATHS_ROOT}\\ghost.exe`
+    const result = await fixRegistryEntries([entry(target)] as any)
+
+    expect(result.fixed).toBe(1)
+    const deletes = mockExecNative.mock.calls.filter(c => c[0] === 'reg' && c[1][0] === 'delete')
+    expect(deletes).toHaveLength(1)
+    expect(deletes[0][1]).toEqual(['delete', target, '/f'])
+  })
+})

--- a/src/main/ipc/registry-cleaner.scan.test.ts
+++ b/src/main/ipc/registry-cleaner.scan.test.ts
@@ -166,6 +166,103 @@ describe('previously-dead scans ship unticked', () => {
   })
 })
 
+describe('scanRegistry — TypeLib', () => {
+  // {00000300-…} carries both 2.8 and 6.0 on a stock Windows install.
+  const MULTI_VERSION_OUTPUT = [
+    'HKEY_CLASSES_ROOT\\TypeLib\\{00000300-0000-0010-8000-00AA006D2EA4}\\2.8\\0\\win32',
+    '    (Default)    REG_SZ    C:\\Program Files\\Gone\\old.tlb',
+    '',
+    'HKEY_CLASSES_ROOT\\TypeLib\\{00000300-0000-0010-8000-00AA006D2EA4}\\6.0\\0\\win32',
+    '    (Default)    REG_SZ    C:\\Windows\\System32\\current.tlb',
+    '',
+  ].join('\r\n')
+
+  it('deletes only the stale version key, never the GUID parent', async () => {
+    mockExecNative.mockImplementation(async (tool: string, args: string[]) => {
+      if (tool === 'reg' && args[0] === 'query' && args[1] === 'HKCR\\TypeLib') {
+        return { stdout: MULTI_VERSION_OUTPUT, stderr: '' }
+      }
+      if (tool === 'schtasks') throw new Error('no tasks')
+      return { stdout: '', stderr: '' }
+    })
+    mockExistsSync.mockImplementation((p: string) => !String(p).includes('Gone'))
+
+    const entries = await scanRegistry()
+    const tlb = entries.filter(e => e.issue.startsWith('Type library file missing'))
+
+    expect(tlb).toHaveLength(1)
+    const target = tlb[0].fix?.key ?? tlb[0].keyPath
+    // Deleting the GUID parent would take the healthy 6.0 registration with it.
+    expect(target).toBe('HKCR\\TypeLib\\{00000300-0000-0010-8000-00AA006D2EA4}\\2.8\\0\\win32')
+    expect(target).not.toBe('HKCR\\TypeLib\\{00000300-0000-0010-8000-00AA006D2EA4}')
+  })
+
+  it('ignores a GUID node with no version segment below it', async () => {
+    mockExecNative.mockImplementation(async (tool: string, args: string[]) => {
+      if (tool === 'reg' && args[0] === 'query' && args[1] === 'HKCR\\TypeLib') {
+        return {
+          stdout: 'HKEY_CLASSES_ROOT\\TypeLib\\{00000300-0000-0010-8000-00AA006D2EA4}\r\n    (Default)    REG_SZ    C:\\Gone\\x.tlb\r\n',
+          stderr: '',
+        }
+      }
+      if (tool === 'schtasks') throw new Error('no tasks')
+      return { stdout: '', stderr: '' }
+    })
+    mockExistsSync.mockImplementation(() => false)
+
+    const entries = await scanRegistry()
+    expect(entries.some(e => e.issue.startsWith('Type library file missing'))).toBe(false)
+  })
+})
+
+describe('scanRegistry — OpenWithList', () => {
+  // Verbatim layout: the app is the value *data*, under an ordinal value *name*.
+  const OPEN_WITH_OUTPUT = [
+    'HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts\\.txt\\OpenWithList',
+    '    a    REG_SZ    notepad.exe',
+    '    b    REG_SZ    ghost.exe',
+    '    MRUList    REG_SZ    ab',
+    '',
+  ].join('\r\n')
+
+  function stubOpenWith(): void {
+    mockExecNative.mockImplementation(async (tool: string, args: string[]) => {
+      if (tool === 'reg' && args[0] === 'query' && String(args[1]).endsWith('FileExts')) {
+        return { stdout: OPEN_WITH_OUTPUT, stderr: '' }
+      }
+      // notepad.exe is a registered App Path; ghost.exe is not.
+      if (tool === 'reg' && args[0] === 'query' && String(args[1]).includes('App Paths\\notepad.exe')) {
+        return { stdout: 'ok', stderr: '' }
+      }
+      if (tool === 'reg' && args[0] === 'query' && String(args[1]).includes('App Paths\\')) {
+        throw new Error('not found')
+      }
+      if (tool === 'schtasks') throw new Error('no tasks')
+      return { stdout: '', stderr: '' }
+    })
+  }
+
+  it('reports the ordinal value name, not the executable data', async () => {
+    stubOpenWith()
+    const entries = await scanRegistry()
+    const found = entries.filter(e => e.issue.startsWith('File association references unregistered app'))
+
+    expect(found).toHaveLength(1)
+    // `reg delete /v ghost.exe` would always fail — the value is named "b".
+    expect(found[0].valueName).toBe('b')
+    expect(found[0].issue).toContain('ghost.exe')
+  })
+
+  it('leaves registered apps and the MRUList index alone', async () => {
+    stubOpenWith()
+    const entries = await scanRegistry()
+    const found = entries.filter(e => e.issue.startsWith('File association references unregistered app'))
+
+    expect(found.some(e => e.valueName === 'a')).toBe(false)
+    expect(found.some(e => e.valueName.toLowerCase() === 'mrulist')).toBe(false)
+  })
+})
+
 describe('isProtectedDeleteKey', () => {
   it('blocks bare hive roots in both forms', () => {
     for (const k of ['HKLM', 'HKCU', 'HKCR', 'HKEY_LOCAL_MACHINE', 'HKEY_CLASSES_ROOT']) {


### PR DESCRIPTION
Fixes a Registry Cleaner bug that could delete an entire registry branch, found while investigating #244.

## The bug

`reg.exe` echoes results using long-form hive names (`HKEY_LOCAL_MACHINE\...`), but nine scans in `registry-cleaner.ipc.ts` matched key headers against the short form (`HKLM\...`). Those matches never succeeded — verified against real `reg query` output, where the App Paths header pattern failed on 4/4 blocks.

Eight of the nine scans guarded on the match (`if (keyMatch && ...)`) and were silently dead. **The App Paths scan did not.** It fell back to the container key:

```ts
keyPath: keyMatch?.[1] || 'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths',
fix: { op: 'delete-key' }
```

So a single App Paths entry pointing at an uninstalled program produced:

```
reg delete "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths" /f
```

…removing every App Paths registration on the machine instead of the one dead entry. The finding was pre-ticked and labelled `risk: 'low'`. Stale App Paths entries are common on any machine that has uninstalled software, so this was reachable in ordinary use.

The bug predates #68, so it has been present for a long time.

## Changes

- **Normalize hive names** in `execReg` output (`normalizeHiveNames`) so key headers parse. Only line-leading hive names are rewritten — value lines are indented four spaces, so registry *data* containing a hive name is untouched. This mirrors `normalizeKeyPath` already used in `context-menu-cleaner.ipc.ts`.
- **Remove the container-key fallbacks** in the App Paths and shellex ContextMenuHandlers scans. If a scan cannot identify the specific subkey it now reports nothing rather than guessing upward.
- **Add `isProtectedDeleteKey`** — `delete-key` hard-refuses hive roots and the container keys the scans enumerate, at execution time, regardless of how the entry was produced. Defence in depth so a future parsing regression cannot wipe a branch again. Refusals surface as a normal per-entry failure.
- **Ship the eight revived scans deselected** (`UNVALIDATED_SCAN_SELECTED`). They have never executed in production and several delete whole COM registration keys (`HKCR\CLSID\{…}`, `HKCR\Interface\{…}`), so they are opt-in per finding until validated on real machines.

## On that last point

Fixing the root cause activates eight scans that have never run. On this machine they now produce matches at scale — e.g. the COM Interface scan matches 28,630 blocks (capped at 30 findings). Landing those pre-ticked in a bugfix for a registry-corruption report would risk causing the next one, hence the deselect. Turning them on is a separate change that deserves its own validation.

## Testing

New `registry-cleaner.scan.test.ts` drives the **real** `scanRegistry` / `fixRegistryEntries` against verbatim `reg.exe` output:

- App Paths targets the stale subkey, never the container
- nothing is emitted when the key header cannot be parsed
- revived findings are reported but arrive deselected
- `isProtectedDeleteKey` blocks hive roots and containers in both hive forms, and allows genuine leaf keys
- `fixRegistryEntries` refuses a container-key delete and issues no `reg delete`, but still deletes a real leaf key

`npm test`: 2229 passing. No new type errors (`tsc` reports only pre-existing failures in unrelated files).

### Why this wasn't caught

`registry-cleaner.ipc.test.ts` replicates the helpers under test rather than importing them, so a regex that never matched real `reg.exe` output could not fail a test. The new file imports the real module instead. Other replica-based suites in the repo likely share this blind spot — worth a follow-up.

## Note on #244

This does **not** explain that reporter's `PresentationCore` error — that is a .NET Framework/GAC problem, and Kudu touches neither the GAC nor `C:\Windows\Microsoft.NET`. Said so plainly in the issue and pointed them at .NET repair plus their `Documents\Kudu Backups` `.reg` files. Fixing this bug is worthwhile on its own merits.

Refs #244
