### PR TITLE
feat(window): remember window size and position across restarts

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import { IPC } from '../shared/channels'
 import { t } from './i18n'
 import { registerCleanerIpc } from './ipc'
 import { getSettings } from './services/settings-store'
+import { loadWindowState, trackWindowState, MIN_WINDOW_WIDTH, MIN_WINDOW_HEIGHT } from './services/window-state'
 import { startScheduler, stopScheduler, getNextScanTime, notifyScheduledScanComplete, completeScheduleRun } from './services/scheduler'
 import { initAutoUpdater } from './services/auto-updater'
 import { attachRendererDiagnostics } from './services/renderer-diagnostics'
@@ -321,16 +322,24 @@ function destroyTray(): void {
 
 function createWindow(): void {
   const { width: screenWidth, height: screenHeight } = screen.getPrimaryDisplay().workAreaSize
-  const width = Math.round(screenWidth * 0.75)
-  const height = Math.round(screenHeight * 0.8)
+  const defaultWidth = Math.round(screenWidth * 0.75)
+  const defaultHeight = Math.round(screenHeight * 0.8)
+
+  // Reopen at the size/position the user left the window at (issue #270).
+  const { width, height, x, y, isMaximized } = loadWindowState({
+    width: defaultWidth,
+    height: defaultHeight
+  })
 
   const icon = nativeImage.createFromPath(getIconPath())
 
   mainWindow = new BrowserWindow({
     width,
     height,
-    minWidth: 900,
-    minHeight: 600,
+    // Omitted when no saved position survived validation, so Electron centres.
+    ...(x !== undefined && y !== undefined ? { x, y } : {}),
+    minWidth: MIN_WINDOW_WIDTH,
+    minHeight: MIN_WINDOW_HEIGHT,
     frame: false,
     backgroundColor: '#09090b',
     icon,
@@ -346,6 +355,12 @@ function createWindow(): void {
       sandbox: !isRoot
     }
   })
+
+  // Maximize before first paint so the window never flashes at its restored
+  // size; getNormalBounds() keeps the un-maximized geometry for later.
+  if (isMaximized) mainWindow.maximize()
+
+  trackWindowState(mainWindow)
 
   const settings = getSettings()
   // Detect startup launch: --startup flag (Windows Task Scheduler / Linux),

--- a/src/main/services/settings-store.persistence.test.ts
+++ b/src/main/services/settings-store.persistence.test.ts
@@ -18,7 +18,7 @@ vi.mock('electron', () => ({
   },
 }))
 
-import { setSettings, getSettings, flushSettings, updateRegistryIgnoredTweaks, getMalwareAllowlist, addMalwareAllowlistEntry, removeMalwareAllowlistEntry } from './settings-store'
+import { setSettings, getSettings, flushSettings, updateRegistryIgnoredTweaks, getMalwareAllowlist, addMalwareAllowlistEntry, removeMalwareAllowlistEntry, getWindowState, setWindowState } from './settings-store'
 import type { MalwareAllowlistEntry } from '../../shared/types'
 
 describe('settings persistence — game mode toggle round-trip (issue #172)', () => {
@@ -90,6 +90,38 @@ describe('settings persistence — game mode toggle round-trip (issue #172)', ()
     updateRegistryIgnoredTweaks([a], false)
     await flushSettings()
     expect(getSettings().registryIgnoredTweaks).toEqual([b])
+  })
+})
+
+describe('window geometry persistence (issue #270)', () => {
+  afterAll(() => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true, force: true })
+  })
+
+  it('has no window state on a fresh install', () => {
+    expect(getWindowState()).toBeNull()
+  })
+
+  it('survives a simulated restart', async () => {
+    await setWindowState({ x: 120, y: 80, width: 1310, height: 880, isMaximized: false })
+    expect(getWindowState()).toEqual({ x: 120, y: 80, width: 1310, height: 880, isMaximized: false })
+  })
+
+  it('replaces the previous geometry rather than merging with it', async () => {
+    await setWindowState({ width: 1000, height: 640, isMaximized: true })
+    const state = getWindowState()
+    expect(state).toEqual({ width: 1000, height: 640, isMaximized: true })
+    // A later save without a position must not resurrect the stale one.
+    expect(state?.x).toBeUndefined()
+  })
+
+  it('does not clobber a concurrent settings write', async () => {
+    setSettings({ minimizeToTray: true })
+    void setWindowState({ x: 5, y: 5, width: 1200, height: 700, isMaximized: false })
+    await flushSettings()
+
+    expect(getSettings().minimizeToTray).toBe(true)
+    expect(getWindowState()).toMatchObject({ width: 1200, height: 700 })
   })
 })
 

--- a/src/main/services/settings-store.ts
+++ b/src/main/services/settings-store.ts
@@ -2,7 +2,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs'
 import { join } from 'path'
 import { app, safeStorage } from 'electron'
 import { randomUUID } from 'crypto'
-import type { KuduSettings, AppStats, ScheduleEntry, ScheduleTaskType, MalwareAllowlistEntry, WindowsPackageManager } from '../../shared/types'
+import type { KuduSettings, AppStats, ScheduleEntry, ScheduleTaskType, MalwareAllowlistEntry, WindowsPackageManager, WindowState } from '../../shared/types'
 
 let _dataDir: string | null = null
 let _configPath: string | null = null
@@ -28,11 +28,14 @@ interface StoreData {
   stats: AppStats
   onboardingComplete: boolean
   machineId: string
+  /** Last known main-window geometry; null until the window is first sized. */
+  windowState: WindowState | null
 }
 
 const defaults: StoreData = {
   machineId: '',
   onboardingComplete: false,
+  windowState: null,
   settings: {
     theme: 'dark' as const,
     language: 'en',
@@ -341,6 +344,30 @@ export function removeMalwareAllowlistEntry(sha256: string): Promise<void> {
     try {
       const data = readStore()
       data.settings.malwareAllowlist = (data.settings.malwareAllowlist ?? []).filter((e) => e.sha256 !== sha256)
+      writeStore(data)
+    } finally {
+      unlock!()
+    }
+  })
+}
+
+/** Read the last persisted main-window geometry (null on first run). */
+export function getWindowState(): WindowState | null {
+  return readStore().windowState ?? null
+}
+
+/**
+ * Persist the main-window geometry within the write lock so a resize landing
+ * at the same time as a settings write can't clobber either one.
+ */
+export function setWindowState(state: WindowState): Promise<void> {
+  const prev = writeLock
+  let unlock: () => void
+  writeLock = new Promise<void>((r) => { unlock = r })
+  return prev.then(() => {
+    try {
+      const data = readStore()
+      data.windowState = state
       writeStore(data)
     } finally {
       unlock!()

--- a/src/main/services/window-state.test.ts
+++ b/src/main/services/window-state.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { EventEmitter } from 'events'
+import type { WindowState } from '../../shared/types'
+
+const savedStates: WindowState[] = []
+let storedState: WindowState | null = null
+let readThrows = false
+
+vi.mock('electron', () => ({
+  screen: {
+    getAllDisplays: () => displays,
+  },
+}))
+
+vi.mock('./settings-store', () => ({
+  getWindowState: () => {
+    if (readThrows) throw new Error('config unreadable')
+    return storedState
+  },
+  setWindowState: (s: WindowState) => {
+    savedStates.push(s)
+    return Promise.resolve()
+  },
+}))
+
+import {
+  sanitizeWindowState,
+  loadWindowState,
+  trackWindowState,
+  MIN_WINDOW_WIDTH,
+  MIN_WINDOW_HEIGHT,
+} from './window-state'
+
+const display = (x: number, y: number, width: number, height: number) => ({
+  workArea: { x, y, width, height },
+})
+
+const LAPTOP = display(0, 0, 1920, 1040)
+let displays = [LAPTOP]
+
+const FALLBACK = { width: 1440, height: 832 }
+
+describe('sanitizeWindowState (issue #270)', () => {
+  it('falls back to the default size when nothing was ever saved', () => {
+    expect(sanitizeWindowState(null, [LAPTOP], FALLBACK)).toEqual({
+      width: 1440,
+      height: 832,
+      isMaximized: false,
+    })
+  })
+
+  it('restores a previously saved size and position verbatim', () => {
+    const saved = { width: 1200, height: 700, x: 100, y: 60, isMaximized: false }
+    expect(sanitizeWindowState(saved, [LAPTOP], FALLBACK)).toEqual(saved)
+  })
+
+  it('restores the maximized flag', () => {
+    const state = sanitizeWindowState(
+      { width: 1200, height: 700, x: 10, y: 10, isMaximized: true },
+      [LAPTOP],
+      FALLBACK
+    )
+    expect(state.isMaximized).toBe(true)
+  })
+
+  it('clamps a size below the window minimums', () => {
+    const state = sanitizeWindowState({ width: 300, height: 200, isMaximized: false }, [LAPTOP], FALLBACK)
+    expect(state.width).toBe(MIN_WINDOW_WIDTH)
+    expect(state.height).toBe(MIN_WINDOW_HEIGHT)
+  })
+
+  it('shrinks a size saved on a larger display to fit the current one', () => {
+    // Saved on a 4K monitor, reopened on the laptop screen.
+    const state = sanitizeWindowState(
+      { width: 3400, height: 1900, x: 0, y: 0, isMaximized: false },
+      [LAPTOP],
+      FALLBACK
+    )
+    expect(state.width).toBe(1920)
+    expect(state.height).toBe(1040)
+  })
+
+  it('drops a position left behind by an unplugged monitor', () => {
+    const state = sanitizeWindowState(
+      { width: 1200, height: 700, x: 2600, y: 300, isMaximized: false },
+      [LAPTOP],
+      FALLBACK
+    )
+    expect(state.x).toBeUndefined()
+    expect(state.y).toBeUndefined()
+    // The size the user chose is still worth keeping.
+    expect(state).toMatchObject({ width: 1200, height: 700 })
+  })
+
+  it('keeps a position on a secondary display placed left of the primary', () => {
+    const secondary = display(-1920, 0, 1920, 1040)
+    const state = sanitizeWindowState(
+      { width: 1200, height: 700, x: -1500, y: 120, isMaximized: false },
+      [LAPTOP, secondary],
+      FALLBACK
+    )
+    expect(state).toMatchObject({ x: -1500, y: 120 })
+  })
+
+  it('drops a position that leaves only a sliver of the window on-screen', () => {
+    // 40px of the window pokes onto the display — not enough to grab the
+    // frameless drag bar with.
+    const state = sanitizeWindowState(
+      { width: 1200, height: 700, x: 1880, y: 200, isMaximized: false },
+      [LAPTOP],
+      FALLBACK
+    )
+    expect(state.x).toBeUndefined()
+  })
+
+  it('ignores a corrupt or partially written record', () => {
+    for (const bad of [
+      { width: Number.NaN, height: 700, isMaximized: false },
+      { width: -1200, height: 700, isMaximized: false },
+      { width: 1200, isMaximized: false },
+      {},
+    ]) {
+      expect(sanitizeWindowState(bad as Partial<WindowState>, [LAPTOP], FALLBACK)).toMatchObject(FALLBACK)
+    }
+  })
+
+  it('ignores a position with a missing or non-numeric coordinate', () => {
+    const state = sanitizeWindowState(
+      { width: 1200, height: 700, x: 100, y: Number.NaN, isMaximized: false },
+      [LAPTOP],
+      FALLBACK
+    )
+    expect(state.x).toBeUndefined()
+    expect(state.y).toBeUndefined()
+  })
+
+  it('accepts a position at the origin', () => {
+    const state = sanitizeWindowState(
+      { width: 1200, height: 700, x: 0, y: 0, isMaximized: false },
+      [LAPTOP],
+      FALLBACK
+    )
+    expect(state).toMatchObject({ x: 0, y: 0 })
+  })
+})
+
+describe('loadWindowState', () => {
+  beforeEach(() => {
+    storedState = null
+    readThrows = false
+    displays = [LAPTOP]
+  })
+
+  it('reads the persisted state through the settings store', () => {
+    storedState = { width: 1100, height: 720, x: 40, y: 40, isMaximized: false }
+    expect(loadWindowState(FALLBACK)).toEqual(storedState)
+  })
+
+  it('falls back to the default size when the config cannot be read', () => {
+    readThrows = true
+    expect(loadWindowState(FALLBACK)).toEqual({ ...FALLBACK, isMaximized: false })
+  })
+})
+
+/** Minimal stand-in for the bits of BrowserWindow that trackWindowState uses. */
+class FakeWindow extends EventEmitter {
+  destroyed = false
+  minimized = false
+  fullScreen = false
+  maximized = false
+  normalBounds = { x: 20, y: 30, width: 1200, height: 700 }
+
+  isDestroyed = (): boolean => this.destroyed
+  isMinimized = (): boolean => this.minimized
+  isFullScreen = (): boolean => this.fullScreen
+  isMaximized = (): boolean => this.maximized
+  getNormalBounds = (): { x: number; y: number; width: number; height: number } => this.normalBounds
+}
+
+function track(): FakeWindow {
+  const win = new FakeWindow()
+  trackWindowState(win as unknown as import('electron').BrowserWindow)
+  return win
+}
+
+describe('trackWindowState', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    savedStates.length = 0
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('persists the new geometry after a resize settles', () => {
+    const win = track()
+    win.normalBounds = { x: 20, y: 30, width: 1310, height: 880 }
+    win.emit('resize')
+
+    expect(savedStates).toHaveLength(0) // debounced, not written mid-drag
+    vi.runAllTimers()
+
+    expect(savedStates).toEqual([{ x: 20, y: 30, width: 1310, height: 880, isMaximized: false }])
+  })
+
+  it('coalesces a drag-resize into a single write', () => {
+    const win = track()
+    for (let i = 0; i < 25; i++) {
+      win.normalBounds = { x: 20, y: 30, width: 1000 + i, height: 700 }
+      win.emit('resize')
+      vi.advanceTimersByTime(16)
+    }
+    vi.runAllTimers()
+
+    expect(savedStates).toHaveLength(1)
+    expect(savedStates[0].width).toBe(1024)
+  })
+
+  it('persists a move', () => {
+    const win = track()
+    win.normalBounds = { x: 400, y: 250, width: 1200, height: 700 }
+    win.emit('move')
+    vi.runAllTimers()
+
+    expect(savedStates[0]).toMatchObject({ x: 400, y: 250 })
+  })
+
+  it('records the maximized flag alongside the restore size', () => {
+    const win = track()
+    win.maximized = true
+    win.emit('maximize')
+    vi.runAllTimers()
+
+    expect(savedStates[0]).toEqual({ x: 20, y: 30, width: 1200, height: 700, isMaximized: true })
+  })
+
+  it('writes the final geometry on close without waiting for the debounce', () => {
+    const win = track()
+    win.normalBounds = { x: 20, y: 30, width: 1500, height: 900 }
+    win.emit('resize')
+    win.emit('close')
+
+    expect(savedStates).toEqual([{ x: 20, y: 30, width: 1500, height: 900, isMaximized: false }])
+
+    // The pending debounce must not fire a second, redundant write.
+    vi.runAllTimers()
+    expect(savedStates).toHaveLength(1)
+  })
+
+  it('does not save transient minimized or fullscreen geometry', () => {
+    const win = track()
+    win.minimized = true
+    win.emit('resize')
+    vi.runAllTimers()
+    expect(savedStates).toHaveLength(0)
+
+    win.minimized = false
+    win.fullScreen = true
+    win.emit('resize')
+    vi.runAllTimers()
+    expect(savedStates).toHaveLength(0)
+  })
+
+  it('does not touch the store once the window is destroyed', () => {
+    const win = track()
+    win.emit('resize')
+    win.destroyed = true
+    vi.runAllTimers()
+    expect(savedStates).toHaveLength(0)
+  })
+
+  it('ignores a bogus zero-sized measurement', () => {
+    const win = track()
+    win.normalBounds = { x: 0, y: 0, width: 0, height: 0 }
+    win.emit('resize')
+    vi.runAllTimers()
+    expect(savedStates).toHaveLength(0)
+  })
+})

--- a/src/main/services/window-state.ts
+++ b/src/main/services/window-state.ts
@@ -1,0 +1,135 @@
+import { screen } from 'electron'
+import type { BrowserWindow, Rectangle } from 'electron'
+import { getWindowState, setWindowState } from './settings-store'
+import type { WindowState } from '../../shared/types'
+
+// Kept here rather than inline in createWindow so the restore clamp and the
+// BrowserWindow constraint can never drift apart.
+export const MIN_WINDOW_WIDTH = 900
+export const MIN_WINDOW_HEIGHT = 600
+
+// Resize/move fire continuously while dragging — coalesce them into one write.
+const SAVE_DEBOUNCE_MS = 400
+
+// How much of the window must overlap a display's work area for the saved
+// position to be reused.  A monitor that was unplugged (or a resolution
+// change) can leave the window entirely off-screen with no way to drag it
+// back — this window is frameless, so the drag handle goes with it.
+const MIN_VISIBLE_PX = 80
+
+interface DisplayLike {
+  workArea: Rectangle
+}
+
+function isFinitePositive(n: unknown): n is number {
+  return typeof n === 'number' && Number.isFinite(n) && n > 0
+}
+
+function isFiniteCoord(n: unknown): n is number {
+  return typeof n === 'number' && Number.isFinite(n)
+}
+
+/** True when enough of `bounds` lands on some display to remain grabbable. */
+function isReachable(bounds: Rectangle, displays: DisplayLike[]): boolean {
+  return displays.some(({ workArea: wa }) => {
+    const overlapX = Math.min(bounds.x + bounds.width, wa.x + wa.width) - Math.max(bounds.x, wa.x)
+    const overlapY = Math.min(bounds.y + bounds.height, wa.y + wa.height) - Math.max(bounds.y, wa.y)
+    return overlapX >= MIN_VISIBLE_PX && overlapY >= MIN_VISIBLE_PX
+  })
+}
+
+/**
+ * Turn whatever is on disk into bounds that are safe to hand to
+ * BrowserWindow: sized within the min constraints and the largest available
+ * display, and positioned only if that position is still on-screen.
+ *
+ * Exported (and display-injected) so the restore rules can be tested without
+ * a real Electron screen.
+ */
+export function sanitizeWindowState(
+  saved: Partial<WindowState> | null | undefined,
+  displays: DisplayLike[],
+  fallback: { width: number; height: number }
+): WindowState {
+  if (!saved || !isFinitePositive(saved.width) || !isFinitePositive(saved.height)) {
+    return { ...fallback, isMaximized: saved?.isMaximized === true }
+  }
+
+  // Never restore bigger than the roomiest display — a window saved on a 4K
+  // monitor must still fit after switching to a laptop screen.
+  const maxWidth = Math.max(...displays.map((d) => d.workArea.width), MIN_WINDOW_WIDTH)
+  const maxHeight = Math.max(...displays.map((d) => d.workArea.height), MIN_WINDOW_HEIGHT)
+
+  const width = Math.round(Math.max(MIN_WINDOW_WIDTH, Math.min(saved.width, maxWidth)))
+  const height = Math.round(Math.max(MIN_WINDOW_HEIGHT, Math.min(saved.height, maxHeight)))
+  const state: WindowState = { width, height, isMaximized: saved.isMaximized === true }
+
+  if (isFiniteCoord(saved.x) && isFiniteCoord(saved.y)) {
+    const x = Math.round(saved.x)
+    const y = Math.round(saved.y)
+    if (isReachable({ x, y, width, height }, displays)) {
+      state.x = x
+      state.y = y
+    }
+  }
+
+  return state
+}
+
+/**
+ * Bounds to open the main window with: the last session's geometry when it is
+ * still usable, otherwise `fallback` (centred by Electron).
+ */
+export function loadWindowState(fallback: { width: number; height: number }): WindowState {
+  let saved: Partial<WindowState> | null = null
+  try {
+    saved = getWindowState()
+  } catch {
+    // Unreadable config — fall back to the default size rather than not opening.
+  }
+  return sanitizeWindowState(saved, screen.getAllDisplays(), fallback)
+}
+
+/**
+ * Record the window's geometry as the user changes it, and once more on close
+ * so a resize made in the final moments before quitting isn't lost.
+ */
+export function trackWindowState(win: BrowserWindow): void {
+  let timer: NodeJS.Timeout | null = null
+
+  const capture = (): void => {
+    if (win.isDestroyed()) return
+    // Minimized/fullscreen bounds describe a transient state, not something to
+    // reopen into — keep whatever was saved before entering it.
+    if (win.isMinimized() || win.isFullScreen()) return
+    const maximized = win.isMaximized()
+    // getNormalBounds() is the un-maximized geometry, so restoring a maximized
+    // window still knows what size to un-maximize back to.
+    const { x, y, width, height } = win.getNormalBounds()
+    if (!isFinitePositive(width) || !isFinitePositive(height)) return
+    void setWindowState({ x, y, width, height, isMaximized: maximized }).catch(() => {
+      // Best-effort — a failed geometry write must never break the window.
+    })
+  }
+
+  const schedule = (): void => {
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(() => {
+      timer = null
+      capture()
+    }, SAVE_DEBOUNCE_MS)
+  }
+
+  win.on('resize', schedule)
+  win.on('move', schedule)
+  win.on('maximize', schedule)
+  win.on('unmaximize', schedule)
+
+  win.on('close', () => {
+    if (timer) {
+      clearTimeout(timer)
+      timer = null
+    }
+    capture()
+  })
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -250,6 +250,20 @@ export interface ActivityEntry {
   spaceSaved?: number
 }
 
+/**
+ * Last known main-window geometry, persisted so a resized/moved window comes
+ * back the same way on the next launch.  `x`/`y` are omitted when the window
+ * has never been positioned explicitly (first run) or when the saved position
+ * no longer lands on a connected display.
+ */
+export interface WindowState {
+  width: number
+  height: number
+  x?: number
+  y?: number
+  isMaximized: boolean
+}
+
 export interface BloatwareApp {
   id: string
   name: string


### PR DESCRIPTION
Closes #270.

## Problem

`createWindow()` sized the window at 75% × 80% of the primary display on every launch, so any resize or move was discarded on quit.

## Change

Window geometry now persists in `config.json` under a new top-level `windowState` key and is restored on the next launch.

- **What's saved** — width, height, x, y, and the maximized flag. `getNormalBounds()` is used so a window closed while maximized reopens maximized *and* still un-maximizes back to the size the user chose.
- **When** — debounced 400 ms on `resize`/`move`/`maximize`/`unmaximize`, so a drag produces a single write, plus a final capture on `close` for a resize made moments before quitting. Minimized and fullscreen geometry is skipped — it's transient, not something to reopen into.
- **Validated before use** — the saved size is clamped to the existing 900×600 minimums and to the largest connected display (a size saved on a 4K monitor must still fit a laptop screen), and the position is dropped unless ≥80 px of the window overlaps some display's work area. Without that check, a window last used on a since-unplugged monitor would reopen off-screen with no way to recover it — the window is frameless, so its drag bar goes off-screen too. Dropping only the position keeps the size and lets Electron centre the window.
- **Corrupt/partial records** fall back to the current default size rather than failing to open.

The restore rules live in `sanitizeWindowState()` with displays injected, so they're testable without a real Electron screen.

## Tests

21 new tests in `window-state.test.ts` (restore, clamping, off-screen rejection, negative-coordinate secondary displays, debounce coalescing, close capture, minimized/fullscreen/destroyed guards) and 4 in `settings-store.persistence.test.ts` covering the round-trip through disk and the write lock.

`npm test` — 2443 passed. No new `tsc` errors.
