### PR TITLE
test(cleaner): cover exclusions surviving a directory-level delete

### DIFF
--- a/src/main/services/file-utils.recency.test.ts
+++ b/src/main/services/file-utils.recency.test.ts
@@ -3,8 +3,10 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync, utimesSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
+const state = vi.hoisted(() => ({ exclusions: [] as string[] }))
+
 vi.mock('./settings-store', () => ({
-  getSettings: () => ({ cleaner: { secureDelete: false, skipRecentMinutes: 60 }, exclusions: [] }),
+  getSettings: () => ({ cleaner: { secureDelete: false, skipRecentMinutes: 60 }, exclusions: state.exclusions }),
 }))
 
 vi.mock('./scan-cache', () => ({ getCachedItems: () => [] }))
@@ -41,6 +43,7 @@ function paths(result: { items: Array<{ path: string }> }): string[] {
 
 beforeEach(() => {
   testDir = mkdtempSync(join(tmpdir(), 'kudu-recency-'))
+  state.exclusions = []
 })
 
 afterEach(() => {
@@ -132,5 +135,27 @@ describe('scanDirectory with deepRecencyCheck', () => {
     const result = await scanDirectory(testDir, 'browser', 'Test', DEEP)
     expect(result.items).toHaveLength(0)
     expect(result.itemCount).toBe(0)
+  })
+
+  // The top-level scan only ever tested the entries it listed, so a directory
+  // could be offered whole and then recursively deleted along with an excluded
+  // file buried inside it. Descending closes that off too.
+  it('never offers a directory holding an excluded descendant', async () => {
+    file('js/settled', 180, 100)
+    file('js/keep-me.txt', 180, 7)
+    state.exclusions = [join(testDir, 'js', 'keep-me.txt')]
+
+    const result = await scanDirectory(testDir, 'browser', 'Test', DEEP)
+    expect(paths(result)).toEqual([join(testDir, 'js', 'settled')])
+    expect(result.totalSize).toBe(100)
+  })
+
+  it('honours an *.ext exclusion below the top level', async () => {
+    file('js/settled', 180, 100)
+    file('js/nested/notes.log', 180, 7)
+    state.exclusions = ['*.log']
+
+    const result = await scanDirectory(testDir, 'browser', 'Test', DEEP)
+    expect(paths(result)).toEqual([join(testDir, 'js', 'settled')])
   })
 })


### PR DESCRIPTION
Follow-up to #266, which merged while I was writing these.

Reviewing the descending recency check afterwards turned up a second property it establishes, separate from the one the PR was about and worth pinning down.

The old top-level scan tested only the entries it listed, so `isExcluded` never saw anything below the first level. A directory could therefore be offered as a single item and then recursively deleted along with an excluded file buried inside it — the exclusion was honoured when choosing what to list, and then quietly bypassed by the `rm -r` that followed.

Descending closes that off as a side effect: an excluded descendant makes the subtree incomplete, so the directory is never collapsed and only its settled, non-excluded siblings are offered.

Two tests, one for a full-path exclusion and one for an `*.ext` glob below the top level. Both fail against the pre-#266 behaviour and pass now — this is coverage for something already fixed, not a new change.

Tests only, no production code touched. 2352 passing.