### PR TITLE
fix(onboarding): persist completion before applying preferences (#269)

### DIFF
--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -162,6 +162,8 @@ export function registerCleanerIpc(getWindow: WindowGetter): void {
   ipcMain.handle(IPC.ONBOARDING_GET, () => getOnboardingComplete())
   ipcMain.handle(IPC.ONBOARDING_SET, async (_event, value: boolean) => {
     if (typeof value !== 'boolean') return
+    // Rejects if the write failed — the renderer logs that, so a wizard that
+    // keeps reappearing leaves evidence behind (issue #269).
     await setOnboardingComplete(value)
   })
 

--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -2053,8 +2053,14 @@ export function registerMalwareScannerIpc(getWindow: WindowGetter): void {
 
   ipcMain.handle(IPC.MALWARE_ALLOWLIST_REMOVE, async (_event, sha256: string) => {
     if (typeof sha256 !== 'string' || !sha256) return false
-    await removeMalwareAllowlistEntry(sha256)
-    return true
+    // The store rejects when the write failed — report that as false rather
+    // than telling the UI the entry is gone when it is still on disk.
+    try {
+      await removeMalwareAllowlistEntry(sha256)
+      return true
+    } catch {
+      return false
+    }
   })
 
   ipcMain.handle(IPC.MALWARE_YARA_INFO, () => getYaraRulesInfo())

--- a/src/main/services/settings-store.onboarding.test.ts
+++ b/src/main/services/settings-store.onboarding.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterAll, vi } from 'vitest'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { rmSync, mkdirSync, existsSync, readFileSync, readdirSync } from 'fs'
+import { rmSync, mkdirSync, existsSync, readFileSync, writeFileSync, readdirSync } from 'fs'
 import { randomUUID } from 'crypto'
 
 const TEST_DIR = join(tmpdir(), `kudu-test-${randomUUID()}`)
@@ -72,6 +72,18 @@ describe('onboarding completion persistence (issue #269)', () => {
     expect(onDisk().machineId).toBe(id)
     // Stable across calls — a second read must not mint a new one.
     expect(getMachineId()).toBe(id)
+  })
+
+  it('clears the legacy stats block that never tracked anything', async () => {
+    const config = JSON.parse(readFileSync(CONFIG_PATH, 'utf-8'))
+    config.stats = { totalSpaceSaved: 0, totalFilesCleaned: 0, totalScans: 0, lastScanDate: null, recentActivity: [] }
+    writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2), 'utf-8')
+
+    setSettings({ theme: 'dark' })
+    await flushSettings()
+
+    expect(onDisk()).not.toHaveProperty('stats')
+    expect(onDisk().onboardingComplete).toBe(true)
   })
 
   it('reports a failed write instead of resolving as if it saved', async () => {

--- a/src/main/services/settings-store.onboarding.test.ts
+++ b/src/main/services/settings-store.onboarding.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, afterAll, vi } from 'vitest'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { rmSync, mkdirSync, existsSync, readFileSync, readdirSync } from 'fs'
+import { randomUUID } from 'crypto'
+
+const TEST_DIR = join(tmpdir(), `kudu-test-${randomUUID()}`)
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: () => TEST_DIR,
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => false,
+    encryptString: (s: string) => Buffer.from(s),
+    decryptString: (b: Buffer) => b.toString(),
+  },
+}))
+
+import {
+  setSettings,
+  flushSettings,
+  getSettings,
+  getOnboardingComplete,
+  setOnboardingComplete,
+  getMachineId,
+} from './settings-store'
+
+const DATA_DIR = join(TEST_DIR, 'Kudu-Dev')
+const CONFIG_PATH = join(DATA_DIR, 'config.json')
+const onDisk = (): any => JSON.parse(readFileSync(CONFIG_PATH, 'utf-8'))
+
+describe('onboarding completion persistence (issue #269)', () => {
+  afterAll(() => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true, force: true })
+  })
+
+  it('writes the flag through to disk, not just to the in-memory copy', async () => {
+    expect(getOnboardingComplete()).toBe(false)
+    await setOnboardingComplete(true)
+    expect(onDisk().onboardingComplete).toBe(true)
+    expect(getOnboardingComplete()).toBe(true)
+  })
+
+  it('keeps the flag through the wizard write order and the settings writes after it', async () => {
+    await setOnboardingComplete(false)
+
+    // Step 1 of the wizard persists the language on its own…
+    setSettings({ language: 'ar' })
+    await flushSettings()
+    // …the final step records completion, and the preference writes it kicks
+    // off land afterwards. None of them may take the flag back down.
+    await setOnboardingComplete(true)
+    setSettings({
+      runAtStartup: true,
+      minimizeToTray: true,
+      schedule: { enabled: true, frequency: 'weekly', day: 1, hour: 9 },
+    })
+    await flushSettings()
+
+    const after = onDisk()
+    expect(after.onboardingComplete).toBe(true)
+    expect(after.settings.language).toBe('ar')
+    expect(after.settings.runAtStartup).toBe(true)
+  })
+
+  it('generates and persists a machine id on first use', async () => {
+    const id = getMachineId()
+    await flushSettings()
+    expect(id).not.toBe('')
+    expect(onDisk().machineId).toBe(id)
+    // Stable across calls — a second read must not mint a new one.
+    expect(getMachineId()).toBe(id)
+  })
+
+  it('reports a failed write instead of resolving as if it saved', async () => {
+    // Stand a directory where config.json belongs: the rename onto it fails,
+    // which is the shape of the EPERM an antivirus scanner produces.
+    rmSync(CONFIG_PATH)
+    mkdirSync(CONFIG_PATH)
+    try {
+      await expect(setOnboardingComplete(true)).rejects.toBeDefined()
+    } finally {
+      rmSync(CONFIG_PATH, { recursive: true, force: true })
+    }
+
+    // A failed write must not wedge the queue for every write after it.
+    setSettings({ theme: 'light' })
+    await flushSettings()
+    expect(getSettings().theme).toBe('light')
+
+    // …and must not leave temp files behind.
+    expect(readdirSync(DATA_DIR).filter((f) => f.endsWith('.tmp'))).toEqual([])
+  })
+})

--- a/src/main/services/settings-store.ts
+++ b/src/main/services/settings-store.ts
@@ -3,7 +3,7 @@ import { join } from 'path'
 import { app, safeStorage } from 'electron'
 import { randomUUID } from 'crypto'
 import { logError } from './logger'
-import type { KuduSettings, AppStats, ScheduleEntry, ScheduleTaskType, MalwareAllowlistEntry, WindowsPackageManager, WindowState } from '../../shared/types'
+import type { KuduSettings, ScheduleEntry, ScheduleTaskType, MalwareAllowlistEntry, WindowsPackageManager, WindowState } from '../../shared/types'
 
 let _dataDir: string | null = null
 let _configPath: string | null = null
@@ -26,7 +26,6 @@ function getConfigPath(): string {
 
 interface StoreData {
   settings: KuduSettings
-  stats: AppStats
   onboardingComplete: boolean
   machineId: string
   /** Last known main-window geometry; null until the window is first sized. */
@@ -95,13 +94,6 @@ const defaults: StoreData = {
     },
     registryIgnoredTweaks: [],
     malwareAllowlist: []
-  },
-  stats: {
-    totalSpaceSaved: 0,
-    totalFilesCleaned: 0,
-    totalScans: 0,
-    lastScanDate: null,
-    recentActivity: []
   }
 }
 
@@ -176,6 +168,12 @@ function readStore(): StoreData {
       const raw = readFileSync(getConfigPath(), 'utf-8')
       const parsed = JSON.parse(raw)
       const merged = deepMerge(defaults, parsed)
+      // Drop the legacy `stats` block. Nothing has ever read it — the counters
+      // the UI shows are derived from history.json — so it sat at zero in
+      // config.json while the dashboard reported real numbers, which reads as
+      // data loss to anyone who opens the file (issue #269). Deleting it here
+      // clears it from existing installs on their next write.
+      delete (merged as { stats?: unknown }).stats
       // Decrypt API key if stored encrypted
       if (merged.settings.cloud.apiKey) {
         merged.settings.cloud.apiKey = decryptApiKey(merged.settings.cloud.apiKey)

--- a/src/main/services/settings-store.ts
+++ b/src/main/services/settings-store.ts
@@ -1,7 +1,8 @@
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs'
+import { readFileSync, writeFileSync, renameSync, unlinkSync, mkdirSync, existsSync } from 'fs'
 import { join } from 'path'
 import { app, safeStorage } from 'electron'
 import { randomUUID } from 'crypto'
+import { logError } from './logger'
 import type { KuduSettings, AppStats, ScheduleEntry, ScheduleTaskType, MalwareAllowlistEntry, WindowsPackageManager, WindowState } from '../../shared/types'
 
 let _dataDir: string | null = null
@@ -191,7 +192,8 @@ function readStore(): StoreData {
           parsed.settings.windowsPackageManager === 'choco')
       ) {
         merged.settings.windowsPackageManagers = [parsed.settings.windowsPackageManager]
-        try { writeStore(merged) } catch { /* best-effort */ }
+        // Best-effort: the migration is recomputed on the next read if it fails.
+        try { writeStore(merged) } catch (err) { logError('Package-manager migration write failed', err) }
       }
       // Migrate legacy single schedule → schedules array
       if (merged.settings.schedule.enabled && merged.settings.schedules.length === 0) {
@@ -215,17 +217,45 @@ function readStore(): StoreData {
         }
         merged.settings.schedules = [migrated]
         merged.settings.schedule.enabled = false
-        // Persist migration immediately
-        try { writeStore(merged) } catch { /* best-effort */ }
+        // Persist migration immediately (best-effort — retried on the next read)
+        try { writeStore(merged) } catch (err) { logError('Schedule migration write failed', err) }
       }
       return merged
     }
-  } catch {
-    // Corrupt file, use defaults
+  } catch (err) {
+    // Corrupt or unreadable file. Falling back to defaults resets every
+    // setting and re-triggers onboarding, so leave a trace of why.
+    logError('config.json could not be read — falling back to defaults', err)
   }
   return JSON.parse(JSON.stringify(defaults))
 }
 
+/**
+ * Attempts for a single write. On Windows an antivirus scanner or the search
+ * indexer routinely holds a just-written file open for a few milliseconds,
+ * which surfaces as a transient EPERM/EBUSY — retrying clears it.
+ */
+const WRITE_ATTEMPTS = 3
+const WRITE_RETRY_MS = 40
+
+function sleepSync(ms: number): void {
+  // Deliberately blocking: writeStore runs inside the write lock and callers
+  // (including quit paths) rely on it being synchronous. Atomics.wait parks the
+  // thread rather than spinning, and only ever runs on a failed write.
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
+}
+
+/**
+ * Write the whole store to disk.
+ *
+ * Writes to a sibling temp file and renames over the target so a crash or
+ * power loss mid-write can never leave a truncated config.json — a parse
+ * failure there sends readStore() back to the defaults, silently resetting
+ * every setting (and re-triggering onboarding, issue #269).
+ *
+ * Throws if the write ultimately fails. Callers must not swallow that: a
+ * silent failure here is indistinguishable from a successful save.
+ */
 function writeStore(data: StoreData): void {
   ensureDir()
   // Encrypt API key before writing to disk
@@ -233,7 +263,23 @@ function writeStore(data: StoreData): void {
   if (toWrite.settings.cloud.apiKey) {
     toWrite.settings.cloud.apiKey = encryptApiKey(toWrite.settings.cloud.apiKey)
   }
-  writeFileSync(getConfigPath(), JSON.stringify(toWrite, null, 2), 'utf-8')
+  const json = JSON.stringify(toWrite, null, 2)
+  const target = getConfigPath()
+  const tmp = `${target}.${process.pid}.tmp`
+
+  let lastErr: unknown
+  for (let attempt = 1; attempt <= WRITE_ATTEMPTS; attempt++) {
+    try {
+      writeFileSync(tmp, json, 'utf-8')
+      renameSync(tmp, target)
+      return
+    } catch (err) {
+      lastErr = err
+      try { unlinkSync(tmp) } catch { /* nothing to clean up */ }
+      if (attempt < WRITE_ATTEMPTS) sleepSync(WRITE_RETRY_MS)
+    }
+  }
+  throw lastErr
 }
 
 export function getSettings(): KuduSettings {
@@ -243,19 +289,42 @@ export function getSettings(): KuduSettings {
 // Simple mutex to prevent TOCTOU race on concurrent read-modify-write
 let writeLock: Promise<void> = Promise.resolve()
 
-export function setSettings(partial: Partial<KuduSettings>): void {
+/**
+ * Serialize one read-modify-write of config.json behind the write lock.
+ *
+ * `mutate` runs on a copy freshly read inside the lock, so concurrent writers
+ * never compute from a stale base. Returning `false` from it skips the write.
+ *
+ * The queue promise (`writeLock`) always resolves, so one failed write can
+ * never wedge every write after it. The promise handed back to the *caller*
+ * rejects when the write failed: the store must never report a save it did
+ * not make, which is how the onboarding flag went missing with nothing in the
+ * log to show for it (issue #269).
+ */
+function runLocked(what: string, mutate: (data: StoreData) => boolean | void): Promise<void> {
   const prev = writeLock
   let unlock: () => void
   writeLock = new Promise<void>((r) => { unlock = r })
-  prev.then(() => {
+  return prev.then(() => {
     try {
       const data = readStore()
-      data.settings = deepMerge(data.settings, partial)
+      if (mutate(data) === false) return
       writeStore(data)
+    } catch (err) {
+      logError(`Failed to persist ${what} to config.json`, err)
+      throw err
     } finally {
       unlock!()
     }
   })
+}
+
+export function setSettings(partial: Partial<KuduSettings>): void {
+  // Fire-and-forget by contract — callers order writes with flushSettings().
+  // runLocked has already logged anything that went wrong.
+  void runLocked('settings', (data) => {
+    data.settings = deepMerge(data.settings, partial)
+  }).catch(() => { /* logged in runLocked */ })
 }
 
 /**
@@ -264,20 +333,11 @@ export function setSettings(partial: Partial<KuduSettings>): void {
  * inside the lock so concurrent completions don't clobber each other.
  */
 export function updateScheduleEntry(scheduleId: string, patch: Partial<import('../../shared/types').ScheduleEntry>): void {
-  const prev = writeLock
-  let unlock: () => void
-  writeLock = new Promise<void>((r) => { unlock = r })
-  prev.then(() => {
-    try {
-      const data = readStore()
-      data.settings.schedules = data.settings.schedules.map((s) =>
-        s.id === scheduleId ? { ...s, ...patch } : s
-      )
-      writeStore(data)
-    } finally {
-      unlock!()
-    }
-  })
+  void runLocked('schedule entry', (data) => {
+    data.settings.schedules = data.settings.schedules.map((s) =>
+      s.id === scheduleId ? { ...s, ...patch } : s
+    )
+  }).catch(() => { /* logged in runLocked */ })
 }
 
 /**
@@ -287,25 +347,16 @@ export function updateScheduleEntry(scheduleId: string, patch: Partial<import('.
  * #172). `ignored = true` adds the signatures, `false` removes them.
  */
 export function updateRegistryIgnoredTweaks(signatures: string[], ignored: boolean): void {
-  const prev = writeLock
-  let unlock: () => void
-  writeLock = new Promise<void>((r) => { unlock = r })
-  prev.then(() => {
-    try {
-      const data = readStore()
-      const set = new Set(data.settings.registryIgnoredTweaks ?? [])
-      for (const sig of signatures) {
-        if (!sig) continue
-        if (ignored) set.add(sig)
-        else set.delete(sig)
-      }
-      // Bound the list to match validation (oldest entries dropped first).
-      data.settings.registryIgnoredTweaks = [...set].slice(-200)
-      writeStore(data)
-    } finally {
-      unlock!()
+  void runLocked('registry ignore list', (data) => {
+    const set = new Set(data.settings.registryIgnoredTweaks ?? [])
+    for (const sig of signatures) {
+      if (!sig) continue
+      if (ignored) set.add(sig)
+      else set.delete(sig)
     }
-  })
+    // Bound the list to match validation (oldest entries dropped first).
+    data.settings.registryIgnoredTweaks = [...set].slice(-200)
+  }).catch(() => { /* logged in runLocked */ })
 }
 
 /** Read the malware false-positive allowlist. */
@@ -319,35 +370,17 @@ export function getMalwareAllowlist(): MalwareAllowlistEntry[] {
  * path/detection metadata) and caps the list to the most recent 500 entries.
  */
 export function addMalwareAllowlistEntry(entry: MalwareAllowlistEntry): Promise<void> {
-  const prev = writeLock
-  let unlock: () => void
-  writeLock = new Promise<void>((r) => { unlock = r })
-  return prev.then(() => {
-    try {
-      const data = readStore()
-      const list = (data.settings.malwareAllowlist ?? []).filter((e) => e.sha256 !== entry.sha256)
-      list.push(entry)
-      data.settings.malwareAllowlist = list.slice(-500)
-      writeStore(data)
-    } finally {
-      unlock!()
-    }
+  return runLocked('malware allowlist', (data) => {
+    const list = (data.settings.malwareAllowlist ?? []).filter((e) => e.sha256 !== entry.sha256)
+    list.push(entry)
+    data.settings.malwareAllowlist = list.slice(-500)
   })
 }
 
 /** Remove an allowlist entry by content hash within the write lock. */
 export function removeMalwareAllowlistEntry(sha256: string): Promise<void> {
-  const prev = writeLock
-  let unlock: () => void
-  writeLock = new Promise<void>((r) => { unlock = r })
-  return prev.then(() => {
-    try {
-      const data = readStore()
-      data.settings.malwareAllowlist = (data.settings.malwareAllowlist ?? []).filter((e) => e.sha256 !== sha256)
-      writeStore(data)
-    } finally {
-      unlock!()
-    }
+  return runLocked('malware allowlist', (data) => {
+    data.settings.malwareAllowlist = (data.settings.malwareAllowlist ?? []).filter((e) => e.sha256 !== sha256)
   })
 }
 
@@ -361,17 +394,8 @@ export function getWindowState(): WindowState | null {
  * at the same time as a settings write can't clobber either one.
  */
 export function setWindowState(state: WindowState): Promise<void> {
-  const prev = writeLock
-  let unlock: () => void
-  writeLock = new Promise<void>((r) => { unlock = r })
-  return prev.then(() => {
-    try {
-      const data = readStore()
-      data.windowState = state
-      writeStore(data)
-    } finally {
-      unlock!()
-    }
+  return runLocked('window geometry', (data) => {
+    data.windowState = state
   })
 }
 
@@ -385,17 +409,8 @@ export function getOnboardingComplete(): boolean {
 }
 
 export function setOnboardingComplete(value: boolean): Promise<void> {
-  const prev = writeLock
-  let unlock: () => void
-  writeLock = new Promise<void>((r) => { unlock = r })
-  return prev.then(() => {
-    try {
-      const data = readStore()
-      data.onboardingComplete = value
-      writeStore(data)
-    } finally {
-      unlock!()
-    }
+  return runLocked('onboarding completion', (data) => {
+    data.onboardingComplete = value
   })
 }
 
@@ -405,20 +420,11 @@ export function getMachineId(): string {
   if (data.machineId) return data.machineId
   // First call ever — generate and persist (uses lock to avoid concurrent writes)
   const id = randomUUID()
-  const prev = writeLock
-  let unlock: () => void
-  writeLock = new Promise<void>((r) => { unlock = r })
-  prev.then(() => {
-    try {
-      const fresh = readStore()
-      if (!fresh.machineId) {
-        fresh.machineId = id
-        writeStore(fresh)
-      }
-    } finally {
-      unlock!()
-    }
-  })
+  void runLocked('machine id', (fresh) => {
+    // A concurrent caller may have won the race and already stored one.
+    if (fresh.machineId) return false
+    fresh.machineId = id
+  }).catch(() => { /* logged in runLocked */ })
   return id
 }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -83,15 +83,27 @@ export function App() {
       p.then((done) => {
         setShowOnboarding(!done)
         setOnboardingChecked(true)
-      }).catch(() => setOnboardingChecked(true))
+      }).catch((err) => {
+        // Fail open — a broken check must not lock the user out of the app —
+        // but say so, since it also means onboarding is skipped silently.
+        console.error('[onboarding] could not read completion state:', err)
+        setOnboardingChecked(true)
+      })
     } else {
       setOnboardingChecked(true)
     }
   }, [])
 
-  const handleOnboardingComplete = () => {
-    window.kudu?.onboardingSet?.(true).catch(() => {})
+  const handleOnboardingComplete = async () => {
     setShowOnboarding(false)
+    try {
+      await window.kudu?.onboardingSet?.(true)
+    } catch (err) {
+      // Swallowing this is what let the wizard come back on every launch with
+      // nothing to go on (issue #269). The main process forwards renderer
+      // console errors into kudu.log.
+      console.error('[onboarding] failed to persist completion:', err)
+    }
   }
 
   useEffect(() => {

--- a/src/renderer/src/components/Onboarding.tsx
+++ b/src/renderer/src/components/Onboarding.tsx
@@ -9,7 +9,8 @@ import { usePlatform } from '@/hooks/usePlatform'
 import logoSrc from '@/assets/logo.png'
 
 interface OnboardingProps {
-  onComplete: () => void
+  /** Records that onboarding is done; awaited before anything that can stall. */
+  onComplete: () => void | Promise<void>
 }
 
 interface OnboardingSettings {
@@ -30,6 +31,15 @@ export function Onboarding({ onComplete }: OnboardingProps) {
   })
 
   const applyAndFinish = async () => {
+    // Record completion first. Applying the startup preference below shells out
+    // to Task Scheduler — three schtasks calls with a 10s timeout each — so the
+    // wizard can sit there for seconds before this line would otherwise be
+    // reached. Quitting during that window used to lose the flag entirely and
+    // the wizard came back on the next launch, forever (issue #269). The
+    // preferences are all editable in Settings; the flag is not.
+    navigate('/')
+    await onComplete()
+
     try {
       const settingsPayload: Record<string, any> = {
         runAtStartup: settings.runAtStartup,
@@ -44,8 +54,6 @@ export function Onboarding({ onComplete }: OnboardingProps) {
     } catch {
       // Best-effort
     }
-    onComplete()
-    navigate('/')
   }
 
   return (


### PR DESCRIPTION
Fixes #269.

## Triage

Three symptoms were reported. Two are not bugs:

- **`machineId` stays `""`** — `getMachineId()` is what mints and persists it, and its only callers are in `cloud-agent.ts`. With no cloud link it is never called. Working as designed.
- **`stats.*` stays at zero** — dead field. The dashboard's counters are derived from `history.json` by the renderer's stats store; nothing has ever written `StoreData.stats`. "4.11 GB on the dashboard, 0 in config.json" is expected, not data loss. Removed in the second commit so the file stops implying otherwise.

The onboarding flag is the real bug, and it had two independent causes.

## Ordering

`applyAndFinish` recorded completion only after `settingsSet` **and** `applyStartup` returned. On Windows `applyStartup` shells out to Task Scheduler — three `schtasks` calls with a 10s timeout each — so the final step of the wizard can sit there for seconds with no feedback. Closing the app in that window left the flag unwritten and the wizard came back on the next launch, forever.

Completion is now recorded first and the wizard dismissed immediately; the startup, tray and schedule preferences apply in the background. They are all editable in Settings afterwards — the flag is not.

## Silent failure

`setOnboardingComplete()` resolved successfully even when `writeFileSync` threw: the promise it returned was the write lock's unlock-promise, resolved in `finally` regardless of outcome. A failed write was indistinguishable from a saved one, at every layer, with nothing in `kudu.log` — which is why the report has no error to point at. A transient `EPERM`/`EBUSY` from an antivirus scanner is the usual cause on Windows.

- `runLocked()` replaces the eight hand-rolled copies of the lock dance. The queue promise still always resolves, so one bad write cannot wedge the writes after it, but the promise handed to the caller now rejects and the failure is logged.
- `writeStore()` writes to a temp file and renames over the target, retrying three times. A torn write can no longer truncate `config.json` into a parse failure that silently resets every setting — the same failure would also have re-triggered onboarding.
- Both onboarding IPC failures are logged in the renderer; `renderer-diagnostics` forwards those to `kudu.log`.

## Which one hit the reporter

Can't tell from the report — there is no log evidence, which was the second defect. Both are fixed, and a recurrence will now leave a trace.

## Tests

`settings-store.onboarding.test.ts` covers the flag through the wizard's write order, machine-id generation, legacy `stats` cleanup, and that a failed write rejects rather than reporting success without wedging the lock. Full suite: 2460 passing.
