### PR TITLE
fix: triage and fix the four remaining open security advisories

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -147,6 +147,8 @@ function createTrayIcon(): Electron.NativeImage {
 }
 
 const TASK_NAME = 'KuduStartup'
+/** The only arguments the startup task is allowed to carry — verified after registration. */
+const TASK_ARGUMENTS = '--startup'
 
 async function applyAutoLaunchWin32(enabled: boolean): Promise<void> {
   // Use Task Scheduler with RunLevel HighestAvailable so the app starts
@@ -192,7 +194,7 @@ async function applyAutoLaunchWin32(enabled: boolean): Promise<void> {
       '  <Actions Context="Author">',
       `    <Exec>`,
       `      <Command>${escapeXml(exePath)}</Command>`,
-      '      <Arguments>--startup</Arguments>',
+      `      <Arguments>${escapeXml(TASK_ARGUMENTS)}</Arguments>`,
       '    </Exec>',
       '  </Actions>',
       '</Task>'
@@ -223,18 +225,26 @@ async function applyAutoLaunchWin32(enabled: boolean): Promise<void> {
     }
 
     // Verify what was actually registered, not merely that something was.
-    // If the definition doesn't run our executable, the XML was tampered with
+    // If the definition isn't the one we submitted, the XML was tampered with
     // in the window above \u2014 tear the task down rather than leave an elevated
-    // logon entry pointing somewhere else.
-    const { stdout: registered } = await execNativeUtf8('schtasks',[
-      '/Query', '/TN', TASK_NAME, '/XML', 'ONE'
-    ], { timeout: 10000 })
+    // logon entry running something else.
+    //
+    // A query that fails or times out is also a failure to verify, and is
+    // treated the same way: an unverified elevated logon task must not survive
+    // this function, whatever the reason we couldn't check it.
+    let verified = false
+    try {
+      const { stdout: registered } = await execNativeUtf8('schtasks',[
+        '/Query', '/TN', TASK_NAME, '/XML', 'ONE'
+      ], { timeout: 10000 })
+      verified = registeredTaskMatches(registered, exePath, TASK_ARGUMENTS)
+    } catch { /* treated as unverified below */ }
 
-    if (!registeredCommandMatches(registered, exePath)) {
+    if (!verified) {
       await execNativeUtf8('schtasks',[
         '/Delete', '/TN', TASK_NAME, '/F'
       ], { timeout: 10000 }).catch(() => {})
-      throw new Error('Startup task verification failed \u2014 registered command did not match')
+      throw new Error('Startup task verification failed \u2014 the registered task did not match')
     }
   } else {
     try {
@@ -253,21 +263,45 @@ function escapeXml(s: string): string {
 }
 
 /**
- * Does the registered task definition run exactly `exePath`?
+ * Is the registered task definition exactly the one we asked for?
  *
- * Compares every <Command> the definition declares — an injected XML can carry
- * more than one Exec action, so checking only the first would miss a payload
- * appended after a legitimate entry. Returns false when no command is present
- * at all, so an unparseable read is treated as a failed verification.
+ * Task Scheduler runs the whole <Actions> block at HighestAvailable, so
+ * matching the command alone is not enough. Arguments decide what that command
+ * does — `--inspect-brk` would turn our own binary into arbitrary elevated code
+ * execution — and a definition may carry action types other than Exec
+ * (ComHandler, SendEmail, ShowMessage) that run without naming a command at
+ * all. So this requires precisely one Exec action, the expected command, the
+ * expected arguments, and no other action of any kind.
+ *
+ * Returns false on anything it cannot account for, so an unparseable or empty
+ * read is a failed verification rather than a pass.
  */
-function registeredCommandMatches(taskXml: string, exePath: string): boolean {
-  const commands = [...taskXml.matchAll(/<Command>([\s\S]*?)<\/Command>/gi)]
-    .map((m) => m[1].trim().replace(/^"|"$/g, ''))
-    .filter((c) => c.length > 0)
-  if (commands.length === 0) return false
-  const expected = exePath.trim().toLowerCase()
-  return commands.every((c) => decodeXmlEntities(c).toLowerCase() === expected)
+function registeredTaskMatches(taskXml: string, exePath: string, expectedArgs: string): boolean {
+  const actionsBlock = taskXml.match(/<Actions\b[^>]*>([\s\S]*?)<\/Actions>/i)
+  if (!actionsBlock) return false
+  const actions = actionsBlock[1]
+
+  // Any element directly under <Actions> is an action. Exactly one, and it
+  // must be an Exec.
+  const actionTags = [...actions.matchAll(/<([A-Za-z][\w.-]*)\b/g)]
+    .map((m) => m[1])
+    .filter((tag) => !TASK_EXEC_CHILD_TAGS.has(tag))
+  if (actionTags.length !== 1 || actionTags[0].toLowerCase() !== 'exec') return false
+
+  const commands = [...actions.matchAll(/<Command>([\s\S]*?)<\/Command>/gi)]
+  if (commands.length !== 1) return false
+  const command = decodeXmlEntities(commands[0][1].trim().replace(/^"|"$/g, '')).toLowerCase()
+  if (command !== exePath.trim().toLowerCase()) return false
+
+  // Arguments may legitimately be absent only if we asked for none.
+  const argMatches = [...actions.matchAll(/<Arguments>([\s\S]*?)<\/Arguments>/gi)]
+  if (argMatches.length > 1) return false
+  const args = argMatches.length === 1 ? decodeXmlEntities(argMatches[0][1].trim()) : ''
+  return args === expectedArgs.trim()
 }
+
+/** Elements that appear *inside* an Exec action rather than being actions themselves. */
+const TASK_EXEC_CHILD_TAGS = new Set(['Command', 'Arguments', 'WorkingDirectory'])
 
 function decodeXmlEntities(s: string): string {
   return s

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, ipcMain, Menu, nativeImage, screen, shell, Tray } from 'electron'
 import { execFile } from 'child_process'
 import { readFileSync } from 'fs'
+import { randomUUID } from 'crypto'
 import { promisify } from 'util'
 import { join } from 'path'
 
@@ -197,8 +198,16 @@ async function applyAutoLaunchWin32(enabled: boolean): Promise<void> {
       '</Task>'
     ].join('\r\n')
 
-    const tmpPath = join(app.getPath('temp'), `${TASK_NAME}.xml`)
-    const { writeFile, unlink } = await import('fs/promises')
+    // The XML lands in %LOCALAPPDATA%\Temp, which any process running as this
+    // user can write \u2014 including a non-elevated one. Since schtasks reads it
+    // back elevated and the task carries RunLevel HighestAvailable, a swap
+    // between our write and its read would register an attacker's command as a
+    // logon-triggered admin task. A random name denies the attacker a path to
+    // camp on, and the post-registration check below is what actually settles
+    // it: whatever ends up registered has to be the command we asked for.
+    const { writeFile, unlink, mkdtemp, rmdir } = await import('fs/promises')
+    const tmpDir = await mkdtemp(join(app.getPath('temp'), 'kudu-task-'))
+    const tmpPath = join(tmpDir, `${randomUUID()}.xml`)
     await writeFile(tmpPath, '\uFEFF' + xml, 'utf-16le')
 
     try {
@@ -209,13 +218,24 @@ async function applyAutoLaunchWin32(enabled: boolean): Promise<void> {
         '/F',
       ], { timeout: 10000 })
     } finally {
-      unlink(tmpPath).catch(() => {})
+      await unlink(tmpPath).catch(() => {})
+      await rmdir(tmpDir).catch(() => {})
     }
 
-    // Verify the task was actually registered
-    await execNativeUtf8('schtasks',[
-      '/Query', '/TN', TASK_NAME
+    // Verify what was actually registered, not merely that something was.
+    // If the definition doesn't run our executable, the XML was tampered with
+    // in the window above \u2014 tear the task down rather than leave an elevated
+    // logon entry pointing somewhere else.
+    const { stdout: registered } = await execNativeUtf8('schtasks',[
+      '/Query', '/TN', TASK_NAME, '/XML', 'ONE'
     ], { timeout: 10000 })
+
+    if (!registeredCommandMatches(registered, exePath)) {
+      await execNativeUtf8('schtasks',[
+        '/Delete', '/TN', TASK_NAME, '/F'
+      ], { timeout: 10000 }).catch(() => {})
+      throw new Error('Startup task verification failed \u2014 registered command did not match')
+    }
   } else {
     try {
       await execNativeUtf8('schtasks',[
@@ -230,6 +250,30 @@ async function applyAutoLaunchWin32(enabled: boolean): Promise<void> {
 
 function escapeXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
+/**
+ * Does the registered task definition run exactly `exePath`?
+ *
+ * Compares every <Command> the definition declares — an injected XML can carry
+ * more than one Exec action, so checking only the first would miss a payload
+ * appended after a legitimate entry. Returns false when no command is present
+ * at all, so an unparseable read is treated as a failed verification.
+ */
+function registeredCommandMatches(taskXml: string, exePath: string): boolean {
+  const commands = [...taskXml.matchAll(/<Command>([\s\S]*?)<\/Command>/gi)]
+    .map((m) => m[1].trim().replace(/^"|"$/g, ''))
+    .filter((c) => c.length > 0)
+  if (commands.length === 0) return false
+  const expected = exePath.trim().toLowerCase()
+  return commands.every((c) => decodeXmlEntities(c).toLowerCase() === expected)
+}
+
+function decodeXmlEntities(s: string): string {
+  return s
+    .replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"').replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&')
 }
 
 async function applyAutoLaunch(enabled: boolean): Promise<void> {

--- a/src/main/ipc/file-shredder.ipc.test.ts
+++ b/src/main/ipc/file-shredder.ipc.test.ts
@@ -508,4 +508,50 @@ describe('shredFile identity verification', () => {
     const result = await shred(fhStub({ size: 100, ino: 99, dev: 1 }))
     expect(result.errors[0].reason).toMatch(/changed while being shredded/)
   })
+
+  // The ancestor-swap case. Replacing a parent *directory* with a symlink
+  // redirects every later resolution of the path equally, so a fresh lstat and
+  // the open would agree with each other while both point at a file outside the
+  // selection — O_NOFOLLOW only guards the final component. The identity
+  // captured during collection predates the swap, which is what catches it.
+  it('refuses when a parent directory was swapped after collection', async () => {
+    let identityReads = 0
+    const beforeSwap = lstatStub({ size: 100, ino: 1, dev: 1 })
+    const afterSwap = lstatStub({ size: 100, ino: 7, dev: 1 })
+    mockLstat.mockImplementation((p: string, statOpts?: { bigint?: boolean }) => {
+      // The identity capture is the bigint read. It happens during collection,
+      // before the swap; every resolution after it sees the redirected path.
+      if (!statOpts?.bigint) return beforeSwap(p, statOpts)
+      identityReads++
+      return identityReads <= 1 ? beforeSwap(p, statOpts) : afterSwap(p, statOpts)
+    })
+    // The open resolves through the swapped parent and lands on the same file a
+    // fresh lstat would now report — self-consistent, but not what we collected.
+    const fh = fhStub({ size: 100, ino: 7, dev: 1 })
+    mockOpen.mockResolvedValue(fh)
+
+    registerFileShredderIpc(() => mockWindow() as any)
+    const handler = getHandler('shredder:shred')
+    const result = (await handler({}, ['/home/user/temp/secret.txt'])) as {
+      shredded: number
+      failed: number
+    }
+
+    expect(result.shredded).toBe(0)
+    expect(result.failed).toBe(1)
+    expect(fh.write).not.toHaveBeenCalled()
+    expect(mockRm).not.toHaveBeenCalled()
+  })
+
+  it('skips a file whose identity was never captured', async () => {
+    // Nothing should reach open() without having been verified during
+    // collection — if it somehow does, refuse rather than shred blind.
+    mockLstat.mockImplementation(lstatStub({ isFile: false, size: 100 }))
+    mockOpen.mockResolvedValue(fhStub({ size: 100 }))
+    registerFileShredderIpc(() => mockWindow() as any)
+    const handler = getHandler('shredder:shred')
+    const result = (await handler({}, ['/home/user/temp/secret.txt'])) as { shredded: number }
+    expect(result.shredded).toBe(0)
+    expect(mockRm).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/ipc/file-shredder.ipc.test.ts
+++ b/src/main/ipc/file-shredder.ipc.test.ts
@@ -46,6 +46,46 @@ function mockWindow() {
   return { isDestroyed: () => false, webContents: { send: mockSend } }
 }
 
+/**
+ * lstat stands in for two callers: the directory walk, which reads plain
+ * numeric stats, and shredFile, which asks for bigint stats so it can compare
+ * the file's identity against the handle it later opens.
+ */
+function lstatStub(opts: {
+  isSymlink?: boolean
+  isFile?: boolean
+  isDir?: boolean
+  size?: number
+  ino?: number
+  dev?: number
+} = {}) {
+  const { isSymlink = false, isFile = true, isDir = false, size = 100, ino = 1, dev = 1 } = opts
+  return (_path?: unknown, statOpts?: { bigint?: boolean }) => {
+    const shape = { isSymbolicLink: () => isSymlink, isFile: () => isFile, isDirectory: () => isDir }
+    return Promise.resolve(
+      statOpts?.bigint
+        ? { ...shape, size: BigInt(size), ino: BigInt(ino), dev: BigInt(dev) }
+        : { ...shape, size }
+    )
+  }
+}
+
+/** A file handle whose fstat agrees with what lstat reported — the benign case. */
+function fhStub(opts: { size?: number; ino?: number; dev?: number; isFile?: boolean } = {}) {
+  const { size = 100, ino = 1, dev = 1, isFile = true } = opts
+  return {
+    write: vi.fn().mockResolvedValue(undefined),
+    datasync: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    stat: vi.fn().mockResolvedValue({
+      isFile: () => isFile,
+      size: BigInt(size),
+      ino: BigInt(ino),
+      dev: BigInt(dev),
+    }),
+  }
+}
+
 // ── Tests ──
 
 describe('registerFileShredderIpc', () => {
@@ -160,7 +200,7 @@ describe('SHREDDER_SELECT_FOLDERS handler', () => {
       filePaths: ['/home/user/secret-folder'],
     })
     // getEntrySize calls lstat, readdir, stat
-    mockLstat.mockResolvedValue({ isSymbolicLink: () => false, isFile: () => false, isDirectory: () => true, size: 0 })
+    mockLstat.mockImplementation(lstatStub({ isFile: false, isDir: true, size: 0 }))
     mockReaddir.mockResolvedValue([
       { isSymbolicLink: () => false, isFile: () => true, isDirectory: () => false, name: 'a.txt' },
     ])
@@ -230,12 +270,8 @@ describe('SHREDDER_SHRED handler', () => {
   })
 
   it('shreds a single file successfully', async () => {
-    const mockFh = {
-      write: vi.fn().mockResolvedValue(undefined),
-      datasync: vi.fn().mockResolvedValue(undefined),
-      close: vi.fn().mockResolvedValue(undefined),
-    }
-    mockLstat.mockResolvedValue({ isSymbolicLink: () => false, isFile: () => true, isDirectory: () => false, size: 512 })
+    const mockFh = fhStub({ size: 512 })
+    mockLstat.mockImplementation(lstatStub({ size: 512 }))
     mockOpen.mockResolvedValue(mockFh)
     mockRm.mockResolvedValue(undefined)
     mockStat.mockResolvedValue({ size: 512 })
@@ -253,7 +289,7 @@ describe('SHREDDER_SHRED handler', () => {
   })
 
   it('handles shred errors and reports them', async () => {
-    mockLstat.mockResolvedValue({ isSymbolicLink: () => false, isFile: () => true, isDirectory: () => false, size: 100 })
+    mockLstat.mockImplementation(lstatStub({ size: 100 }))
     mockOpen.mockRejectedValue(new Error('EACCES: permission denied'))
     mockStat.mockResolvedValue({ size: 100 })
 
@@ -267,12 +303,8 @@ describe('SHREDDER_SHRED handler', () => {
   })
 
   it('deduplicates file paths', async () => {
-    const mockFh = {
-      write: vi.fn().mockResolvedValue(undefined),
-      datasync: vi.fn().mockResolvedValue(undefined),
-      close: vi.fn().mockResolvedValue(undefined),
-    }
-    mockLstat.mockResolvedValue({ isSymbolicLink: () => false, isFile: () => true, isDirectory: () => false, size: 100 })
+    const mockFh = fhStub({ size: 100 })
+    mockLstat.mockImplementation(lstatStub({ size: 100 }))
     mockOpen.mockResolvedValue(mockFh)
     mockRm.mockResolvedValue(undefined)
     mockStat.mockResolvedValue({ size: 100 })
@@ -286,7 +318,7 @@ describe('SHREDDER_SHRED handler', () => {
   })
 
   it('skips symlinks during file shredding', async () => {
-    mockLstat.mockResolvedValue({ isSymbolicLink: () => true, isFile: () => false, isDirectory: () => false, size: 100 })
+    mockLstat.mockImplementation(lstatStub({ isSymlink: true, isFile: false, size: 100 }))
 
     registerFileShredderIpc(() => null)
     const handler = getHandler('shredder:shred')
@@ -296,21 +328,13 @@ describe('SHREDDER_SHRED handler', () => {
   })
 
   it('recursively collects files from directories', async () => {
-    const mockFh = {
-      write: vi.fn().mockResolvedValue(undefined),
-      datasync: vi.fn().mockResolvedValue(undefined),
-      close: vi.fn().mockResolvedValue(undefined),
-    }
+    const mockFh = fhStub({ size: 256 })
 
-    let lstatCallCount = 0
-    mockLstat.mockImplementation((p: string) => {
-      lstatCallCount++
-      if (p === '/home/user/temp/mydir') {
-        return Promise.resolve({ isSymbolicLink: () => false, isFile: () => false, isDirectory: () => true, size: 0 })
-      }
-      // shredFile lstat
-      return Promise.resolve({ isSymbolicLink: () => false, isFile: () => true, isDirectory: () => false, size: 256 })
-    })
+    const dirStub = lstatStub({ isFile: false, isDir: true, size: 0 })
+    const fileStub = lstatStub({ size: 256 })
+    mockLstat.mockImplementation((p: string, statOpts?: { bigint?: boolean }) =>
+      p === '/home/user/temp/mydir' ? dirStub(p, statOpts) : fileStub(p, statOpts)
+    )
 
     mockReaddir.mockImplementation((p: string) => {
       if (typeof p === 'string' && p.includes('mydir')) {
@@ -334,15 +358,11 @@ describe('SHREDDER_SHRED handler', () => {
   })
 
   it('sends final progress after shredding', async () => {
-    mockLstat.mockResolvedValue({ isSymbolicLink: () => false, isFile: () => true, isDirectory: () => false, size: 0 })
+    mockLstat.mockImplementation(lstatStub({ size: 0 }))
     mockStat.mockResolvedValue({ size: 0 })
 
     // shredFile skips zero-size files, rm still called
-    const mockFh = {
-      write: vi.fn().mockResolvedValue(undefined),
-      datasync: vi.fn().mockResolvedValue(undefined),
-      close: vi.fn().mockResolvedValue(undefined),
-    }
+    const mockFh = fhStub({ size: 0 })
     mockOpen.mockResolvedValue(mockFh)
     mockRm.mockResolvedValue(undefined)
 
@@ -390,7 +410,7 @@ describe('protected path safety', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     // Make lstat return file for all so we can check protection
-    mockLstat.mockResolvedValue({ isSymbolicLink: () => false, isFile: () => true, isDirectory: () => false, size: 100 })
+    mockLstat.mockImplementation(lstatStub({ size: 100 }))
     mockStat.mockResolvedValue({ size: 100 })
   })
 
@@ -413,5 +433,79 @@ describe('protected path safety', () => {
     const handler = getHandler('shredder:shred')
     const result = await handler({}, ['/home/user/project/node_modules'])
     expect(result.errors.some((e: { path: string; reason: string }) => e.reason.includes('Protected'))).toBe(true)
+  })
+})
+
+// ── Swap-under-the-shredder (TOCTOU) ──
+// lstat describes the path at one instant; the open() that follows resolves it
+// again. Anything that can write to the directory can swap the file for a
+// symlink in between and redirect this elevated process onto a file it was
+// never meant to touch. The handle is therefore re-checked against the lstat.
+
+describe('shredFile identity verification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRm.mockResolvedValue(undefined)
+    mockStat.mockResolvedValue({ size: 100 })
+  })
+
+  async function shred(fh: ReturnType<typeof fhStub>) {
+    mockLstat.mockImplementation(lstatStub({ size: 100, ino: 1, dev: 1 }))
+    mockOpen.mockResolvedValue(fh)
+    registerFileShredderIpc(() => mockWindow() as any)
+    const handler = getHandler('shredder:shred')
+    return (await handler({}, ['/home/user/temp/secret.txt'])) as {
+      shredded: number
+      failed: number
+      errors: { path: string; reason: string }[]
+    }
+  }
+
+  it('shreds a file whose handle matches what lstat described', async () => {
+    const fh = fhStub({ size: 100, ino: 1, dev: 1 })
+    const result = await shred(fh)
+    expect(result.shredded).toBe(1)
+    expect(fh.write).toHaveBeenCalled()
+    expect(mockRm).toHaveBeenCalled()
+  })
+
+  it('refuses to overwrite when the inode changed under it', async () => {
+    const fh = fhStub({ size: 100, ino: 99, dev: 1 })
+    const result = await shred(fh)
+    expect(result.shredded).toBe(0)
+    expect(result.failed).toBe(1)
+    expect(fh.write).not.toHaveBeenCalled()
+  })
+
+  it('refuses when the path now resolves to another device', async () => {
+    const fh = fhStub({ size: 100, ino: 1, dev: 42 })
+    const result = await shred(fh)
+    expect(result.shredded).toBe(0)
+    expect(fh.write).not.toHaveBeenCalled()
+  })
+
+  it('refuses when the opened handle is no longer a regular file', async () => {
+    const fh = fhStub({ size: 100, ino: 1, dev: 1, isFile: false })
+    const result = await shred(fh)
+    expect(result.shredded).toBe(0)
+    expect(fh.write).not.toHaveBeenCalled()
+  })
+
+  it('refuses when the size changed between check and open', async () => {
+    const fh = fhStub({ size: 4096, ino: 1, dev: 1 })
+    const result = await shred(fh)
+    expect(result.shredded).toBe(0)
+    expect(fh.write).not.toHaveBeenCalled()
+  })
+
+  it('does not delete the substituted file — a silent skip would still destroy it', async () => {
+    const fh = fhStub({ size: 100, ino: 99, dev: 1 })
+    await shred(fh)
+    expect(mockRm).not.toHaveBeenCalled()
+  })
+
+  it('reports the refusal rather than counting it as shredded', async () => {
+    const result = await shred(fhStub({ size: 100, ino: 99, dev: 1 }))
+    expect(result.errors[0].reason).toMatch(/changed while being shredded/)
   })
 })

--- a/src/main/ipc/file-shredder.ipc.ts
+++ b/src/main/ipc/file-shredder.ipc.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, dialog, ipcMain, shell } from 'electron'
 import { readdir, rmdir, stat, lstat, open, rm } from 'fs/promises'
+import { constants as fsConstants } from 'fs'
 import { join, isAbsolute, basename, resolve, normalize } from 'path'
 import { randomBytes } from 'crypto'
 import { IPC } from '../../shared/channels'
@@ -72,17 +73,42 @@ function sendProgress(win: BrowserWindow | null, data: ShredderProgress): void {
 
 /**
  * Overwrite a single file with random data then zeros (2-pass shred).
- * Uses lstat to avoid following symlinks.  Checks the module-level
- * `cancelled` flag between chunks so large files can be interrupted.
+ * Checks the module-level `cancelled` flag between chunks so large files can
+ * be interrupted.
+ *
+ * lstat alone cannot make this safe: it describes the path at one instant, and
+ * the open() that follows resolves the path a second time. Between those two
+ * resolutions anything that can write to the directory — which for a shred
+ * target is by definition somewhere the user picked, possibly a shared or
+ * removable volume — can swap the file for a symlink or junction and redirect
+ * this elevated process onto a file it was never meant to touch. So the handle
+ * is re-checked against the lstat once it is open, and O_NOFOLLOW refuses the
+ * substitution outright where the platform provides it.
  */
 async function shredFile(filePath: string): Promise<void> {
-  const stats = await lstat(filePath)
-  if (stats.isSymbolicLink() || !stats.isFile() || stats.size === 0) return
+  const stats = await lstat(filePath, { bigint: true })
+  if (stats.isSymbolicLink() || !stats.isFile() || stats.size === 0n) return
 
-  const size = stats.size
+  const size = Number(stats.size)
   const CHUNK = 1024 * 1024 // 1 MB
-  const fh = await open(filePath, 'r+')
+  // O_NOFOLLOW is POSIX-only; on Windows the fstat comparison below carries it.
+  const openFlags = fsConstants.O_RDWR | (fsConstants.O_NOFOLLOW ?? 0)
+  const fh = await open(filePath, openFlags)
   try {
+    // Confirm the handle refers to the same file lstat described. A swapped
+    // path resolves to a different inode, so this closes the window that
+    // remains between the two path resolutions.
+    const opened = await fh.stat({ bigint: true })
+    const identityKnown = stats.ino !== 0n && opened.ino !== 0n
+    if (
+      !opened.isFile() ||
+      opened.size !== stats.size ||
+      (identityKnown && (opened.ino !== stats.ino || opened.dev !== stats.dev))
+    ) {
+      // Throw rather than return: the caller deletes whatever shredFile leaves
+      // behind, so a silent skip here would still destroy the substituted file.
+      throw new Error('File changed while being shredded — skipped')
+    }
     // Pass 1: random data
     let offset = 0
     while (offset < size) {

--- a/src/main/ipc/file-shredder.ipc.ts
+++ b/src/main/ipc/file-shredder.ipc.ts
@@ -65,6 +65,24 @@ function isProtectedPath(targetPath: string): boolean {
   return false
 }
 
+/** What a file was when we found it, so we can tell later whether it still is. */
+interface FileIdentity {
+  dev: bigint
+  ino: bigint
+  size: bigint
+}
+
+/** Identity of a regular file, or null if the path isn't one we should shred. */
+async function readIdentity(filePath: string): Promise<FileIdentity | null> {
+  try {
+    const s = await lstat(filePath, { bigint: true })
+    if (s.isSymbolicLink() || !s.isFile()) return null
+    return { dev: s.dev, ino: s.ino, size: s.size }
+  } catch {
+    return null
+  }
+}
+
 function sendProgress(win: BrowserWindow | null, data: ShredderProgress): void {
   if (win && !win.isDestroyed()) {
     win.webContents.send(IPC.SHREDDER_PROGRESS, data)
@@ -76,34 +94,34 @@ function sendProgress(win: BrowserWindow | null, data: ShredderProgress): void {
  * Checks the module-level `cancelled` flag between chunks so large files can
  * be interrupted.
  *
- * lstat alone cannot make this safe: it describes the path at one instant, and
- * the open() that follows resolves the path a second time. Between those two
- * resolutions anything that can write to the directory — which for a shred
- * target is by definition somewhere the user picked, possibly a shared or
- * removable volume — can swap the file for a symlink or junction and redirect
- * this elevated process onto a file it was never meant to touch. So the handle
- * is re-checked against the lstat once it is open, and O_NOFOLLOW refuses the
- * substitution outright where the platform provides it.
+ * A path is not a stable reference to a file. Every resolution of it consults
+ * the directories above it, and for a shred target those directories are
+ * wherever the user pointed — possibly a shared or removable volume something
+ * else can write. So `expected` is the identity recorded when the tree was
+ * walked and the path was known to lie inside the selection; the handle opened
+ * here has to still be that same file.
+ *
+ * Re-lstat'ing the path here instead would not be enough: swapping a *parent*
+ * directory for a symlink redirects both the lstat and the open equally, so
+ * the two agree with each other while both point somewhere the user never
+ * selected. O_NOFOLLOW only guards the final component. Comparing against an
+ * identity captured before the walk finished is what closes that.
  */
-async function shredFile(filePath: string): Promise<void> {
-  const stats = await lstat(filePath, { bigint: true })
-  if (stats.isSymbolicLink() || !stats.isFile() || stats.size === 0n) return
+async function shredFile(filePath: string, expected: FileIdentity): Promise<void> {
+  if (expected.size === 0n) return
 
-  const size = Number(stats.size)
+  const size = Number(expected.size)
   const CHUNK = 1024 * 1024 // 1 MB
   // O_NOFOLLOW is POSIX-only; on Windows the fstat comparison below carries it.
   const openFlags = fsConstants.O_RDWR | (fsConstants.O_NOFOLLOW ?? 0)
   const fh = await open(filePath, openFlags)
   try {
-    // Confirm the handle refers to the same file lstat described. A swapped
-    // path resolves to a different inode, so this closes the window that
-    // remains between the two path resolutions.
     const opened = await fh.stat({ bigint: true })
-    const identityKnown = stats.ino !== 0n && opened.ino !== 0n
+    const identityKnown = expected.ino !== 0n && opened.ino !== 0n
     if (
       !opened.isFile() ||
-      opened.size !== stats.size ||
-      (identityKnown && (opened.ino !== stats.ino || opened.dev !== stats.dev))
+      opened.size !== expected.size ||
+      (identityKnown && (opened.ino !== expected.ino || opened.dev !== expected.dev))
     ) {
       // Throw rather than return: the caller deletes whatever shredFile leaves
       // behind, so a silent skip here would still destroy the substituted file.
@@ -140,10 +158,16 @@ const MAX_DEPTH = 50
  * Collect all file paths within a directory recursively.
  * Skips symlinks and protected paths, respects a depth limit.
  * Sets `state.depthExceeded` if any branch is cut short by MAX_DEPTH.
+ *
+ * Records each file's identity as it is found. That identity is what the shred
+ * pass verifies against — captured here, while the path is known to resolve
+ * inside the walked tree, rather than re-derived later from a path whose
+ * ancestors may since have been swapped.
  */
 async function collectFiles(
   dirPath: string,
   files: string[],
+  identities: Map<string, FileIdentity>,
   state: { depthExceeded: boolean },
   depth: number = 0
 ): Promise<void> {
@@ -158,9 +182,12 @@ async function collectFiles(
       const fullPath = join(dirPath, entry.name)
       if (entry.isDirectory()) {
         if (isProtectedPath(fullPath)) continue
-        await collectFiles(fullPath, files, state, depth + 1)
+        await collectFiles(fullPath, files, identities, state, depth + 1)
       } else if (entry.isFile()) {
+        const identity = await readIdentity(fullPath)
+        if (!identity) continue
         files.push(fullPath)
+        identities.set(fullPath, identity)
       }
     }
   } catch {
@@ -296,6 +323,7 @@ export function registerFileShredderIpc(getWindow: WindowGetter): void {
     // First, collect all individual files to shred
     const allFiles: string[] = []
     const dirPaths: string[] = []
+    const identities = new Map<string, FileIdentity>()
     const collectState = { depthExceeded: false }
 
     for (const p of allowedPaths) {
@@ -304,9 +332,12 @@ export function registerFileShredderIpc(getWindow: WindowGetter): void {
         if (s.isSymbolicLink()) continue
         if (s.isDirectory()) {
           dirPaths.push(p)
-          await collectFiles(p, allFiles, collectState)
+          await collectFiles(p, allFiles, identities, collectState)
         } else if (s.isFile()) {
+          const identity = await readIdentity(p)
+          if (!identity) continue
           allFiles.push(p)
+          identities.set(p, identity)
         }
       } catch { /* skip */ }
     }
@@ -353,7 +384,9 @@ export function registerFileShredderIpc(getWindow: WindowGetter): void {
       }
 
       try {
-        await shredFile(filePath)
+        const identity = identities.get(filePath)
+        if (!identity) throw new Error('File was not verified during collection — skipped')
+        await shredFile(filePath, identity)
         await rm(filePath, { force: true })
         const fileSize = fileSizes.get(filePath) || 0
         bytesShredded += fileSize

--- a/src/main/platform/darwin/startup.ts
+++ b/src/main/platform/darwin/startup.ts
@@ -11,6 +11,21 @@ import type { StartupItem, StartupBootTrace } from '../../../shared/types'
 const execFileAsync = promisify(execFile)
 const HOME = resolve(homedir())
 
+// Login item names are chosen by whoever created the item, so they are
+// untrusted input. Rather than splice them into script text and try to
+// neutralise the result — the previous approach stripped \ and ", which also
+// silently mangled legitimate names and could act on the wrong item — the name
+// is passed as an argument and read from `argv`, so it is never parsed as code.
+const MAKE_LOGIN_ITEM_SCRIPT =
+  'on run argv\n' +
+  '  tell application "System Events" to make login item at end with properties {name:(item 1 of argv), hidden:false}\n' +
+  'end run'
+
+const DELETE_LOGIN_ITEM_SCRIPT =
+  'on run argv\n' +
+  '  tell application "System Events" to delete login item (item 1 of argv)\n' +
+  'end run'
+
 export function createDarwinStartup(): PlatformStartup {
   return {
     async listItems(): Promise<StartupItem[]> {
@@ -123,15 +138,13 @@ export function createDarwinStartup(): PlatformStartup {
           return true
         }
         if (source === 'login-item') {
-          // Sanitize name to prevent AppleScript injection
-          const safeName = name.replace(/[\\"]/g, '')
           if (enabled) {
             await execFileAsync('/usr/bin/osascript', [
-              '-e', `tell application "System Events" to make login item at end with properties {name:"${safeName}", hidden:false}`,
+              '-e', MAKE_LOGIN_ITEM_SCRIPT, name,
             ], { timeout: 10_000 })
           } else {
             await execFileAsync('/usr/bin/osascript', [
-              '-e', `tell application "System Events" to delete login item "${safeName}"`,
+              '-e', DELETE_LOGIN_ITEM_SCRIPT, name,
             ], { timeout: 10_000 })
           }
           return true
@@ -165,9 +178,8 @@ export function createDarwinStartup(): PlatformStartup {
           return true
         }
         if (source === 'login-item') {
-          const safeName = name.replace(/[\\"]/g, '')
           await execFileAsync('/usr/bin/osascript', [
-            '-e', `tell application "System Events" to delete login item "${safeName}"`,
+            '-e', DELETE_LOGIN_ITEM_SCRIPT, name,
           ], { timeout: 10_000 })
           return true
         }

--- a/src/main/services/cloud-agent.flood.test.ts
+++ b/src/main/services/cloud-agent.flood.test.ts
@@ -97,3 +97,59 @@ describe('parallel-safe command admission', () => {
     expect(admit(state, 'clean', false, T)).toMatch(/still running/)
   })
 })
+
+// ─── Slot accounting across a timeout ───────────────────────────
+// Timing out gives up waiting for a result; it does not stop the work. If the
+// timeout released the slot, every timeout would admit another batch while the
+// previous one still ran, and real concurrency would drift past the ceiling.
+// The slot is therefore released only when the operation settles.
+
+interface Slots {
+  running: number
+  release(): void
+  onTimeout(): void
+}
+
+function slots(): Slots {
+  const s = {
+    running: 0,
+    release() { s.running = Math.max(0, s.running - 1) },
+    onTimeout() { /* reports the failure; deliberately does not release */ },
+  }
+  return s
+}
+
+describe('command slot accounting', () => {
+  it('keeps the slot held when a command times out', () => {
+    const s = slots()
+    s.running++
+    s.onTimeout()
+    expect(s.running).toBe(1)
+  })
+
+  it('releases the slot when the timed-out command finally settles', () => {
+    const s = slots()
+    s.running++
+    s.onTimeout()
+    s.release()
+    expect(s.running).toBe(0)
+  })
+
+  it('releases exactly once, so a timeout plus settle cannot double-count', () => {
+    const s = slots()
+    s.running += 2
+    s.onTimeout() // command A times out, still running
+    s.release()   // command B settles
+    expect(s.running).toBe(1)
+  })
+
+  it('does not let repeated timeouts open unlimited slots', () => {
+    const s = slots()
+    for (let i = 0; i < MAX_PARALLEL_COMMANDS; i++) {
+      s.running++
+      s.onTimeout()
+    }
+    const state = newState({ runningCommands: s.running })
+    expect(admit(state, 'scan', true, 10_000_000)).toMatch(/Too many commands running/)
+  })
+})

--- a/src/main/services/cloud-agent.flood.test.ts
+++ b/src/main/services/cloud-agent.flood.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+
+// ─── Parallel-safe admission control (replica of executeCommand's gate) ──
+// "Parallel-safe" means a command won't corrupt state if overlapped — not that
+// it's cheap. `scan` walks the whole disk. Before this gate existed, parallel-
+// safe commands had neither a concurrency cap nor a rate limit, so anything
+// able to send commands could pin the device's CPU and I/O just by repeating
+// one. That is reachable by a hostile key holder, and equally by a dashboard
+// retrying too eagerly.
+
+const MAX_PARALLEL_COMMANDS = 4
+const PARALLEL_COMMAND_MIN_SPACING_MS = 1000
+const MUTATING_MIN_SPACING_MS = 500
+
+interface GateState {
+  runningCommands: number
+  commandRunning: boolean
+  lastCommandFinishedAt: number
+  lastParallelStartAt: Map<string, number>
+}
+
+function newState(overrides: Partial<GateState> = {}): GateState {
+  return {
+    runningCommands: 0,
+    commandRunning: false,
+    lastCommandFinishedAt: 0,
+    lastParallelStartAt: new Map(),
+    ...overrides,
+  }
+}
+
+/** Returns the rejection reason, or null if the command is admitted. */
+function admit(state: GateState, type: string, isParallelSafe: boolean, now: number): string | null {
+  if (!isParallelSafe && state.commandRunning) return 'A mutating command is already running'
+  if (!isParallelSafe && state.runningCommands > 0) return 'Commands are still running — try again shortly'
+  if (isParallelSafe && state.runningCommands >= MAX_PARALLEL_COMMANDS) {
+    return 'Too many commands running — try again shortly'
+  }
+  if (!isParallelSafe) {
+    if (now - state.lastCommandFinishedAt < MUTATING_MIN_SPACING_MS) return 'Rate limited — try again shortly'
+  } else {
+    const lastStart = state.lastParallelStartAt.get(type) ?? 0
+    if (now - lastStart < PARALLEL_COMMAND_MIN_SPACING_MS) return 'Rate limited — try again shortly'
+    state.lastParallelStartAt.set(type, now)
+  }
+  if (!isParallelSafe) state.commandRunning = true
+  state.runningCommands++
+  return null
+}
+
+describe('parallel-safe command admission', () => {
+  const T = 10_000_000
+
+  it('admits a scan when the device is idle', () => {
+    expect(admit(newState(), 'scan', true, T)).toBeNull()
+  })
+
+  it('caps how many parallel-safe commands run at once', () => {
+    const state = newState({ runningCommands: MAX_PARALLEL_COMMANDS })
+    expect(admit(state, 'scan', true, T)).toMatch(/Too many commands running/)
+  })
+
+  it('rejects a flood of repeated scans instead of stacking them', () => {
+    const state = newState()
+    const outcomes = Array.from({ length: 20 }, (_, i) => admit(state, 'scan', true, T + i))
+    expect(outcomes.filter((o) => o === null)).toHaveLength(1)
+    expect(state.runningCommands).toBe(1)
+  })
+
+  it('spaces out repeats of the same command type', () => {
+    const state = newState()
+    expect(admit(state, 'scan', true, T)).toBeNull()
+    state.runningCommands = 0 // first one finished
+    expect(admit(state, 'scan', true, T + 100)).toMatch(/Rate limited/)
+    expect(admit(state, 'scan', true, T + PARALLEL_COMMAND_MIN_SPACING_MS)).toBeNull()
+  })
+
+  it('keys the spacing per type, so scans do not crowd out get-status', () => {
+    const state = newState()
+    expect(admit(state, 'scan', true, T)).toBeNull()
+    expect(admit(state, 'get-status', true, T)).toBeNull()
+  })
+
+  it('still admits a mutating command when nothing is running', () => {
+    expect(admit(newState({ lastCommandFinishedAt: 0 }), 'clean', false, T)).toBeNull()
+  })
+
+  it('leaves the mutating exclusive lock intact', () => {
+    const state = newState({ commandRunning: true })
+    expect(admit(state, 'clean', false, T)).toMatch(/already running/)
+  })
+
+  it('does not let the parallel cap block mutating commands, which have their own gate', () => {
+    // runningCommands > 0 already rejects mutating work, so the cap must not be
+    // the thing deciding it — otherwise the message would be wrong.
+    const state = newState({ runningCommands: MAX_PARALLEL_COMMANDS })
+    expect(admit(state, 'clean', false, T)).toMatch(/still running/)
+  })
+})

--- a/src/main/services/cloud-agent.ts
+++ b/src/main/services/cloud-agent.ts
@@ -99,6 +99,10 @@ class CloudHttpError extends Error {
 
 const COMMAND_TIMEOUT_MS = 5 * 60 * 1000
 const LONG_COMMAND_TIMEOUT_MS = 30 * 60 * 1000 // for bulk update / install commands
+/** Ceiling on concurrently executing commands, so a burst can't saturate the device. */
+const MAX_PARALLEL_COMMANDS = 4
+/** Minimum spacing between two starts of the same parallel-safe command type. */
+const PARALLEL_COMMAND_MIN_SPACING_MS = 1000
 
 const LONG_RUNNING_COMMANDS = new Set([
   'scan',
@@ -202,6 +206,8 @@ class CloudAgentService {
   private runningCommands: number = 0
   private healthReportRunning: boolean = false
   private lastCommandFinishedAt: number = 0
+  /** Last start time per parallel-safe command type, for spacing repeats. */
+  private lastParallelStartAt: Map<string, number> = new Map()
   private processedRequestIds = new Map<string, number>() // requestId → timestamp
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
   private reconnectAttempts: number = 0
@@ -1631,6 +1637,17 @@ class CloudAgentService {
       return
     }
 
+    // Parallel-safe means "won't corrupt state if overlapped", not "free".
+    // A scan walks the whole disk, so an unbounded number in flight is a way
+    // to pin the device's CPU and I/O — reachable by anything that can send
+    // commands, whether hostile or just a dashboard retrying too eagerly.
+    if (isParallelSafe && this.runningCommands >= MAX_PARALLEL_COMMANDS) {
+      if ('requestId' in cmd) {
+        this.postCommandResult(cmd.requestId, false, undefined, 'Too many commands running — try again shortly').catch(() => {})
+      }
+      return
+    }
+
     // Rate limit mutating commands: minimum 500ms to prevent accidental double-fires
     if (!isParallelSafe) {
       const elapsed = Date.now() - this.lastCommandFinishedAt
@@ -1640,6 +1657,18 @@ class CloudAgentService {
         }
         return
       }
+    } else {
+      // Cheap reads can still arrive faster than they finish, so space out the
+      // expensive ones too. Keyed per command type so a burst of scans can't
+      // crowd out an unrelated get-status.
+      const lastStart = this.lastParallelStartAt.get(cmd.type) ?? 0
+      if (Date.now() - lastStart < PARALLEL_COMMAND_MIN_SPACING_MS) {
+        if ('requestId' in cmd) {
+          this.postCommandResult(cmd.requestId, false, undefined, 'Rate limited — try again shortly').catch(() => {})
+        }
+        return
+      }
+      this.lastParallelStartAt.set(cmd.type, Date.now())
     }
 
     if (!isParallelSafe) this.commandRunning = true

--- a/src/main/services/cloud-agent.ts
+++ b/src/main/services/cloud-agent.ts
@@ -1678,8 +1678,12 @@ class CloudAgentService {
 
     const timeout = setTimeout(() => {
       timedOut = true
+      // Release the mutating exclusive lock so a slow command can't wedge the
+      // queue, but keep holding the concurrency slot. Timing out only gives up
+      // waiting for the result — it does not stop the work, which is still
+      // consuming the device. Freeing the slot here would let a new batch in
+      // after every timeout and let real concurrency drift past the ceiling.
       if (!isParallelSafe) this.commandRunning = false
-      this.runningCommands = Math.max(0, this.runningCommands - 1)
       if ('requestId' in cmd) {
         this.postCommandResult(cmd.requestId, false, undefined, 'Command timed out').catch(() => {})
       }
@@ -1846,11 +1850,11 @@ class CloudAgentService {
       }
     } finally {
       clearTimeout(timeout)
-      if (!timedOut) {
-        if (!isParallelSafe) this.commandRunning = false
-        this.runningCommands = Math.max(0, this.runningCommands - 1)
-        this.lastCommandFinishedAt = Date.now()
-      }
+      // Release unconditionally: the slot tracks work that is actually running,
+      // so it comes back when the operation settles, timed out or not.
+      if (!isParallelSafe) this.commandRunning = false
+      this.runningCommands = Math.max(0, this.runningCommands - 1)
+      this.lastCommandFinishedAt = Date.now()
     }
   }
 

--- a/src/main/startup-task-verify.test.ts
+++ b/src/main/startup-task-verify.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+
+// ─── registeredCommandMatches (replica of src/main/index.ts) ─────
+// index.ts boots the Electron app on import, so the pure helper is replicated
+// here — same convention as malware-scanner.test.ts.
+//
+// Why this check exists: the task XML is written to %LOCALAPPDATA%\Temp, which
+// any process running as this user can write, including a non-elevated one.
+// schtasks reads it back elevated and the task carries RunLevel
+// HighestAvailable, so a swap between our write and its read would register an
+// attacker's command as a logon-triggered admin task. After registering we ask
+// Task Scheduler what it actually stored and compare it against our exe.
+
+function decodeXmlEntities(s: string): string {
+  return s
+    .replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"').replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&')
+}
+
+function registeredCommandMatches(taskXml: string, exePath: string): boolean {
+  const commands = [...taskXml.matchAll(/<Command>([\s\S]*?)<\/Command>/gi)]
+    .map((m) => m[1].trim().replace(/^"|"$/g, ''))
+    .filter((c) => c.length > 0)
+  if (commands.length === 0) return false
+  const expected = exePath.trim().toLowerCase()
+  return commands.every((c) => decodeXmlEntities(c).toLowerCase() === expected)
+}
+
+const EXE = 'C:\\Program Files\\Kudu\\Kudu.exe'
+
+function taskXml(...commands: string[]): string {
+  return [
+    '<?xml version="1.0" encoding="UTF-16"?>',
+    '<Task version="1.2">',
+    '  <Actions Context="Author">',
+    ...commands.map((c) => `    <Exec><Command>${c}</Command><Arguments>--startup</Arguments></Exec>`),
+    '  </Actions>',
+    '</Task>',
+  ].join('\r\n')
+}
+
+describe('registeredCommandMatches', () => {
+  it('accepts the task we meant to register', () => {
+    expect(registeredCommandMatches(taskXml(EXE), EXE)).toBe(true)
+  })
+
+  it('accepts a command Task Scheduler echoed back quoted', () => {
+    expect(registeredCommandMatches(taskXml(`"${EXE}"`), EXE)).toBe(true)
+  })
+
+  it('accepts a path whose ampersand came back XML-escaped', () => {
+    const exe = 'C:\\Tools\\R&D\\Kudu.exe'
+    expect(registeredCommandMatches(taskXml('C:\\Tools\\R&amp;D\\Kudu.exe'), exe)).toBe(true)
+  })
+
+  it('ignores case, which Windows paths do', () => {
+    expect(registeredCommandMatches(taskXml(EXE.toUpperCase()), EXE)).toBe(true)
+  })
+
+  it('tolerates surrounding whitespace', () => {
+    expect(registeredCommandMatches(taskXml(`\r\n      ${EXE}\r\n    `), EXE)).toBe(true)
+  })
+
+  it('rejects a substituted command', () => {
+    expect(registeredCommandMatches(taskXml('C:\\attacker\\backdoor.exe'), EXE)).toBe(false)
+  })
+
+  it('rejects a payload appended after a legitimate entry', () => {
+    // Checking only the first <Command> would pass this — an injected XML can
+    // declare more than one Exec action and Task Scheduler runs them all.
+    expect(registeredCommandMatches(taskXml(EXE, 'C:\\attacker\\backdoor.exe'), EXE)).toBe(false)
+  })
+
+  it('rejects a payload placed before the legitimate entry', () => {
+    expect(registeredCommandMatches(taskXml('C:\\attacker\\backdoor.exe', EXE), EXE)).toBe(false)
+  })
+
+  it('rejects a definition with no command at all', () => {
+    expect(registeredCommandMatches('<Task version="1.2"><Actions /></Task>', EXE)).toBe(false)
+  })
+
+  it('rejects empty output, so a failed query is not read as success', () => {
+    expect(registeredCommandMatches('', EXE)).toBe(false)
+  })
+
+  it('rejects a command that merely starts with our path', () => {
+    expect(registeredCommandMatches(taskXml(EXE + '.evil.exe'), EXE)).toBe(false)
+  })
+})

--- a/src/main/startup-task-verify.test.ts
+++ b/src/main/startup-task-verify.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
-// ─── registeredCommandMatches (replica of src/main/index.ts) ─────
+// ─── registeredTaskMatches (replica of src/main/index.ts) ────────
 // index.ts boots the Electron app on import, so the pure helper is replicated
 // here — same convention as malware-scanner.test.ts.
 //
@@ -8,8 +8,10 @@ import { describe, it, expect } from 'vitest'
 // any process running as this user can write, including a non-elevated one.
 // schtasks reads it back elevated and the task carries RunLevel
 // HighestAvailable, so a swap between our write and its read would register an
-// attacker's command as a logon-triggered admin task. After registering we ask
-// Task Scheduler what it actually stored and compare it against our exe.
+// attacker's definition as a logon-triggered admin task. After registering we
+// ask Task Scheduler what it actually stored and compare it to what we sent.
+
+const TASK_EXEC_CHILD_TAGS = new Set(['Command', 'Arguments', 'WorkingDirectory'])
 
 function decodeXmlEntities(s: string): string {
   return s
@@ -18,73 +20,129 @@ function decodeXmlEntities(s: string): string {
     .replace(/&amp;/g, '&')
 }
 
-function registeredCommandMatches(taskXml: string, exePath: string): boolean {
-  const commands = [...taskXml.matchAll(/<Command>([\s\S]*?)<\/Command>/gi)]
-    .map((m) => m[1].trim().replace(/^"|"$/g, ''))
-    .filter((c) => c.length > 0)
-  if (commands.length === 0) return false
-  const expected = exePath.trim().toLowerCase()
-  return commands.every((c) => decodeXmlEntities(c).toLowerCase() === expected)
+function registeredTaskMatches(taskXml: string, exePath: string, expectedArgs: string): boolean {
+  const actionsBlock = taskXml.match(/<Actions\b[^>]*>([\s\S]*?)<\/Actions>/i)
+  if (!actionsBlock) return false
+  const actions = actionsBlock[1]
+
+  const actionTags = [...actions.matchAll(/<([A-Za-z][\w.-]*)\b/g)]
+    .map((m) => m[1])
+    .filter((tag) => !TASK_EXEC_CHILD_TAGS.has(tag))
+  if (actionTags.length !== 1 || actionTags[0].toLowerCase() !== 'exec') return false
+
+  const commands = [...actions.matchAll(/<Command>([\s\S]*?)<\/Command>/gi)]
+  if (commands.length !== 1) return false
+  const command = decodeXmlEntities(commands[0][1].trim().replace(/^"|"$/g, '')).toLowerCase()
+  if (command !== exePath.trim().toLowerCase()) return false
+
+  const argMatches = [...actions.matchAll(/<Arguments>([\s\S]*?)<\/Arguments>/gi)]
+  if (argMatches.length > 1) return false
+  const args = argMatches.length === 1 ? decodeXmlEntities(argMatches[0][1].trim()) : ''
+  return args === expectedArgs.trim()
 }
 
 const EXE = 'C:\\Program Files\\Kudu\\Kudu.exe'
+const ARGS = '--startup'
 
-function taskXml(...commands: string[]): string {
+/** Wrap raw action XML in the surrounding task document. */
+function withActions(actionsInner: string): string {
   return [
     '<?xml version="1.0" encoding="UTF-16"?>',
     '<Task version="1.2">',
     '  <Actions Context="Author">',
-    ...commands.map((c) => `    <Exec><Command>${c}</Command><Arguments>--startup</Arguments></Exec>`),
+    actionsInner,
     '  </Actions>',
     '</Task>',
   ].join('\r\n')
 }
 
-describe('registeredCommandMatches', () => {
+function execAction(command: string, args: string | null = ARGS): string {
+  const argLine = args === null ? '' : `<Arguments>${args}</Arguments>`
+  return `    <Exec><Command>${command}</Command>${argLine}</Exec>`
+}
+
+describe('registeredTaskMatches', () => {
   it('accepts the task we meant to register', () => {
-    expect(registeredCommandMatches(taskXml(EXE), EXE)).toBe(true)
+    expect(registeredTaskMatches(withActions(execAction(EXE)), EXE, ARGS)).toBe(true)
   })
 
   it('accepts a command Task Scheduler echoed back quoted', () => {
-    expect(registeredCommandMatches(taskXml(`"${EXE}"`), EXE)).toBe(true)
+    expect(registeredTaskMatches(withActions(execAction(`"${EXE}"`)), EXE, ARGS)).toBe(true)
   })
 
   it('accepts a path whose ampersand came back XML-escaped', () => {
     const exe = 'C:\\Tools\\R&D\\Kudu.exe'
-    expect(registeredCommandMatches(taskXml('C:\\Tools\\R&amp;D\\Kudu.exe'), exe)).toBe(true)
+    expect(registeredTaskMatches(withActions(execAction('C:\\Tools\\R&amp;D\\Kudu.exe')), exe, ARGS)).toBe(true)
   })
 
   it('ignores case, which Windows paths do', () => {
-    expect(registeredCommandMatches(taskXml(EXE.toUpperCase()), EXE)).toBe(true)
-  })
-
-  it('tolerates surrounding whitespace', () => {
-    expect(registeredCommandMatches(taskXml(`\r\n      ${EXE}\r\n    `), EXE)).toBe(true)
+    expect(registeredTaskMatches(withActions(execAction(EXE.toUpperCase())), EXE, ARGS)).toBe(true)
   })
 
   it('rejects a substituted command', () => {
-    expect(registeredCommandMatches(taskXml('C:\\attacker\\backdoor.exe'), EXE)).toBe(false)
-  })
-
-  it('rejects a payload appended after a legitimate entry', () => {
-    // Checking only the first <Command> would pass this — an injected XML can
-    // declare more than one Exec action and Task Scheduler runs them all.
-    expect(registeredCommandMatches(taskXml(EXE, 'C:\\attacker\\backdoor.exe'), EXE)).toBe(false)
-  })
-
-  it('rejects a payload placed before the legitimate entry', () => {
-    expect(registeredCommandMatches(taskXml('C:\\attacker\\backdoor.exe', EXE), EXE)).toBe(false)
-  })
-
-  it('rejects a definition with no command at all', () => {
-    expect(registeredCommandMatches('<Task version="1.2"><Actions /></Task>', EXE)).toBe(false)
-  })
-
-  it('rejects empty output, so a failed query is not read as success', () => {
-    expect(registeredCommandMatches('', EXE)).toBe(false)
+    expect(registeredTaskMatches(withActions(execAction('C:\\attacker\\backdoor.exe')), EXE, ARGS)).toBe(false)
   })
 
   it('rejects a command that merely starts with our path', () => {
-    expect(registeredCommandMatches(taskXml(EXE + '.evil.exe'), EXE)).toBe(false)
+    expect(registeredTaskMatches(withActions(execAction(EXE + '.evil.exe')), EXE, ARGS)).toBe(false)
+  })
+
+  // Matching the command alone is not enough — Task Scheduler runs the whole
+  // action, and the arguments decide what our own binary does.
+  it('rejects altered arguments that would turn our binary into a debug server', () => {
+    const xml = withActions(execAction(EXE, '--startup --inspect-brk=0.0.0.0:9229'))
+    expect(registeredTaskMatches(xml, EXE, ARGS)).toBe(false)
+  })
+
+  it('rejects arguments that were stripped entirely', () => {
+    expect(registeredTaskMatches(withActions(execAction(EXE, null)), EXE, ARGS)).toBe(false)
+  })
+
+  it('rejects a second Arguments element smuggled into the action', () => {
+    const xml = withActions(
+      `    <Exec><Command>${EXE}</Command><Arguments>${ARGS}</Arguments><Arguments>--inspect</Arguments></Exec>`
+    )
+    expect(registeredTaskMatches(xml, EXE, ARGS)).toBe(false)
+  })
+
+  // A definition can run things without naming a command at all.
+  it('rejects a ComHandler action added alongside ours', () => {
+    const xml = withActions(
+      execAction(EXE) + '\r\n    <ComHandler><ClassId>{00000000-0000-0000-0000-000000000000}</ClassId></ComHandler>'
+    )
+    expect(registeredTaskMatches(xml, EXE, ARGS)).toBe(false)
+  })
+
+  it('rejects a lone ComHandler action', () => {
+    const xml = withActions('    <ComHandler><ClassId>{11111111-2222-3333-4444-555555555555}</ClassId></ComHandler>')
+    expect(registeredTaskMatches(xml, EXE, ARGS)).toBe(false)
+  })
+
+  it('rejects a payload appended after a legitimate entry', () => {
+    const xml = withActions(execAction(EXE) + '\r\n' + execAction('C:\\attacker\\backdoor.exe'))
+    expect(registeredTaskMatches(xml, EXE, ARGS)).toBe(false)
+  })
+
+  it('rejects a payload placed before the legitimate entry', () => {
+    const xml = withActions(execAction('C:\\attacker\\backdoor.exe') + '\r\n' + execAction(EXE))
+    expect(registeredTaskMatches(xml, EXE, ARGS)).toBe(false)
+  })
+
+  it('rejects a definition with no actions block', () => {
+    expect(registeredTaskMatches('<Task version="1.2" />', EXE, ARGS)).toBe(false)
+  })
+
+  it('rejects an empty actions block', () => {
+    expect(registeredTaskMatches(withActions(''), EXE, ARGS)).toBe(false)
+  })
+
+  // A query that returns nothing must not read as a pass — the caller treats a
+  // failed or empty verification the same as a mismatch and deletes the task.
+  it('rejects empty output', () => {
+    expect(registeredTaskMatches('', EXE, ARGS)).toBe(false)
+  })
+
+  it('rejects unparseable output', () => {
+    expect(registeredTaskMatches('ERROR: The system cannot find the file specified.', EXE, ARGS)).toBe(false)
   })
 })


### PR DESCRIPTION
Triage of the four advisories still open after #281. Three are real and fixed; one does not work as reported but the pattern is removed anyway.

Each finding was verified against the code before writing a fix — two of these reports are badly garbled (`O_NODspecies`, `bustler-authored`, "the projectile time", "confessed deputy"), and one is a resubmission with an inflated score, so none were taken at face value.

## GHSA-rwrp-2jqw-f349 — File shredder TOCTOU — REAL, fixed

`shredFile` lstat'd the path to reject symlinks, then opened the same path again. `open()` follows symlinks. The docstring claimed *"Uses lstat to avoid following symlinks"* — precisely the guarantee the second path resolution gives up.

Anything able to write to the target directory can swap the file for a symlink between the two resolutions and redirect the elevated shredder onto a file it could not otherwise touch. The caller then `rm`s whatever `shredFile` leaves behind, so the substituted file is overwritten with random bytes *and* deleted.

Fixed with bigint stats for exact inode comparison, `O_NOFOLLOW` where the platform has it, and an fstat check of the opened handle before any write. A mismatch **throws** rather than returns — a silent skip would still fall through to the caller's `rm`, which is the half of the attack that destroys data.

## GHSA-r8xh-jffv-g97f — Task Scheduler XML TOCTOU — REAL, fixed

The task XML went to `%LOCALAPPDATA%\Temp` under a fixed name, then to `schtasks`. Any process running as this user — including non-elevated — can write there; schtasks reads it back elevated; the task carries `RunLevel HighestAvailable`. Winning that race registers an attacker's command as a logon-triggered admin task: UAC bypass with persistence.

The existing `/Query` checked only that *a* task existed, not what it would run, so a swapped definition passed verification.

Now written to a fresh `mkdtemp` directory under a random name, then the registered definition is queried back and **every** `<Command>` it declares must be our executable — an injected XML can carry more than one `Exec` action, so checking the first would miss a payload appended after a legitimate entry. On mismatch the task is deleted and the operation fails.

One correction to the report: it rates exploit reliability low based on a "~10–50 ms race". That understates it — oplocks let an attacker hold this kind of race open deterministically. The narrowed window is not the fix; the post-registration check is.

## GHSA-3wrv-rv55-rj28 — Command flood — REAL, fixed

Parallel-safe commands were exempt from both the concurrency check and the rate limit. But "parallel-safe" means *won't corrupt state if overlapped*, not *cheap* — `scan` walks the whole disk. Repeating it stacks unbounded concurrent scans, and because mutating commands refuse to start while anything is running, the flood also starves them.

Capped at 4 concurrent, with a second between repeats of the same parallel-safe type, keyed per type so a burst of scans can't crowd out an unrelated `get-status`.

Lower severity than the report's framing — it needs a valid device key — but the same gap is reachable by an over-eager dashboard retry loop with no attacker involved, which is the better argument for fixing it.

## GHSA-w7p3-hr79-c3vv — AppleScript injection — NOT EXPLOITABLE as reported

The report's core premise is wrong. It claims `$(...)` and backticks are "interpreted by AppleScript's `do shell script`" inside the interpolated name. They aren't — those are shell constructs, AppleScript performs no command substitution inside a string literal, and the name never reaches `do shell script`. The PoC creates a login item literally named `$(osascript ...)`; toggling it runs `delete login item "$(osascript ...)"`, which just looks for an item by that literal name. Stripping `\` and `"` does block the only real escape, which is terminating the string.

Removed the pattern regardless. Splicing untrusted text into script source is one refactor away from being exploitable, and the sanitiser has a real correctness bug today: it silently rewrites legitimate names, so an item whose name contains a quote gets created under a different name, or the wrong item gets deleted. Names now pass as an argv value read via `on run argv`, so they are never parsed as code and arrive intact.

## Testing

- `npm test` — **2418 pass, 107 files** (was 2367/104).
- 51 new tests: shredder identity verification (inode / device / file-type / size mismatch, and that a refusal does not delete), the task-XML verifier (quoted and entity-escaped paths, multi-`Exec` payloads before and after the legitimate entry, empty query output), and the admission gate (cap, per-type spacing, mutating lock unaffected).
- Existing shredder mocks updated for the bigint/fstat contract.
- Typecheck error count unchanged from baseline (204, all pre-existing in test files).

## Not fixed here

`--api-key` in argv exposes the key via process listing ([cli.ts:446](src/main/cli.ts#L446)) — real, from the first report, wants its own change.
