### PR TITLE
fix(malware): bind quarantine/delete to a real detection, gate remote quarantine

### DIFF
--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -994,6 +994,9 @@ function hashFileSha256(filePath: string): Promise<string> {
 
 const DETECTION_TTL_MS = 24 * 60 * 60 * 1000
 
+/** Bound on retained detections, so a long-lived daemon can't grow the ledger without limit. */
+const MAX_DETECTION_RECORDS = 10_000
+
 interface DetectionRecord {
   /** null when the file was unreadable at scan time — falls back to a path-only binding. */
   sha256: string | null
@@ -1003,13 +1006,41 @@ interface DetectionRecord {
 const detectionLedger = new Map<string, DetectionRecord>()
 
 function ledgerKey(filePath: string): string {
-  return normalize(resolve(filePath)).toLowerCase()
+  const normalized = normalize(resolve(filePath))
+  // Only fold case where the filesystem does. On a case-sensitive volume
+  // `Foo.exe` and `foo.exe` are different files, and folding would let a
+  // path-only record (one whose file was unreadable at scan time, so there is
+  // no hash to catch the substitution) authorize action on the wrong one.
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized
 }
 
-/** Replace the ledger with the results of a completed scan. */
-async function recordDetections(threats: MalwareThreat[]): Promise<void> {
+function pruneDetections(now: number): void {
+  for (const [key, record] of detectionLedger) {
+    if (now - record.detectedAt > DETECTION_TTL_MS) detectionLedger.delete(key)
+  }
+  // Map preserves insertion order, and every write re-inserts at the end, so
+  // the front of the iteration is the oldest.
+  let overflow = detectionLedger.size - MAX_DETECTION_RECORDS
+  if (overflow <= 0) return
+  for (const key of detectionLedger.keys()) {
+    detectionLedger.delete(key)
+    if (--overflow <= 0) break
+  }
+}
+
+/**
+ * Fold a completed scan's results into the ledger.
+ *
+ * Merged rather than replaced: both the renderer and the cloud agent call
+ * scanMalware in this process, so a background scan finishing must not revoke
+ * authorization for results a user is still looking at. Entries age out on the
+ * TTL instead.
+ */
+async function recordDetections(threats: MalwareThreat[], suppressedPaths: string[] = []): Promise<void> {
   const now = Date.now()
-  detectionLedger.clear()
+  // A detection the user has since marked "not a virus" loses its
+  // authorization immediately rather than lingering out its TTL.
+  for (const path of suppressedPaths) detectionLedger.delete(ledgerKey(path))
   for (const threat of threats) {
     let sha256: string | null = null
     try {
@@ -1018,8 +1049,16 @@ async function recordDetections(threats: MalwareThreat[]): Promise<void> {
       // Locked or already gone — still worth authorizing by path so the user
       // can act on it, just without the tamper check.
     }
-    detectionLedger.set(ledgerKey(threat.path), { sha256, detectedAt: now })
+    const key = ledgerKey(threat.path)
+    detectionLedger.delete(key) // re-insert so the eviction order stays newest-last
+    detectionLedger.set(key, { sha256, detectedAt: now })
   }
+  pruneDetections(now)
+}
+
+/** Revoke a detection's authorization — used when the user marks a file safe. */
+function revokeDetection(filePath: string): void {
+  detectionLedger.delete(ledgerKey(filePath))
 }
 
 /**
@@ -1089,11 +1128,13 @@ export function resetDetectionLedger(): void {
  * swallowed so an unreadable path never aborts a scan. Returns the surviving
  * threats plus the count suppressed, so the caller can report it (no silent caps).
  */
-async function filterAllowlistedThreats(threats: MalwareThreat[]): Promise<{ kept: MalwareThreat[]; suppressed: number }> {
+async function filterAllowlistedThreats(
+  threats: MalwareThreat[]
+): Promise<{ kept: MalwareThreat[]; suppressedPaths: string[] }> {
   const allowed = new Set(getMalwareAllowlist().map((e) => e.sha256))
-  if (allowed.size === 0) return { kept: threats, suppressed: 0 }
+  if (allowed.size === 0) return { kept: threats, suppressedPaths: [] }
   const kept: MalwareThreat[] = []
-  let suppressed = 0
+  const suppressedPaths: string[] = []
   for (const threat of threats) {
     let isFile = false
     try {
@@ -1104,7 +1145,7 @@ async function filterAllowlistedThreats(threats: MalwareThreat[]): Promise<{ kep
     if (isFile) {
       try {
         if (allowed.has(await hashFileSha256(threat.path))) {
-          suppressed++
+          suppressedPaths.push(threat.path)
           continue
         }
       } catch {
@@ -1113,7 +1154,7 @@ async function filterAllowlistedThreats(threats: MalwareThreat[]): Promise<{ kep
     }
     kept.push(threat)
   }
-  return { kept, suppressed }
+  return { kept, suppressedPaths }
 }
 
 // Only scan files with these extensions for performance
@@ -1738,14 +1779,16 @@ export async function scanMalware(
 
     // Suppress detections the user has marked as false positives (matched by
     // file content hash) before reporting results.
-    const { kept: visibleThreats, suppressed } = await filterAllowlistedThreats(threats)
+    const { kept: visibleThreats, suppressedPaths } = await filterAllowlistedThreats(threats)
+    const suppressed = suppressedPaths.length
     if (suppressed > 0) {
       completedSteps.push(`Ignored ${suppressed} detection${suppressed !== 1 ? 's' : ''} you previously marked safe`)
     }
 
-    // Authorize quarantine/delete for exactly what this scan reported — nothing
-    // else can be acted on until a later scan flags it.
-    await recordDetections(visibleThreats)
+    // Authorize quarantine/delete for what this scan reported. Detections from
+    // earlier scans stay valid until their TTL — another scan finishing must not
+    // revoke results a user is still acting on.
+    await recordDetections(visibleThreats, suppressedPaths)
 
     completedSteps.push(`Scan complete — ${visibleThreats.length} total threat${visibleThreats.length !== 1 ? 's' : ''} detected`)
     sendProgress({
@@ -1841,12 +1884,15 @@ export async function deleteMalware(paths: string[], opts: DeleteMalwareOptions 
     for (const filePath of validPaths) {
       try {
         if (mode === 'recycle') {
-          // trashItem throws if the file is gone; treat that as already done to
-          // match the idempotence rm(force) gave us.
+          // trashItem throws if the file is gone; treat *only* that as already
+          // done, to match the idempotence rm(force) gave us. A permission or
+          // I/O error must not be mistaken for a missing file — that would
+          // report success and drop the manifest entry while the file remains.
           let exists = true
           try {
             await stat(filePath)
-          } catch {
+          } catch (statErr: any) {
+            if (statErr?.code !== 'ENOENT') throw statErr
             exists = false
           }
           // No fallback to an unlink here — on a host without a working trash
@@ -1962,6 +2008,9 @@ export async function ignoreMalware(path: string, meta?: QuarantineMeta): Promis
         addedAt: Date.now()
       }
       await addMalwareAllowlistEntry(entry)
+      // Marking it safe revokes the pending authorization too, rather than
+      // leaving a stale one to age out over the TTL.
+      revokeDetection(path)
       return entry
     } catch {
       return null

--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -1,4 +1,4 @@
-import { ipcMain, app, BrowserWindow } from 'electron'
+import { ipcMain, app, BrowserWindow, shell } from 'electron'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { readFile, readdir, writeFile, stat, mkdir, rename, rm } from 'fs/promises'
@@ -983,6 +983,105 @@ function hashFileSha256(filePath: string): Promise<string> {
   })
 }
 
+// ─── Detection ledger ────────────────────────────────────────
+// Quarantine and delete only act on files a scan in this process actually
+// flagged.  Being inside a scan directory is not authorization on its own —
+// those roots span Documents, Desktop, Downloads and both AppData trees, so a
+// caller that reaches the IPC channel or the cloud command bus could otherwise
+// name any user file and have it destroyed.  Each detection is recorded with
+// the content hash seen at scan time, so swapping the file afterwards revokes
+// the authorization instead of redirecting it.
+
+const DETECTION_TTL_MS = 24 * 60 * 60 * 1000
+
+interface DetectionRecord {
+  /** null when the file was unreadable at scan time — falls back to a path-only binding. */
+  sha256: string | null
+  detectedAt: number
+}
+
+const detectionLedger = new Map<string, DetectionRecord>()
+
+function ledgerKey(filePath: string): string {
+  return normalize(resolve(filePath)).toLowerCase()
+}
+
+/** Replace the ledger with the results of a completed scan. */
+async function recordDetections(threats: MalwareThreat[]): Promise<void> {
+  const now = Date.now()
+  detectionLedger.clear()
+  for (const threat of threats) {
+    let sha256: string | null = null
+    try {
+      sha256 = await hashFileSha256(threat.path)
+    } catch {
+      // Locked or already gone — still worth authorizing by path so the user
+      // can act on it, just without the tamper check.
+    }
+    detectionLedger.set(ledgerKey(threat.path), { sha256, detectedAt: now })
+  }
+}
+
+/**
+ * Confirm a path was flagged by a recent scan and still holds the same bytes.
+ * Returns null when authorized, otherwise the reason it was refused.
+ */
+async function checkDetected(filePath: string): Promise<string | null> {
+  const record = detectionLedger.get(ledgerKey(filePath))
+  if (!record) return 'Not flagged by a malware scan — run a scan first'
+  if (Date.now() - record.detectedAt > DETECTION_TTL_MS) {
+    return 'Detection has expired — run a new malware scan'
+  }
+  if (record.sha256) {
+    let current: string
+    try {
+      current = await hashFileSha256(filePath)
+    } catch {
+      return 'File could not be read to verify it is unchanged'
+    }
+    if (current !== record.sha256) return 'File changed since it was detected — run a new malware scan'
+  }
+  return null
+}
+
+/**
+ * Screen requested paths against the scan roots and the detection ledger.
+ * Refusals are returned as errors rather than dropped, so the caller's
+ * succeeded/failed counts account for every path it asked about.
+ */
+async function authorizeMalwareAction(
+  paths: string[],
+  allowedDirs: string[],
+  opts: { exemptDirs?: string[] } = {}
+): Promise<{ authorized: string[]; refused: MalwareActionResult['errors'] }> {
+  const authorized: string[] = []
+  const refused: MalwareActionResult['errors'] = []
+  if (!Array.isArray(paths)) return { authorized, refused }
+
+  for (const filePath of paths) {
+    if (typeof filePath !== 'string') continue
+    if (!isPathInAllowedDirs(filePath, allowedDirs)) {
+      refused.push({ path: String(filePath), reason: 'Path is outside the allowed scan directories' })
+      continue
+    }
+    // Files already isolated in quarantine skip the ledger — they were bound to
+    // a detection on the way in, and emptying the vault must keep working.
+    if (opts.exemptDirs?.length && isPathInAllowedDirs(filePath, opts.exemptDirs)) {
+      authorized.push(filePath)
+      continue
+    }
+    const reason = await checkDetected(filePath)
+    if (reason) refused.push({ path: filePath, reason })
+    else authorized.push(filePath)
+  }
+  return { authorized, refused }
+}
+
+/** Test seam — drops all recorded detections. */
+export function resetDetectionLedger(): void {
+  detectionLedger.clear()
+}
+
 /**
  * Drop any detection whose file content hash is on the user's false-positive
  * allowlist. Only real files are hashed (non-file detections — registry, hosts —
@@ -1644,6 +1743,10 @@ export async function scanMalware(
       completedSteps.push(`Ignored ${suppressed} detection${suppressed !== 1 ? 's' : ''} you previously marked safe`)
     }
 
+    // Authorize quarantine/delete for exactly what this scan reported — nothing
+    // else can be acted on until a later scan flags it.
+    await recordDetections(visibleThreats)
+
     completedSteps.push(`Scan complete — ${visibleThreats.length} total threat${visibleThreats.length !== 1 ? 's' : ''} detected`)
     sendProgress({
       step: 'complete',
@@ -1664,9 +1767,7 @@ export async function scanMalware(
 
 export async function quarantineMalware(paths: string[], meta?: QuarantineMeta[]): Promise<MalwareActionResult> {
     const allowedDirs = getScanPaths()
-    const validPaths = Array.isArray(paths)
-      ? paths.filter((v): v is string => typeof v === 'string' && isPathInAllowedDirs(v, allowedDirs))
-      : []
+    const { authorized: validPaths, refused } = await authorizeMalwareAction(paths, allowedDirs)
 
     // Index detection metadata by path so each quarantined file records why it was flagged.
     const metaByPath = new Map<string, QuarantineMeta>()
@@ -1683,8 +1784,8 @@ export async function quarantineMalware(paths: string[], meta?: QuarantineMeta[]
 
     const manifest = await readManifest()
     let succeeded = 0
-    let failed = 0
-    const errors: MalwareActionResult['errors'] = []
+    let failed = refused.length
+    const errors: MalwareActionResult['errors'] = [...refused]
 
     for (const filePath of validPaths) {
       try {
@@ -1713,22 +1814,48 @@ export async function quarantineMalware(paths: string[], meta?: QuarantineMeta[]
     return { succeeded, failed, errors }
 }
 
-export async function deleteMalware(paths: string[]): Promise<MalwareActionResult> {
+export interface DeleteMalwareOptions {
+  /**
+   * 'permanent' unlinks the file; 'recycle' sends it to the recycle bin/trash
+   * so a mistaken or hostile delete stays recoverable.  Remote callers use
+   * 'recycle' — the operator confirming in the dashboard is not something this
+   * process can verify, so the destruction has to be undoable on the device.
+   */
+  mode?: 'permanent' | 'recycle'
+}
+
+export async function deleteMalware(paths: string[], opts: DeleteMalwareOptions = {}): Promise<MalwareActionResult> {
+    const mode = opts.mode === 'recycle' ? 'recycle' : 'permanent'
     const quarantineDir = getQuarantinePath()
     const allowedDirs = [...getScanPaths(), quarantineDir]
-    const validPaths = Array.isArray(paths)
-      ? paths.filter((v): v is string => typeof v === 'string' && isPathInAllowedDirs(v, allowedDirs))
-      : []
+    const { authorized: validPaths, refused } = await authorizeMalwareAction(paths, allowedDirs, {
+      exemptDirs: [quarantineDir]
+    })
 
     const manifest = await readManifest()
     let manifestDirty = false
     let succeeded = 0
-    let failed = 0
-    const errors: MalwareActionResult['errors'] = []
+    let failed = refused.length
+    const errors: MalwareActionResult['errors'] = [...refused]
 
     for (const filePath of validPaths) {
       try {
-        await rm(filePath, { force: true })
+        if (mode === 'recycle') {
+          // trashItem throws if the file is gone; treat that as already done to
+          // match the idempotence rm(force) gave us.
+          let exists = true
+          try {
+            await stat(filePath)
+          } catch {
+            exists = false
+          }
+          // No fallback to an unlink here — on a host without a working trash
+          // (headless Linux) the delete fails closed rather than quietly
+          // becoming permanent. Quarantine still works everywhere.
+          if (exists) await shell.trashItem(filePath)
+        } else {
+          await rm(filePath, { force: true })
+        }
         // Clean up manifest if deleting from quarantine
         const name = basename(filePath)
         if (manifest[name]) {
@@ -1738,7 +1865,10 @@ export async function deleteMalware(paths: string[]): Promise<MalwareActionResul
         succeeded++
       } catch (err: any) {
         failed++
-        errors.push({ path: filePath, reason: err.message || 'Failed to delete' })
+        const reason = mode === 'recycle'
+          ? err.message || 'Failed to move to the recycle bin — quarantine the file instead'
+          : err.message || 'Failed to delete'
+        errors.push({ path: filePath, reason })
       }
     }
 

--- a/src/main/ipc/malware-scanner.test.ts
+++ b/src/main/ipc/malware-scanner.test.ts
@@ -389,6 +389,7 @@ describe('canAllowlistThreat', () => {
 // channel or the cloud command bus name an arbitrary user file.
 
 const DETECTION_TTL_MS = 24 * 60 * 60 * 1000
+const MAX_DETECTION_RECORDS = 10_000
 
 interface LedgerRecord {
   sha256: string | null
@@ -518,5 +519,144 @@ describe('malware action screening', () => {
     const r = screen([null, 42, 'C:/Users/v/Downloads/malware.exe'], { inAllowedDirs: always, detected: flagged })
     expect(r.authorized).toHaveLength(1)
     expect(r.refused).toEqual([])
+  })
+})
+
+// ─── Ledger key case folding (replica of ledgerKey) ──────────────
+// Only fold case where the filesystem does. On a case-sensitive volume
+// `Foo.exe` and `foo.exe` are different files, and folding would let a
+// path-only record — one whose file was unreadable at scan time, so there is
+// no hash to catch the substitution — authorize action on the wrong one.
+
+function ledgerKey(normalizedPath: string, platform: string): string {
+  return platform === 'win32' ? normalizedPath.toLowerCase() : normalizedPath
+}
+
+describe('ledger key case folding', () => {
+  it('folds case on Windows, where the filesystem does', () => {
+    expect(ledgerKey('C:\\Users\\v\\Downloads\\Foo.exe', 'win32'))
+      .toBe(ledgerKey('C:\\Users\\v\\downloads\\foo.exe', 'win32'))
+  })
+
+  it('keeps distinct case-variant paths distinct on Linux', () => {
+    expect(ledgerKey('/home/v/Downloads/Foo.exe', 'linux'))
+      .not.toBe(ledgerKey('/home/v/Downloads/foo.exe', 'linux'))
+  })
+
+  it('keeps distinct case-variant paths distinct on macOS', () => {
+    expect(ledgerKey('/Users/v/Downloads/Foo.exe', 'darwin'))
+      .not.toBe(ledgerKey('/Users/v/Downloads/foo.exe', 'darwin'))
+  })
+
+  it('does not let a case variant inherit a path-only authorization', () => {
+    // The dangerous combination: sha256 null (unreadable at scan time) means
+    // there is no content check to fall back on, so the key must not alias.
+    const ledger = new Map<string, LedgerRecord>()
+    ledger.set(ledgerKey('/home/v/Downloads/Foo.exe', 'linux'), { sha256: null, detectedAt: 0 })
+    expect(ledger.get(ledgerKey('/home/v/Downloads/foo.exe', 'linux'))).toBeUndefined()
+  })
+})
+
+// ─── Ledger merge semantics (replica of recordDetections) ────────
+// Both the renderer and the cloud agent call scanMalware in this process, so a
+// background scan completing must not revoke authorization for results a user
+// is still looking at. Entries age out on the TTL instead of being cleared.
+
+function recordDetections(
+  ledger: Map<string, LedgerRecord>,
+  detected: { path: string; sha256: string | null }[],
+  now: number,
+  suppressedPaths: string[] = []
+): Map<string, LedgerRecord> {
+  for (const path of suppressedPaths) ledger.delete(path)
+  for (const d of detected) {
+    ledger.delete(d.path)
+    ledger.set(d.path, { sha256: d.sha256, detectedAt: now })
+  }
+  for (const [key, record] of ledger) {
+    if (now - record.detectedAt > DETECTION_TTL_MS) ledger.delete(key)
+  }
+  let overflow = ledger.size - MAX_DETECTION_RECORDS
+  if (overflow > 0) {
+    for (const key of ledger.keys()) {
+      ledger.delete(key)
+      if (--overflow <= 0) break
+    }
+  }
+  return ledger
+}
+
+describe('detection ledger merge', () => {
+  const now = 1_000_000_000_000
+
+  it('keeps an earlier scan\u2019s detection when a later scan finds nothing', () => {
+    const ledger = recordDetections(new Map(), [{ path: '/a/local.exe', sha256: 'h1' }], now)
+    recordDetections(ledger, [], now + 1000)
+    expect(ledger.get('/a/local.exe')).toBeDefined()
+  })
+
+  it('keeps detections from two overlapping scans', () => {
+    const ledger = recordDetections(new Map(), [{ path: '/a/one.exe', sha256: 'h1' }], now)
+    recordDetections(ledger, [{ path: '/a/two.exe', sha256: 'h2' }], now + 1000)
+    expect([...ledger.keys()].sort()).toEqual(['/a/one.exe', '/a/two.exe'])
+  })
+
+  it('refreshes the timestamp when a later scan re-flags the same file', () => {
+    const ledger = recordDetections(new Map(), [{ path: '/a/one.exe', sha256: 'h1' }], now)
+    recordDetections(ledger, [{ path: '/a/one.exe', sha256: 'h2' }], now + 1000)
+    expect(ledger.get('/a/one.exe')).toEqual({ sha256: 'h2', detectedAt: now + 1000 })
+  })
+
+  it('drops entries past the TTL as later scans come in', () => {
+    const ledger = recordDetections(new Map(), [{ path: '/a/old.exe', sha256: 'h1' }], now)
+    recordDetections(ledger, [{ path: '/a/new.exe', sha256: 'h2' }], now + DETECTION_TTL_MS + 1)
+    expect(ledger.has('/a/old.exe')).toBe(false)
+    expect(ledger.has('/a/new.exe')).toBe(true)
+  })
+
+  it('revokes a detection the user has since marked safe', () => {
+    const ledger = recordDetections(new Map(), [{ path: '/a/false-positive.exe', sha256: 'h1' }], now)
+    recordDetections(ledger, [], now + 1000, ['/a/false-positive.exe'])
+    expect(ledger.has('/a/false-positive.exe')).toBe(false)
+  })
+
+  it('evicts oldest-first once the retention cap is reached', () => {
+    const ledger = new Map<string, LedgerRecord>()
+    for (let i = 0; i < MAX_DETECTION_RECORDS; i++) {
+      recordDetections(ledger, [{ path: `/a/f${i}.exe`, sha256: 'h' }], now + i)
+    }
+    expect(ledger.size).toBe(MAX_DETECTION_RECORDS)
+    recordDetections(ledger, [{ path: '/a/newest.exe', sha256: 'h' }], now + MAX_DETECTION_RECORDS)
+    expect(ledger.size).toBe(MAX_DETECTION_RECORDS)
+    expect(ledger.has('/a/f0.exe')).toBe(false)
+    expect(ledger.has('/a/newest.exe')).toBe(true)
+  })
+})
+
+// ─── Recycle-mode existence check (replica) ──────────────────────
+// Only ENOENT means "already gone". Treating any stat failure as missing
+// reports success and drops the manifest entry while the file is still there.
+
+function shouldTreatAsAlreadyDeleted(statErrCode: string | null): boolean {
+  if (statErrCode === null) return false
+  if (statErrCode !== 'ENOENT') throw Object.assign(new Error(statErrCode), { code: statErrCode })
+  return true
+}
+
+describe('recycle-mode existence check', () => {
+  it('treats a missing file as already deleted', () => {
+    expect(shouldTreatAsAlreadyDeleted('ENOENT')).toBe(true)
+  })
+
+  it('proceeds to trash a file that stats cleanly', () => {
+    expect(shouldTreatAsAlreadyDeleted(null)).toBe(false)
+  })
+
+  it('fails a permission error rather than reporting a phantom success', () => {
+    expect(() => shouldTreatAsAlreadyDeleted('EACCES')).toThrow('EACCES')
+  })
+
+  it('fails an I/O error rather than reporting a phantom success', () => {
+    expect(() => shouldTreatAsAlreadyDeleted('EIO')).toThrow('EIO')
   })
 })

--- a/src/main/ipc/malware-scanner.test.ts
+++ b/src/main/ipc/malware-scanner.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect } from 'vitest'
+﻿import { describe, it, expect } from 'vitest'
 
-// ─── Test the exported-by-value constants and pure functions ─────
+// â”€â”€â”€ Test the exported-by-value constants and pure functions â”€â”€â”€â”€â”€
 // The malware-scanner.ipc.ts file doesn't export its helpers directly,
 // so we replicate the pure logic here to test correctness of the algorithms.
 // This avoids importing the Electron-dependent module while still ensuring
 // the core detection logic is correct.
 
-// ─── calculateEntropy (replica) ──────────────────────────────────
+// â”€â”€â”€ calculateEntropy (replica) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 function calculateEntropy(buffer: Buffer): number {
   if (buffer.length === 0) return 0
@@ -51,7 +51,7 @@ describe('calculateEntropy', () => {
   })
 })
 
-// ─── hasDoubleExtension (replica) ────────────────────────────────
+// â”€â”€â”€ hasDoubleExtension (replica) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 function hasDoubleExtension(fileName: string): boolean {
   const execExtensions = new Set(['.exe', '.scr', '.bat', '.cmd', '.com', '.pif', '.vbs', '.wsh', '.wsf', '.ps1'])
@@ -109,7 +109,7 @@ describe('hasDoubleExtension', () => {
   })
 })
 
-// ─── isPEFile (replica) ──────────────────────────────────────────
+// â”€â”€â”€ isPEFile (replica) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 function isPEFile(buffer: Buffer): boolean {
   if (buffer.length < 64) return false
@@ -144,7 +144,7 @@ describe('isPEFile', () => {
   })
 })
 
-// ─── findSuspiciousStrings (replica) ─────────────────────────────
+// â”€â”€â”€ findSuspiciousStrings (replica) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 const SUSPICIOUS_IMPORTS = [
   'CreateRemoteThread', 'VirtualAllocEx', 'WriteProcessMemory',
@@ -186,7 +186,7 @@ describe('findSuspiciousStrings', () => {
   })
 })
 
-// ─── SUSPICIOUS_FILENAMES outside system dirs ────────────────────
+// â”€â”€â”€ SUSPICIOUS_FILENAMES outside system dirs â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 const SUSPICIOUS_FILENAMES: { pattern: RegExp; name: string }[] = [
   { pattern: /^svchost\.exe$/i, name: 'Suspicious.FakeSvchost' },
@@ -218,7 +218,7 @@ describe('suspicious filename detection', () => {
   })
 })
 
-// ─── TRUSTED_PATHS check ─────────────────────────────────────────
+// â”€â”€â”€ TRUSTED_PATHS check â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 const TRUSTED_PATHS = [
   'zoom', 'microsoft', 'google', 'mozilla', 'adobe', 'oracle',
@@ -246,7 +246,7 @@ describe('trusted path detection', () => {
   })
 })
 
-// ─── PE heuristic scoring (replica of malware-scanner.ipc.ts) ────────
+// â”€â”€â”€ PE heuristic scoring (replica of malware-scanner.ipc.ts) â”€â”€â”€â”€â”€â”€â”€â”€
 // Mirrors the decision that raises Heuristic.Suspicious.PE so we can guard
 // against the over-aggressive scoring that flagged legit packed binaries (#156).
 
@@ -281,7 +281,7 @@ describe('PE heuristic scoring', () => {
   })
 
   it('does not let high section + high file entropy double-count into a flag on their own', () => {
-    // Both entropy signals fire but nothing else — must not reach the threshold
+    // Both entropy signals fire but nothing else â€” must not reach the threshold
     expect(isPESuspicious({
       isPacked: true,
       hasWritableExecutable: false,
@@ -318,14 +318,14 @@ describe('PE heuristic scoring', () => {
   })
 })
 
-// ─── Allowlist suppression decision (replica) ────────────────────
+// â”€â”€â”€ Allowlist suppression decision (replica) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 // Mirrors filterAllowlistedThreats: a detection is suppressed only when it is
 // a real file whose content hash is on the allowlist. Non-files and unreadable
 // files are kept (never silently dropped).
 
 function isSuppressed(opts: { isFile: boolean; hash: string | null; allowed: Set<string> }): boolean {
   if (!opts.isFile) return false       // registry/hosts targets can't be allowlisted
-  if (opts.hash === null) return false // unreadable file — keep the detection
+  if (opts.hash === null) return false // unreadable file â€” keep the detection
   return opts.allowed.has(opts.hash)
 }
 
@@ -353,7 +353,7 @@ describe('allowlist suppression decision', () => {
   })
 })
 
-// ─── canAllowlistThreat (replica of MalwareScannerPage) ──────────
+// â”€â”€â”€ canAllowlistThreat (replica of MalwareScannerPage) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 // The "Not a virus" action only appears for real-filesystem-path detections.
 
 function canAllowlistThreat(threat: { path: string }): boolean {
@@ -379,5 +379,144 @@ describe('canAllowlistThreat', () => {
 
   it('rejects a scheduled-task path (single leading backslash, not UNC)', () => {
     expect(canAllowlistThreat({ path: '\\Microsoft\\Windows\\SuspiciousTask' })).toBe(false)
+  })
+})
+
+// ─── Detection ledger authorization (replica) ────────────────────
+// Quarantine and delete must only touch files a recent scan flagged. Being
+// inside a scan root is not enough — those roots cover Documents, Desktop,
+// Downloads and AppData, so a path-only check lets any caller on the IPC
+// channel or the cloud command bus name an arbitrary user file.
+
+const DETECTION_TTL_MS = 24 * 60 * 60 * 1000
+
+interface LedgerRecord {
+  sha256: string | null
+  detectedAt: number
+}
+
+function checkDetected(
+  record: LedgerRecord | undefined,
+  now: number,
+  currentHash: string | null
+): string | null {
+  if (!record) return 'Not flagged by a malware scan — run a scan first'
+  if (now - record.detectedAt > DETECTION_TTL_MS) return 'Detection has expired — run a new malware scan'
+  if (record.sha256) {
+    if (currentHash === null) return 'File could not be read to verify it is unchanged'
+    if (currentHash !== record.sha256) return 'File changed since it was detected — run a new malware scan'
+  }
+  return null
+}
+
+describe('detection ledger authorization', () => {
+  const now = 1_000_000_000_000
+  const detected: LedgerRecord = { sha256: 'abc123', detectedAt: now }
+
+  it('authorizes a file the scan flagged whose content is unchanged', () => {
+    expect(checkDetected(detected, now, 'abc123')).toBeNull()
+  })
+
+  it('refuses a path no scan ever flagged', () => {
+    expect(checkDetected(undefined, now, 'abc123')).toMatch(/run a scan first/)
+  })
+
+  it('refuses a flagged path whose content changed after detection', () => {
+    expect(checkDetected(detected, now, 'def456')).toMatch(/changed since it was detected/)
+  })
+
+  it('refuses when the file cannot be re-read to verify it is unchanged', () => {
+    expect(checkDetected(detected, now, null)).toMatch(/could not be read/)
+  })
+
+  it('refuses a detection older than the TTL', () => {
+    expect(checkDetected(detected, now + DETECTION_TTL_MS + 1, 'abc123')).toMatch(/expired/)
+  })
+
+  it('authorizes right up to the TTL boundary', () => {
+    expect(checkDetected(detected, now + DETECTION_TTL_MS, 'abc123')).toBeNull()
+  })
+
+  it('falls back to a path-only binding when the file was unreadable at scan time', () => {
+    const unhashed: LedgerRecord = { sha256: null, detectedAt: now }
+    expect(checkDetected(unhashed, now, null)).toBeNull()
+  })
+})
+
+// ─── Action screening (replica of authorizeMalwareAction) ────────
+// Refused paths must surface as errors, not be silently dropped — otherwise
+// the succeeded/failed counts don't account for everything the caller asked
+// about, and a fully-refused batch reports as a clean no-op.
+
+function screen(
+  paths: unknown[],
+  opts: {
+    inAllowedDirs: (p: string) => boolean
+    inExemptDirs?: (p: string) => boolean
+    detected: (p: string) => string | null
+  }
+): { authorized: string[]; refused: { path: string; reason: string }[] } {
+  const authorized: string[] = []
+  const refused: { path: string; reason: string }[] = []
+  for (const p of paths) {
+    if (typeof p !== 'string') continue
+    if (!opts.inAllowedDirs(p)) {
+      refused.push({ path: p, reason: 'Path is outside the allowed scan directories' })
+      continue
+    }
+    if (opts.inExemptDirs?.(p)) {
+      authorized.push(p)
+      continue
+    }
+    const reason = opts.detected(p)
+    if (reason) refused.push({ path: p, reason })
+    else authorized.push(p)
+  }
+  return { authorized, refused }
+}
+
+describe('malware action screening', () => {
+  const always = (): boolean => true
+  const flagged = (p: string): string | null =>
+    p.includes('malware') ? null : 'Not flagged by a malware scan — run a scan first'
+
+  it('refuses an undetected file that merely sits inside a scan root', () => {
+    const r = screen(['C:/Users/v/Documents/taxes.xlsx'], { inAllowedDirs: always, detected: flagged })
+    expect(r.authorized).toEqual([])
+    expect(r.refused).toHaveLength(1)
+  })
+
+  it('reports refusals as errors rather than dropping them', () => {
+    const r = screen(['C:/Users/v/Documents/taxes.xlsx', 'C:/Windows/System32/kernel32.dll'], {
+      inAllowedDirs: (p) => !p.startsWith('C:/Windows'),
+      detected: flagged
+    })
+    expect(r.refused.map((e) => e.path)).toEqual([
+      'C:/Users/v/Documents/taxes.xlsx',
+      'C:/Windows/System32/kernel32.dll'
+    ])
+    expect(r.refused[1].reason).toMatch(/outside the allowed scan directories/)
+  })
+
+  it('authorizes a detected file', () => {
+    const r = screen(['C:/Users/v/Downloads/malware.exe'], { inAllowedDirs: always, detected: flagged })
+    expect(r.authorized).toEqual(['C:/Users/v/Downloads/malware.exe'])
+    expect(r.refused).toEqual([])
+  })
+
+  it('exempts already-quarantined files from the ledger so the vault can be emptied', () => {
+    const r = screen(['C:/Users/v/AppData/kudu/quarantine/1_x_thing.quarantined'], {
+      inAllowedDirs: always,
+      inExemptDirs: (p) => p.includes('quarantine'),
+      detected: flagged
+    })
+    expect(r.authorized).toHaveLength(1)
+    expect(r.refused).toEqual([])
+  })
+
+  it('ignores non-string entries without counting them', () => {
+    const r = screen([null, 42, 'C:/Users/v/Downloads/malware.exe'], { inAllowedDirs: always, detected: flagged })
+    expect(r.authorized).toHaveLength(1)
+    expect(r.refused).toEqual([])
   })
 })

--- a/src/main/services/cloud-agent.ts
+++ b/src/main/services/cloud-agent.ts
@@ -1565,6 +1565,7 @@ class CloudAgentService {
         if (s.allowRemotePower === false) return 'Disabled by user: remote power control is turned off'
         break
       case 'clean':
+      case 'malware-quarantine':
       case 'malware-delete':
       case 'driver-clean':
       case 'debloater-remove':
@@ -1608,7 +1609,6 @@ class CloudAgentService {
     'software-update-check', 'windows-update-check',
     'driver-update-scan', 'startup-list', 'disk-health',
     'privacy-scan', 'debloater-scan', 'service-scan', 'registry-scan',
-    'malware-quarantine', // quarantine is read-like (moves to vault)
     'get-threat-status',
   ])
 

--- a/src/main/services/cloud-agent.ts
+++ b/src/main/services/cloud-agent.ts
@@ -3001,7 +3001,9 @@ class CloudAgentService {
       return
     }
     cloudLog('INFO', `Deleting ${paths.length} malware files`)
-    const result = await deleteMalware(paths)
+    // Recoverable on the device: the confirmation dialog for this command lives
+    // in the dashboard, which the agent cannot verify actually ran.
+    const result = await deleteMalware(paths, { mode: 'recycle' })
     await this.postCommandResult(requestId, true, {
       succeeded: result.succeeded,
       failed: result.failed,


### PR DESCRIPTION
Triage of GHSA-pc4f-8mp6-fmjj. The report itself was closed as not-accepted, and several of its specifics don't hold up — it cites three settings toggles that don't exist, claims a remote allowlist covering Program Files and `%USERPROFILE%` root (the cloud path is screened by the narrower `isAllowedMalwarePath` first, so those are unreachable), and describes the API key as stored in plaintext when safeStorage/DPAPI is used with a plaintext fallback only where no OS keyring exists.

Three real gaps were underneath it, one of which the report missed.

## 1. `malware-quarantine` had no gate at all

It sat in `PARALLEL_SAFE` with the comment `// quarantine is read-like (moves to vault)`, so it had no permission check, no exclusive lock and no rate limit. It moves files. `CLOUD-COMMANDS.md` already listed it as a mutating command gated like its siblings, so the code was contradicting its own published contract. Turning off `allowRemoteCleanup` now stops remote quarantine as well as remote delete.

**Behaviour change:** fleet-wide quarantine sweeps now serialize where they previously ran in parallel.

## 2. Neither action was bound to a detection

`quarantineMalware`/`deleteMalware` accepted any path inside a scan root. Those roots span Documents, Desktop, Downloads and both AppData trees — essentially everything the user owns — so "inside a scan root" was never meaningful authorization. Nothing verified the file had been flagged, and delete unlinked it with `rm(force)`.

`CLOUD-COMMANDS.md` already specified the binding ("paths from a previous `scan` with `scanType: malware`"). It was simply never enforced.

Detections are now recorded at scan completion with the content hash seen at the time, and actions require their target to be in that ledger with unchanged contents — swapping a file between scan and action revokes the authorization rather than redirecting it.

**Design note worth a second opinion:** the ledger is in-memory, session-scoped, 24h TTL. A ledger on disk would itself be a file an attacker with local write could poison, so this way the binding is only satisfiable by a scan that actually ran in this process. The cost is that scan → agent restart → delete now refuses and the dashboard has to re-scan. Happy to switch to a persisted ledger if that tradeoff is wrong for the fleet workflow.

Paths already inside the quarantine vault are exempt, so emptying it keeps working.

## 3. Remote deletes were permanent

The confirmation dialog for `malware-delete` lives in the dashboard, which the agent can't verify ever ran — so the whole guardrail for an irreversible operation lived in a codebase this one doesn't control. Remote deletes now go to the recycle bin / trash. Where no trash is available (headless Linux) the delete **fails closed** rather than quietly becoming permanent; quarantine still works there. Local deletes from the Kudu UI are unchanged and permanent.

## Also

Refused paths are now returned in `errors` instead of being silently dropped. Previously an out-of-bounds path vanished from the succeeded/failed accounting, so a fully-refused batch came back looking like a clean no-op.

## Testing

- `npm test` — 2367 pass, 104 files. 12 new cases covering ledger authorization (hash mismatch, TTL boundary, unreadable-at-scan-time fallback) and action screening (refusals surfacing as errors, quarantine-vault exemption).
- Typecheck error count unchanged from baseline; zero in the changed files.
- Each commit typechecks and tests green standalone.
- Verified the local UI flow doesn't regress: the renderer's threat store is in-memory with no persist middleware, so it can never display a threat the ledger has forgotten.

## Not included

`CLOUD-COMMANDS.md` is gitignored (`.gitignore:10`), so the doc updates are on disk but can't be committed here. That's also why the drift in #1 survived — the agent↔dashboard contract can't be reviewed alongside the code implementing it. Worth reconsidering separately if the dashboard team treats that file as the spec.

The report's fourth point — `--api-key` in argv exposing the key via process listing ([cli.ts:446](src/main/cli.ts#L446)) — is real but untouched here; it wants its own change.
