### PR TITLE
fix(release): repair changelog generation and fail loudly when it breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,49 @@
 # [1.48.0](https://github.com/adventdevinc/kudu/compare/v1.47.0...v1.48.0) (2026-08-03)
 
+
 ### Bug Fixes
 
-* triage and fix the four remaining open security advisories ([#283](https://github.com/adventdevinc/kudu/issues/283)) ([04a3c77](https://github.com/adventdevinc/kudu/commit/04a3c779b23488070b1e50e2f85c7490754de7ff))
 * **malware:** bind quarantine/delete to a real detection, gate remote quarantine ([#281](https://github.com/adventdevinc/kudu/issues/281)) ([6691097](https://github.com/adventdevinc/kudu/commit/66910978997f302d1b608d5a7a4e31900035c073))
+* triage and fix the four remaining open security advisories ([#283](https://github.com/adventdevinc/kudu/issues/283)) ([04a3c77](https://github.com/adventdevinc/kudu/commit/04a3c779b23488070b1e50e2f85c7490754de7ff))
 
 
 ### Features
 
-* **window:** remember window size and position across restarts ([#284](https://github.com/adventdevinc/kudu/issues/284)) ([582cacd](https://github.com/adventdevinc/kudu/commit/582cacd69f5f4adb40f8e00f319e9e22be7adc75))
 * **services:** allow re-enabling a disabled service ([#282](https://github.com/adventdevinc/kudu/issues/282)) ([3d8e955](https://github.com/adventdevinc/kudu/commit/3d8e955f073ae7b3ade0a3d4cabd7d219acdc3d4))
+* **window:** remember window size and position across restarts ([#284](https://github.com/adventdevinc/kudu/issues/284)) ([582cacd](https://github.com/adventdevinc/kudu/commit/582cacd69f5f4adb40f8e00f319e9e22be7adc75))
 # [1.47.0](https://github.com/adventdevinc/kudu/compare/v1.46.0...v1.47.0) (2026-07-27)
+
+
+### Bug Fixes
+
+* **browser-cleaner:** report Chromium caches the scan was silently dropping ([#265](https://github.com/adventdevinc/kudu/issues/265)) ([#266](https://github.com/adventdevinc/kudu/issues/266)) ([ac81503](https://github.com/adventdevinc/kudu/commit/ac8150380f5a2d5726afae93eace8444a0725d3e))
+* **build:** install per-machine so the Windows installer elevates ([#264](https://github.com/adventdevinc/kudu/issues/264)) ([#268](https://github.com/adventdevinc/kudu/issues/268)) ([f12ba9d](https://github.com/adventdevinc/kudu/commit/f12ba9dd9b1e1327cbf5764acbbeccee95510200))
 # [1.46.0](https://github.com/adventdevinc/kudu/compare/v1.45.0...v1.46.0) (2026-07-27)
+
+
+### Bug Fixes
+
+* **cli:** keep stdout parseable in JSON mode ([#257](https://github.com/adventdevinc/kudu/issues/257)) ([0af251b](https://github.com/adventdevinc/kudu/commit/0af251b18ea3bd2d159f6f64910b38c2c1875f07))
+* **driver-manager:** stop flagging installed drivers as stale duplicates ([#262](https://github.com/adventdevinc/kudu/issues/262)) ([c85e72d](https://github.com/adventdevinc/kudu/commit/c85e72d6e9461b7230c316738c90ae9d575ddc23))
+* **firewall:** stop the rule audit timing out and echoing its own script ([#259](https://github.com/adventdevinc/kudu/issues/259)) ([f1c3799](https://github.com/adventdevinc/kudu/commit/f1c37995d8bc310b9f98b28eb44bb849b0cf69c6))
+* **game-mode:** unblock activation when a restore step can never succeed ([#258](https://github.com/adventdevinc/kudu/issues/258)) ([e055e17](https://github.com/adventdevinc/kudu/commit/e055e174e4cc80bcd18183ec57670d50e464bfa7))
+* **gui:** don't let minimize-to-tray block app quit and OS shutdown ([#240](https://github.com/adventdevinc/kudu/issues/240)) ([252e3e4](https://github.com/adventdevinc/kudu/commit/252e3e446ad2d7c45969dfad57fb3cd1e59f8f24))
+* **registry:** stop deleting whole registry branches on a failed key parse ([#261](https://github.com/adventdevinc/kudu/issues/261)) ([106bb56](https://github.com/adventdevinc/kudu/commit/106bb562e34399b4c1cfb8101badce25f82583fc))
+* **startup:** stop listing programs that are no longer installed ([#260](https://github.com/adventdevinc/kudu/issues/260)) ([9c7567c](https://github.com/adventdevinc/kudu/commit/9c7567c7ff63e7a4c24b99f350d968edca2a7043))
+
+
+### Features
+
+* **cleaner:** opt-in log of deleted file paths ([#247](https://github.com/adventdevinc/kudu/issues/247)) ([#263](https://github.com/adventdevinc/kudu/issues/263)) ([7231707](https://github.com/adventdevinc/kudu/commit/72317074633e069d7b20b68ca19973c7e2c48581))
+* **updater:** aggregate Scoop & npm alongside winget/Chocolatey ([#227](https://github.com/adventdevinc/kudu/issues/227)) ([086c887](https://github.com/adventdevinc/kudu/commit/086c88792b4949e074ebe3643746b9cea5c7ac05))
 # [1.45.0](https://github.com/adventdevinc/kudu/compare/v1.44.1...v1.45.0) (2026-07-21)
+
+
+### Bug Fixes
+
+* **drivers:** respect Windows "driver updates disabled" policy and fix 0.0 MB display ([#228](https://github.com/adventdevinc/kudu/issues/228)) ([d8cde59](https://github.com/adventdevinc/kudu/commit/d8cde591a2abdc92de0b954cb8c75b992a681568))
+* **firewall-audit:** stop flagging known-good services as medium risk ([#226](https://github.com/adventdevinc/kudu/issues/226)) ([296ef94](https://github.com/adventdevinc/kudu/commit/296ef9476f3bc981d47e3a2b77b4249414bd9b3d))
+* **malware-scanner:** drop Heuristic.HiddenADS false positives ([#237](https://github.com/adventdevinc/kudu/issues/237)) ([50eac72](https://github.com/adventdevinc/kudu/commit/50eac72d2e51cd1618509427bbd4d6fbc4511698))
 ## [1.44.1](https://github.com/adventdevinc/kudu/compare/v1.44.0...v1.44.1) (2026-06-11)
 # [1.44.0](https://github.com/adventdevinc/kudu/compare/v1.43.0...v1.44.0) (2026-06-09)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,15 @@ npm run release -- patch|minor|major
 
 This handles everything: version bump, changelog generation, commit, tag, push, and triggers CI to build and publish.
 
+`conventional-changelog-angular` is pinned to `^8` as a direct devDependency even
+though nothing imports it. This is deliberate: commitlint depends on `^9`, which
+npm hoists to the top of `node_modules`, where `conventional-changelog`'s preset
+loader picks it up instead of the `^8` it needs — and v9 exports a shape v8's
+loader can't read, so changelog generation silently produces empty sections.
+Pinning `^8` as a direct dependency keeps the right version hoisted and pushes
+commitlint's copy into a nested folder. Don't remove it as unused. `npm ls
+conventional-changelog-angular` should show `8.x` at the top level.
+
 ## Testing
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.4",
         "ajv": "^8.18.0",
+        "conventional-changelog-angular": "^8.3.1",
         "conventional-changelog-cli": "^5.0.0",
         "electron": "^41.3.0",
         "electron-builder": "^26.8.1",
@@ -552,6 +553,19 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/parse/node_modules/conventional-changelog-angular": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-9.2.1.tgz",
+      "integrity": "sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@conventional-changelog/template": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@commitlint/read": {
@@ -3900,16 +3914,16 @@
       }
     },
     "node_modules/conventional-changelog-angular": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-9.2.1.tgz",
-      "integrity": "sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+      "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.2.1"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-atom": {
@@ -4131,19 +4145,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/conventional-changelog/node_modules/conventional-changelog-angular": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
-      "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "compare-func": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/conventional-changelog/node_modules/conventional-changelog-conventionalcommits": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
@@ -4155,16 +4156,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/conventional-commits-filter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
-      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/conventional-commits-parser": {
@@ -5645,33 +5636,6 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
-    "node_modules/git-raw-commits/node_modules/conventional-commits-filter": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
-      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/git-semver-tags": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-8.0.1.tgz",
@@ -5744,33 +5708,6 @@
       },
       "funding": {
         "url": "https://ko-fi.com/dangreen"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/conventional-commits-filter": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
-      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/github-from-package": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1579,9 +1579,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1597,9 +1594,6 @@
       "integrity": "sha512-PG0UmruaoV3k5gdhdciBCqwpr4xfPYJwhvuqXNRy+e0dH9u/i4rQl51YlecO607OP1sjTyDBWVmY+jdYoRJ4tA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1887,9 +1881,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1904,9 +1895,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1921,9 +1909,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1938,9 +1923,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1955,9 +1937,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1972,9 +1951,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1989,9 +1965,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2006,9 +1979,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2023,9 +1993,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2040,9 +2007,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2057,9 +2021,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2074,9 +2035,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2091,9 +2049,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2384,9 +2339,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2404,9 +2356,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2424,9 +2373,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2444,9 +2390,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2485,6 +2428,72 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.3",
@@ -5636,6 +5645,25 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/git-semver-tags": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-8.0.1.tgz",
@@ -5708,6 +5736,25 @@
       },
       "funding": {
         "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/git-semver-tags/node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/github-from-package": {
@@ -6596,9 +6643,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6620,9 +6664,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6644,9 +6685,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6668,9 +6706,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.4",
     "ajv": "^8.18.0",
+    "conventional-changelog-angular": "^8.3.1",
     "conventional-changelog-cli": "^5.0.0",
     "electron": "^41.3.0",
     "electron-builder": "^26.8.1",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const { execSync } = require('child_process')
-const { readFileSync } = require('fs')
+const { readFileSync, writeFileSync } = require('fs')
 
 const run = (cmd) => execSync(cmd, { stdio: 'inherit' })
 const capture = (cmd) => execSync(cmd, { encoding: 'utf-8' }).trim()
@@ -41,8 +41,50 @@ const tag = `v${version}`
 console.log(`\nBumped to ${tag}`)
 
 // 2. Generate changelog
+//
+// Work out first which commits the angular preset is expected to render, so the
+// check below can tell a broken generator apart from a release that genuinely
+// has nothing to announce (1.44.1 was chore-only, and its bare header is
+// correct). Only these types produce entries; chore/docs/style/test/ci do not.
+const RENDERED_TYPES = /^(feat|fix|perf|revert)(\(.+\))?!?:/
+const previousTag = capture('git describe --tags --abbrev=0 HEAD')
+const subjects = capture(`git log ${previousTag}..HEAD --no-merges --format=%s`)
+  .split('\n')
+  .filter(Boolean)
+const expectedEntries = subjects.filter((s) => RENDERED_TYPES.test(s))
+
+const changelogBefore = readFileSync('CHANGELOG.md', 'utf-8')
 run('npx conventional-changelog -p angular -i CHANGELOG.md -s')
-console.log('Changelog updated')
+
+// conventional-changelog exits 0 whether or not it found anything, so a broken
+// generator is silent. It broke once when a transitive dependency hoisted a
+// preset version the generator couldn't read, and four releases shipped with
+// empty notes before anyone noticed. Fail loudly instead.
+const changelogAfter = readFileSync('CHANGELOG.md', 'utf-8')
+const added = changelogAfter.slice(0, changelogAfter.length - changelogBefore.length)
+const wroteEntries = /^\s*[*-]\s+\S/m.test(added)
+
+if (expectedEntries.length > 0 && !wroteEntries) {
+  console.error(`\nError: changelog generation produced no entries for ${tag}.`)
+  console.error(`${expectedEntries.length} commit(s) since ${previousTag} should have appeared:\n`)
+  for (const s of expectedEntries) console.error(`  ${s}`)
+  console.error('\nWhat was written instead:\n')
+  console.error(added.trim() || '  (nothing)')
+  console.error('\nThis usually means the changelog preset failed to load. Check that the')
+  console.error('conventional-changelog-angular version hoisted to the top of node_modules')
+  console.error('is the one conventional-changelog depends on:\n')
+  console.error('  npm ls conventional-changelog-angular\n')
+  console.error('Nothing has been committed or pushed; reverting the version bump.')
+  writeFileSync('CHANGELOG.md', changelogBefore)
+  run('git checkout -- package.json package-lock.json')
+  process.exit(1)
+}
+
+if (expectedEntries.length === 0) {
+  console.log(`Changelog updated (no user-facing commits since ${previousTag})`)
+} else {
+  console.log(`Changelog updated (${expectedEntries.length} entr${expectedEntries.length === 1 ? 'y' : 'ies'})`)
+}
 
 // 3. Commit and tag
 run('git add package.json package-lock.json CHANGELOG.md')


### PR DESCRIPTION
Releases **1.45.0 through 1.48.0 shipped with empty changelog sections** — a version header with nothing under it. 1.48.0 was the security release, which is how this got noticed.

## Cause

`@commitlint/cli` depends on `conventional-changelog-angular@^9`, so npm hoists v9 to the top of `node_modules`. `conventional-changelog@6` needs `^8` and npm correctly nests `8.3.1` beneath it — but `conventional-changelog-preset-loader` resolves the preset by bare specifier *from its own top-level location*, so it walks up and finds the hoisted **v9**.

v9 exports `{commits, parser, writer, whatBump}`; v8's loader expects `{parserOpts, writerOpts}`. The writer therefore received no options and emitted no entries.

```
kudu@1.48.0
+-- @commitlint/cli@21.2.1
|  `-- ... `-- conventional-changelog-angular@9.2.1   <-- hoisted, wrongly picked up
`-- conventional-changelog-cli@5.0.0
   `-- conventional-changelog@6.0.0
      `-- conventional-changelog-angular@8.3.1        <-- correct, ignored
```

Worth stating plainly: **the parser was never the problem.** It parses these commits correctly — verified by running the stages by hand, where `git-raw-commits` yielded all 7 commits and the parser typed them all correctly. Only the writer stage was starved. That's why nothing ever looked broken.

## Fix

**Pin `conventional-changelog-angular@^8` as a direct devDependency.** The direct dependency wins hoisting, commitlint's `^9` moves to a nested folder, and both work. `conventional-changelog-cli@5.0.0` is already the newest release, so there's no upstream version to move to.

**Add a guard to `scripts/release.js`.** This is the part that matters — the dependency fix addresses this instance, the guard addresses the class. `conventional-changelog` exits 0 whether or not it found anything, which is why four releases went out unnoticed.

The guard compares what the angular preset *should* have rendered — commits typed `feat`/`fix`/`perf`/`revert` since the last tag — against what was actually written, and aborts before committing or tagging if entries were expected and none appeared, restoring `CHANGELOG.md` and the version bump on the way out.

My first attempt at this guard simply required at least one bullet, which was wrong: **1.44.1 was a legitimate chore-only release** whose empty section is correct, and that guard would have blocked it. Verified against real history:

| Release | Expected entries | Guard |
|---|---|---|
| 1.48.0 | 4 | active — would catch a silent failure |
| 1.47.0 | 2 | active — **would have blocked the broken release** |
| 1.44.1 | 0 | inactive — correctly allows the empty section |

## Backfill

1.45.0, 1.46.0 and 1.47.0 regenerated from git history. The hand-written 1.48.0 entry is replaced with generated output so the file is uniform. 1.44.1 is left alone — it genuinely had only `chore(deps)` commits.

## Verification

- Generation produces correct output again; reintroducing v9 with `npm install --no-save` reproduces the empty result, and the guard rejects it.
- commitlint still passes valid messages and rejects invalid ones on its nested v9.
- `npm test` — 2455 pass, 108 files.

## Note

The `conventional-changelog-angular` pin looks like an unused dependency and invites removal. Documented in [CLAUDE.md](CLAUDE.md) with the reasoning, and the guard's failure message points at `npm ls conventional-changelog-angular`.
