### PR TITLE
Accurately report recycle bin cleanup results

### DIFF
--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'fs'
 import { readdir } from 'fs/promises'
 import { join } from 'path'
 import { scanDirectory, scanFile, scanMultipleDirectories, scanDirectoriesAsItems, resolveChildSubdirs, cleanItems, getDirectorySize } from './services/file-utils'
-import { cacheItems } from './services/scan-cache'
+import { cacheItems, clearCache } from './services/scan-cache'
 import { BROWSER_CACHE_RECENCY, chromiumBrowsers, chromiumCacheTargets } from './services/chromium-cache'
 import { CleanerType } from '../shared/enums'
 import type { ScanResult, CleanResult } from '../shared/types'
@@ -369,7 +369,7 @@ async function scanDatabaseCli(): Promise<ScanResult[]> {
   return results
 }
 
-async function cleanRecycleBin(sizeBytes: number = 0): Promise<CleanResult> {
+async function cleanRecycleBin(sizeBytes: number = 0, countBefore: number = 0): Promise<CleanResult> {
   // On macOS/Linux, trash items are real files cleaned via cleanItems() in the main flow.
   // This function is only called for Windows COM-based recycle bin.
   const { execFile } = await import('child_process')
@@ -383,12 +383,30 @@ async function cleanRecycleBin(sizeBytes: number = 0): Promise<CleanResult> {
   const logDeletions = isDeletionLoggingEnabled()
   const binContents = logDeletions ? await listRecycleBinContents() : []
   try {
-    const cleanScript = `$shell = New-Object -ComObject Shell.Application; $shell.NameSpace(0x0a).Items() | ForEach-Object { Remove-Item $_.Path -Recurse -Force -ErrorAction SilentlyContinue }; Clear-RecycleBin -Force -Confirm:$false -ErrorAction SilentlyContinue`
-    await execFileAsync('powershell.exe', [
+    const cleanScript = `Add-Type -TypeDefinition 'using System; using System.Runtime.InteropServices; public class RecycleBin { [DllImport("Shell32.dll", CharSet = CharSet.Unicode)] public static extern uint SHEmptyRecycleBin(IntPtr hwnd, string pszRootPath, uint dwFlags); }'; $result = [RecycleBin]::SHEmptyRecycleBin([IntPtr]::Zero, $null, 7); Write-Output $result`
+    const { stdout: emptyStdout } = await execFileAsync('powershell.exe', [
       '-NoProfile', '-Command', psUtf8(cleanScript)
     ], { windowsHide: true })
+    const resultCode = parseInt(emptyStdout.trim()) || 0
+
+    const verifyScript = `$shell = New-Object -ComObject Shell.Application; $rb = $shell.NameSpace(0x0a); $items = $rb.Items(); $count = $items.Count; $size = ($items | Measure-Object -Property Size -Sum).Sum; Write-Output "$count|$size"`
+    const { stdout } = await execFileAsync('powershell.exe', [
+      '-NoProfile', '-Command', psUtf8(verifyScript)
+    ], { windowsHide: true })
+    const [remainingCountStr, remainingSizeStr] = stdout.trim().split('|')
+    const remaining = parseInt(remainingCountStr) || 0
+    const remainingSize = parseInt(remainingSizeStr) || 0
+
     if (logDeletions) await recordEmptiedRecycleBin(binContents, 'cli')
-    return { totalCleaned: sizeBytes, filesDeleted: 1, filesSkipped: 0, errors: [], needsElevation: false }
+    return {
+      totalCleaned: Math.max(0, sizeBytes - remainingSize),
+      filesDeleted: Math.max(0, countBefore - remaining),
+      filesSkipped: remaining,
+      errors: remaining > 0
+        ? [{ path: 'Recycle Bin', reason: `${remaining} item(s) could not be removed (may be in use or protected)` }]
+        : [],
+      needsElevation: remaining > 0 && resultCode === 0x80070005,
+    }
   } catch (err: any) {
     return { totalCleaned: 0, filesDeleted: 0, filesSkipped: 0, errors: [{ path: 'Recycle Bin', reason: err.message }], needsElevation: false }
   }
@@ -1437,6 +1455,7 @@ async function handleMetricsServer(args: string[], ctx: CliContext): Promise<voi
 // ─── Legacy file cleaner (backward compatible) ───────────────
 
 async function runLegacyScanClean(categories: string[], doClean: boolean, ctx: CliContext): Promise<number> {
+  clearCache()
   const scannerMap: Record<string, () => Promise<ScanResult[]>> = {
     system: scanSystem,
     browser: scanBrowserCli,
@@ -1496,8 +1515,8 @@ async function runLegacyScanClean(categories: string[], doClean: boolean, ctx: C
     let dbCleaned: CleanResult = { totalCleaned: 0, filesDeleted: 0, filesSkipped: 0, errors: [], needsElevation: false }
     if (fileItemIds.length > 0) fileCleaned = await cleanItems(fileItemIds, undefined, 'cli')
     if (hasRecycleBin) {
-      const rbSize = allResults.find(r => r.category === CleanerType.RecycleBin)?.totalSize || 0
-      recycleCleaned = await cleanRecycleBin(rbSize)
+      const rbResult = allResults.find(r => r.category === CleanerType.RecycleBin)
+      recycleCleaned = await cleanRecycleBin(rbResult?.totalSize || 0, rbResult?.itemCount || 0)
     }
     if (dbItemIds.length > 0) dbCleaned = await cleanDatabasesCli(dbItemIds)
     cleanResult = {

--- a/src/main/ipc/app-cleaner.ipc.test.ts
+++ b/src/main/ipc/app-cleaner.ipc.test.ts
@@ -20,6 +20,7 @@ vi.mock('../services/file-utils', () => ({
 const mockCacheItems = vi.fn()
 vi.mock('../services/scan-cache', () => ({
   cacheItems: (...args: unknown[]) => mockCacheItems(...args),
+  clearCachedCategory: vi.fn(),
 }))
 
 const mockAppPaths = vi.fn()

--- a/src/main/ipc/app-cleaner.ipc.ts
+++ b/src/main/ipc/app-cleaner.ipc.ts
@@ -2,7 +2,7 @@ import { ipcMain } from 'electron'
 import { IPC } from '../../shared/channels'
 import { getPlatform } from '../platform'
 import { scanMultipleDirectories, resolveChildSubdirs, cleanItems } from '../services/file-utils'
-import { cacheItems } from '../services/scan-cache'
+import { cacheItems, clearCachedCategory } from '../services/scan-cache'
 import { CleanerType } from '../../shared/enums'
 import type { ScanResult, CleanResult } from '../../shared/types'
 import type { WindowGetter } from './index'
@@ -12,6 +12,7 @@ export function registerAppCleanerIpc(getWindow: WindowGetter): void {
   ipcMain.handle(IPC.APP_SCAN, async (): Promise<ScanResult[]> => {
     const results: ScanResult[] = []
     const category = CleanerType.App
+    clearCachedCategory(category)
 
     for (const app of getPlatform().paths.appPaths()) {
       try {

--- a/src/main/ipc/browser-cleaner.ipc.test.ts
+++ b/src/main/ipc/browser-cleaner.ipc.test.ts
@@ -24,6 +24,7 @@ vi.mock('../services/file-utils', () => ({
 const mockCacheItems = vi.fn()
 vi.mock('../services/scan-cache', () => ({
   cacheItems: (...args: unknown[]) => mockCacheItems(...args),
+  clearCachedCategory: vi.fn(),
 }))
 
 const mockGetSettings = vi.fn()

--- a/src/main/ipc/browser-cleaner.ipc.ts
+++ b/src/main/ipc/browser-cleaner.ipc.ts
@@ -5,7 +5,7 @@ import { join } from 'path'
 import { IPC } from '../../shared/channels'
 import { getPlatform } from '../platform'
 import { scanDirectory, cleanItems } from '../services/file-utils'
-import { cacheItems } from '../services/scan-cache'
+import { cacheItems, clearCachedCategory } from '../services/scan-cache'
 import { getSettings } from '../services/settings-store'
 import { CleanerType } from '../../shared/enums'
 import type { ScanResult, CleanResult } from '../../shared/types'
@@ -17,6 +17,7 @@ export function registerBrowserCleanerIpc(getWindow: WindowGetter): void {
   ipcMain.handle(IPC.BROWSER_SCAN, async (): Promise<ScanResult[]> => {
     const results: ScanResult[] = []
     const category = CleanerType.Browser
+    clearCachedCategory(category)
     const browserPaths = getPlatform().paths.browserPaths()
     const recency = BROWSER_CACHE_RECENCY
 

--- a/src/main/ipc/database-optimizer.ipc.test.ts
+++ b/src/main/ipc/database-optimizer.ipc.test.ts
@@ -44,6 +44,7 @@ vi.mock('fs', () => {
 
 vi.mock('../services/scan-cache', () => ({
   cacheItems: (...args: unknown[]) => mockCacheItems(...args),
+  clearCachedCategory: vi.fn(),
   getCachedItem: (...args: unknown[]) => mockGetCachedItem(...args),
 }))
 

--- a/src/main/ipc/database-optimizer.ipc.ts
+++ b/src/main/ipc/database-optimizer.ipc.ts
@@ -5,7 +5,7 @@ import crypto from 'crypto'
 import Database from 'better-sqlite3'
 import { IPC } from '../../shared/channels'
 import { getPlatform } from '../platform'
-import { cacheItems, getCachedItem } from '../services/scan-cache'
+import { cacheItems, clearCachedCategory, getCachedItem } from '../services/scan-cache'
 import { CleanerType } from '../../shared/enums'
 import type { ScanResult, ScanItem, CleanResult, CleanError } from '../../shared/types'
 import type { DatabaseTarget } from '../platform/types'
@@ -60,6 +60,7 @@ function resolveProfileDirs(basePath: string, target: DatabaseTarget): string[] 
 
 export function registerDatabaseOptimizerIpc(getWindow: WindowGetter): void {
   ipcMain.handle(IPC.DATABASE_SCAN, async (): Promise<ScanResult[]> => {
+    clearCachedCategory(CleanerType.Database)
     const results: ScanResult[] = []
     const category = CleanerType.Database
     const targets = getPlatform().paths.databaseOptimizeTargets()

--- a/src/main/ipc/environment-cleaner.ipc.ts
+++ b/src/main/ipc/environment-cleaner.ipc.ts
@@ -5,7 +5,7 @@ import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { IPC } from '../../shared/channels'
 import { CleanerType } from '../../shared/enums'
-import { cacheItems } from '../services/scan-cache'
+import { cacheItems, clearCachedCategory } from '../services/scan-cache'
 import { validateStringArray } from '../services/ipc-validation'
 import { psUtf8, execNativeUtf8 } from '../services/exec-utf8'
 import type { ScanItem, ScanResult, CleanResult, CleanError } from '../../shared/types'
@@ -262,6 +262,7 @@ const envEntryCache = new Map<string, EnvEntry>()
 
 export function registerEnvironmentCleanerIpc(getWindow: WindowGetter): void {
   ipcMain.handle(IPC.ENVIRONMENT_SCAN, async (): Promise<ScanResult[]> => {
+    clearCachedCategory(CleanerType.Environment)
     envEntryCache.clear()
     const results: ScanResult[] = []
     const category = CleanerType.Environment

--- a/src/main/ipc/gaming-cleaner.ipc.ts
+++ b/src/main/ipc/gaming-cleaner.ipc.ts
@@ -6,7 +6,7 @@ import { randomUUID } from 'crypto'
 import { IPC } from '../../shared/channels'
 import { getPlatform } from '../platform'
 import { scanDirectoriesAsItems, cleanItems, getDirectorySize } from '../services/file-utils'
-import { cacheItems } from '../services/scan-cache'
+import { cacheItems, clearCachedCategory } from '../services/scan-cache'
 import { CleanerType } from '../../shared/enums'
 import type { ScanItem, ScanResult, CleanResult } from '../../shared/types'
 import type { WindowGetter } from './index'
@@ -16,6 +16,7 @@ export function registerGamingCleanerIpc(getWindow: WindowGetter): void {
   ipcMain.handle(IPC.GAMING_SCAN, async (): Promise<ScanResult[]> => {
     const results: ScanResult[] = []
     const category = CleanerType.Gaming
+    clearCachedCategory(category)
 
     // Launcher caches — directory-level items, one row per launcher
     for (const launcher of getPlatform().paths.gamingPaths()) {

--- a/src/main/ipc/recycle-bin.deletion-log.test.ts
+++ b/src/main/ipc/recycle-bin.deletion-log.test.ts
@@ -13,7 +13,7 @@ const state = vi.hoisted(() => ({
   /** stdout for the bin-contents enumeration, in call order */
   enumerations: [] as string[],
   /** stdout for the post-empty count check */
-  remainingCount: '0',
+  statsOutputs: [] as string[],
   emptyThrows: false,
   psScripts: [] as string[],
   recorded: [] as any[],
@@ -30,8 +30,8 @@ vi.mock('child_process', () => ({
     if (script.includes('ConvertTo-Json')) {
       return cb(null, { stdout: state.enumerations.shift() ?? '[]' })
     }
-    // Remaining-count verification
-    return cb(null, { stdout: state.remainingCount })
+    // Initial scan and post-empty count/size verification.
+    return cb(null, { stdout: state.statsOutputs.shift() ?? '0|0' })
   },
 }))
 
@@ -44,7 +44,7 @@ vi.mock('../services/file-utils', () => ({
   cleanItems: vi.fn(),
 }))
 
-vi.mock('../services/scan-cache', () => ({ cacheItems: vi.fn() }))
+vi.mock('../services/scan-cache', () => ({ cacheItems: vi.fn(), clearCachedCategory: vi.fn() }))
 
 vi.mock('../services/exec-utf8', () => ({ psUtf8: (s: string) => s }))
 
@@ -65,6 +65,11 @@ function getHandler(channel: string): (...args: unknown[]) => Promise<any> {
   return call[1] as (...args: unknown[]) => Promise<any>
 }
 
+async function scanThenClean(): Promise<any> {
+  await getHandler(IPC.RECYCLE_BIN_SCAN)()
+  return getHandler(IPC.RECYCLE_BIN_CLEAN)()
+}
+
 const binItems = (items: Array<{ name: string; origin?: string; size?: number }>) =>
   JSON.stringify(items.map((i) => ({ name: i.name, origin: i.origin ?? '', size: i.size ?? 0 })))
 
@@ -73,7 +78,7 @@ describe('recycle bin deletion logging (Windows)', () => {
     mockHandle.mockClear()
     state.keepDeletionLog = false
     state.enumerations = []
-    state.remainingCount = '0'
+    state.statsOutputs = ['2|4216', '0|0']
     state.emptyThrows = false
     state.psScripts = []
     state.recorded = []
@@ -81,7 +86,7 @@ describe('recycle bin deletion logging (Windows)', () => {
   })
 
   it('does not enumerate the bin when logging is off', async () => {
-    const result = await getHandler(IPC.RECYCLE_BIN_CLEAN)()
+    const result = await scanThenClean()
 
     expect(result.errors).toEqual([])
     expect(state.recorded).toHaveLength(0)
@@ -95,7 +100,7 @@ describe('recycle bin deletion logging (Windows)', () => {
       { name: 'photo.png', origin: 'D:\\Pictures', size: 4096 },
     ])]
 
-    await getHandler(IPC.RECYCLE_BIN_CLEAN)()
+    await scanThenClean()
 
     expect(state.recorded.map((r) => r.path)).toEqual([
       join('C:\\Users\\dave\\Documents', 'notes.txt'),
@@ -113,14 +118,14 @@ describe('recycle bin deletion logging (Windows)', () => {
     state.keepDeletionLog = true
     state.enumerations = [binItems([{ name: 'orphan.dat' }])]
 
-    await getHandler(IPC.RECYCLE_BIN_CLEAN)()
+    await scanThenClean()
 
     expect(state.recorded.map((r) => r.path)).toEqual(['orphan.dat'])
   })
 
   it('on a partial empty, records only the items that are actually gone', async () => {
     state.keepDeletionLog = true
-    state.remainingCount = '1'
+    state.statsOutputs = ['2|4216', '1|4096']
     state.enumerations = [
       binItems([
         { name: 'gone.txt', origin: 'C:\\a' },
@@ -130,9 +135,11 @@ describe('recycle bin deletion logging (Windows)', () => {
       binItems([{ name: 'locked.txt', origin: 'C:\\b' }]),
     ]
 
-    const result = await getHandler(IPC.RECYCLE_BIN_CLEAN)()
+    const result = await scanThenClean()
 
     expect(result.filesSkipped).toBe(1)
+    expect(result.filesDeleted).toBe(1)
+    expect(result.totalCleaned).toBe(120)
     expect(state.recorded.map((r) => r.path)).toEqual([join('C:\\a', 'gone.txt')])
   })
 
@@ -140,10 +147,10 @@ describe('recycle bin deletion logging (Windows)', () => {
     state.keepDeletionLog = true
     state.enumerations = ['not json at all']
 
-    const result = await getHandler(IPC.RECYCLE_BIN_CLEAN)()
+    const result = await scanThenClean()
 
     expect(result.errors).toEqual([])
-    expect(result.filesDeleted).toBe(1)
+    expect(result.filesDeleted).toBe(2)
     expect(state.recorded).toHaveLength(0)
   })
 
@@ -152,7 +159,7 @@ describe('recycle bin deletion logging (Windows)', () => {
     state.enumerations = [binItems([{ name: 'notes.txt', origin: 'C:\\a' }])]
     state.emptyThrows = true
 
-    const result = await getHandler(IPC.RECYCLE_BIN_CLEAN)()
+    const result = await scanThenClean()
 
     expect(result.filesDeleted).toBe(0)
     expect(result.errors).toHaveLength(1)

--- a/src/main/ipc/recycle-bin.ipc.test.ts
+++ b/src/main/ipc/recycle-bin.ipc.test.ts
@@ -85,16 +85,17 @@ describe('recycle bin scan result structure', () => {
 describe('recycle bin clean result structure', () => {
   it('reports success when remaining count is 0', () => {
     const sizeBeforeClean = 5000
+    const countBeforeClean = 10
     const remainingStdout = '0'
     const remaining = parseInt(remainingStdout.trim()) || 0
 
     const result = remaining === 0
-      ? { totalCleaned: sizeBeforeClean, filesDeleted: 1, filesSkipped: 0, errors: [], needsElevation: false }
+      ? { totalCleaned: sizeBeforeClean, filesDeleted: countBeforeClean, filesSkipped: 0, errors: [], needsElevation: false }
       : null
 
     expect(result).toEqual({
       totalCleaned: 5000,
-      filesDeleted: 1,
+      filesDeleted: 10,
       filesSkipped: 0,
       errors: [],
       needsElevation: false
@@ -103,17 +104,21 @@ describe('recycle bin clean result structure', () => {
 
   it('reports partial clean when remaining items exist', () => {
     const sizeBeforeClean = 10000
+    const countBeforeClean = 8
     const remaining = 3
+    const remainingSize = 7000
 
     const result = {
-      totalCleaned: sizeBeforeClean,
-      filesDeleted: 1,
+      totalCleaned: Math.max(0, sizeBeforeClean - remainingSize),
+      filesDeleted: Math.max(0, countBeforeClean - remaining),
       filesSkipped: remaining,
       errors: [{ path: 'Recycle Bin', reason: `${remaining} item(s) could not be removed (may be in use or protected)` }],
       needsElevation: false
     }
 
     expect(result.filesSkipped).toBe(3)
+    expect(result.filesDeleted).toBe(5)
+    expect(result.totalCleaned).toBe(3000)
     expect(result.errors).toHaveLength(1)
     expect(result.errors[0].reason).toContain('3 item(s)')
   })
@@ -162,17 +167,24 @@ describe('trash path handling', () => {
 describe('recycle bin state tracking', () => {
   it('tracks lastScannedSize for clean operations', () => {
     let lastScannedSize = 0
+    let lastScannedCount = 0
 
     // Simulate scan
-    const { size } = parseRecycleBinScanOutput('100|1048576')
+    const { count, size } = parseRecycleBinScanOutput('100|1048576')
     lastScannedSize = size
+    lastScannedCount = count
     expect(lastScannedSize).toBe(1048576)
+    expect(lastScannedCount).toBe(100)
 
-    // Simulate clean - uses the tracked size
+    // Simulate a partial clean and retain the survivors for an accurate retry.
     const sizeBeforeClean = lastScannedSize
-    lastScannedSize = 0
+    const countBeforeClean = lastScannedCount
+    lastScannedSize = 4096
+    lastScannedCount = 2
     expect(sizeBeforeClean).toBe(1048576)
-    expect(lastScannedSize).toBe(0)
+    expect(countBeforeClean).toBe(100)
+    expect(lastScannedSize).toBe(4096)
+    expect(lastScannedCount).toBe(2)
   })
 
   it('tracks lastScannedItemIds for macOS/Linux', () => {

--- a/src/main/ipc/recycle-bin.ipc.ts
+++ b/src/main/ipc/recycle-bin.ipc.ts
@@ -8,7 +8,7 @@ import type { ScanResult, CleanResult } from '../../shared/types'
 import { randomUUID } from 'crypto'
 import { getPlatform } from '../platform'
 import { scanDirectory, cleanItems } from '../services/file-utils'
-import { cacheItems } from '../services/scan-cache'
+import { cacheItems, clearCachedCategory } from '../services/scan-cache'
 import { psUtf8 } from '../services/exec-utf8'
 import {
   isDeletionLoggingEnabled, listRecycleBinContents, recordEmptiedRecycleBin
@@ -22,11 +22,16 @@ function psArgs(script: string): string[] {
 
 // Windows: track last scanned size (virtual items have no real path)
 let lastScannedSize = 0
+let lastScannedCount = 0
 // macOS/Linux: track last scanned item IDs for cleanItems()
 let lastScannedItemIds: string[] = []
 
 export function registerRecycleBinIpc(): void {
   ipcMain.handle(IPC.RECYCLE_BIN_SCAN, async (): Promise<ScanResult[]> => {
+    clearCachedCategory(CleanerType.RecycleBin)
+    lastScannedSize = 0
+    lastScannedCount = 0
+    lastScannedItemIds = []
     const trashPath = getPlatform().paths.trashPath()
 
     if (trashPath) {
@@ -56,6 +61,7 @@ export function registerRecycleBinIpc(): void {
       const size = parseInt(sizeStr) || 0
 
       lastScannedSize = size
+      lastScannedCount = count
 
       if (count === 0) return []
 
@@ -95,36 +101,45 @@ export function registerRecycleBinIpc(): void {
 
     // Windows: SHEmptyRecycleBin Win32 API
     const sizeBeforeClean = lastScannedSize
+    const countBeforeClean = lastScannedCount
     // Capture the contents first — after the bin is emptied there is nothing
     // left to enumerate.
     const logDeletions = isDeletionLoggingEnabled()
     const binContents = logDeletions ? await listRecycleBinContents() : []
     try {
       // Flags: SHERB_NOCONFIRMATION(1) | SHERB_NOPROGRESSUI(2) | SHERB_NOSOUND(4) = 7
-      await execFileAsync('powershell.exe', psArgs(
-        `Add-Type -TypeDefinition 'using System; using System.Runtime.InteropServices; public class RecycleBin { [DllImport("Shell32.dll", CharSet = CharSet.Unicode)] public static extern uint SHEmptyRecycleBin(IntPtr hwnd, string pszRootPath, uint dwFlags); }'; [RecycleBin]::SHEmptyRecycleBin([IntPtr]::Zero, $null, 7)`
+      const { stdout: emptyStdout } = await execFileAsync('powershell.exe', psArgs(
+        `Add-Type -TypeDefinition 'using System; using System.Runtime.InteropServices; public class RecycleBin { [DllImport("Shell32.dll", CharSet = CharSet.Unicode)] public static extern uint SHEmptyRecycleBin(IntPtr hwnd, string pszRootPath, uint dwFlags); }'; $result = [RecycleBin]::SHEmptyRecycleBin([IntPtr]::Zero, $null, 7); Write-Output $result`
       ), { windowsHide: true })
+      const resultCode = parseInt(emptyStdout.trim()) || 0
 
-      // Verify the bin is actually empty
+      // Verify both count and bytes. SHEmptyRecycleBin returns an HRESULT rather
+      // than throwing, and it can partially succeed across multiple drives.
       const { stdout } = await execFileAsync('powershell.exe', psArgs(
-        `$shell = New-Object -ComObject Shell.Application; $rb = $shell.NameSpace(0x0a); $items = $rb.Items(); Write-Output $items.Count`
+        `$shell = New-Object -ComObject Shell.Application; $rb = $shell.NameSpace(0x0a); $items = $rb.Items(); $count = $items.Count; $size = ($items | Measure-Object -Property Size -Sum).Sum; Write-Output "$count|$size"`
       ), { windowsHide: true })
-      const remaining = parseInt(stdout.trim()) || 0
+      const [remainingCountStr, remainingSizeStr] = stdout.trim().split('|')
+      const remaining = parseInt(remainingCountStr) || 0
+      const remainingSize = parseInt(remainingSizeStr) || 0
+      const totalCleaned = Math.max(0, sizeBeforeClean - remainingSize)
+      const filesDeleted = Math.max(0, countBeforeClean - remaining)
 
       if (logDeletions) await recordEmptiedRecycleBin(binContents, 'local')
 
+      lastScannedSize = remainingSize
+      lastScannedCount = remaining
+
       if (remaining === 0) {
-        lastScannedSize = 0
-        return { totalCleaned: sizeBeforeClean, filesDeleted: 1, filesSkipped: 0, errors: [], needsElevation: false }
+        return { totalCleaned, filesDeleted, filesSkipped: 0, errors: [], needsElevation: false }
       } else {
         // Partial clean - some items couldn't be removed
-        lastScannedSize = 0
+        const accessDenied = resultCode === 0x80070005
         return {
-          totalCleaned: sizeBeforeClean,
-          filesDeleted: 1,
+          totalCleaned,
+          filesDeleted,
           filesSkipped: remaining,
           errors: [{ path: 'Recycle Bin', reason: `${remaining} item(s) could not be removed (may be in use or protected)` }],
-          needsElevation: false
+          needsElevation: accessDenied
         }
       }
     } catch (err: any) {

--- a/src/main/ipc/shortcut-cleaner.ipc.ts
+++ b/src/main/ipc/shortcut-cleaner.ipc.ts
@@ -8,7 +8,7 @@ import { randomUUID } from 'crypto'
 import { homedir } from 'os'
 import { IPC } from '../../shared/channels'
 import { CleanerType } from '../../shared/enums'
-import { cacheItems } from '../services/scan-cache'
+import { cacheItems, clearCachedCategory } from '../services/scan-cache'
 import { cleanItems } from '../services/file-utils'
 import { validateStringArray } from '../services/ipc-validation'
 import type { ScanItem, ScanResult, CleanResult } from '../../shared/types'
@@ -204,6 +204,7 @@ function isTargetBroken(info: ShortcutInfo): boolean {
 
 export function registerShortcutCleanerIpc(getWindow: WindowGetter): void {
   ipcMain.handle(IPC.SHORTCUT_SCAN, async (): Promise<ScanResult[]> => {
+    clearCachedCategory(CleanerType.Shortcut)
     const results: ScanResult[] = []
     const category = CleanerType.Shortcut
     const dirs = getShortcutDirs()

--- a/src/main/ipc/system-cleaner.ipc.ts
+++ b/src/main/ipc/system-cleaner.ipc.ts
@@ -2,7 +2,7 @@ import { ipcMain } from 'electron'
 import { IPC } from '../../shared/channels'
 import { getPlatform } from '../platform'
 import { scanDirectory, scanFile, scanMultipleDirectories, resolveChildSubdirs, cleanItems } from '../services/file-utils'
-import { cacheItems } from '../services/scan-cache'
+import { cacheItems, clearCachedCategory } from '../services/scan-cache'
 import { isAdmin } from '../services/elevation'
 import type { ScanResult, CleanResult } from '../../shared/types'
 import { CleanerType } from '../../shared/enums'
@@ -13,6 +13,7 @@ export function registerSystemCleanerIpc(getWindow: WindowGetter): void {
   ipcMain.handle(IPC.SYSTEM_SCAN, async (): Promise<ScanResult[]> => {
     const results: ScanResult[] = []
     const category = CleanerType.System
+    clearCachedCategory(category)
 
     const elevated = isAdmin()
     const platform = getPlatform()

--- a/src/main/services/cloud-agent.ts
+++ b/src/main/services/cloud-agent.ts
@@ -17,7 +17,7 @@ const Pusher = ((PusherImport as unknown as { Pusher?: typeof PusherImport }).Pu
 type Pusher = PusherImport
 import { getSettings, setSettings, getMachineId } from './settings-store'
 import { scanDirectory, scanMultipleDirectories, scanDirectoriesAsItems, resolveChildSubdirs, cleanItems } from './file-utils'
-import { cacheItems } from './scan-cache'
+import { cacheItems, clearCachedCategory } from './scan-cache'
 import { BROWSER_CACHE_RECENCY, chromiumBrowsers, chromiumCacheTargets } from './chromium-cache'
 import { psUtf8 } from './exec-utf8'
 import { getPlatform } from '../platform'
@@ -1934,6 +1934,7 @@ class CloudAgentService {
 
     switch (scanType) {
       case 'system': {
+        clearCachedCategory(CleanerType.System)
         const results: ScanResult[] = []
         const targets = getPlatform().paths.systemCleanTargets()
         for (const t of targets) {
@@ -1965,6 +1966,7 @@ class CloudAgentService {
       }
 
       case 'browser': {
+        clearCachedCategory(CleanerType.Browser)
         const browserResults: ScanResult[] = []
         const browserPaths = getPlatform().paths.browserPaths()
         const browserCategory = CleanerType.Browser
@@ -2041,6 +2043,7 @@ class CloudAgentService {
       }
 
       case 'app': {
+        clearCachedCategory(CleanerType.App)
         const appResults: ScanResult[] = []
         const appCategory = CleanerType.App
         for (const appDef of getPlatform().paths.appPaths()) {
@@ -2066,6 +2069,7 @@ class CloudAgentService {
       }
 
       case 'gaming': {
+        clearCachedCategory(CleanerType.Gaming)
         const gamingResults: ScanResult[] = []
         const gamingCategory = CleanerType.Gaming
 
@@ -2100,6 +2104,7 @@ class CloudAgentService {
       }
 
       case 'recycle-bin': {
+        clearCachedCategory(CleanerType.RecycleBin)
         const trashPath = getPlatform().paths.trashPath()
         if (trashPath) {
           // macOS / Linux
@@ -2214,6 +2219,7 @@ class CloudAgentService {
       }
 
       case 'database': {
+        clearCachedCategory(CleanerType.Database)
         const dbTargets = getPlatform().paths.databaseOptimizeTargets()
         const dbResults: ScanResult[] = []
         const dbCategory = CleanerType.Database

--- a/src/main/services/file-utils.clean-log.test.ts
+++ b/src/main/services/file-utils.clean-log.test.ts
@@ -38,6 +38,7 @@ vi.mock('./settings-store', () => ({
 
 vi.mock('./scan-cache', () => ({
   getCachedItems: () => state.items,
+  removeCachedItems: () => {},
 }))
 
 vi.mock('./deletion-log-store', () => ({
@@ -238,7 +239,10 @@ describe('cleanItems deletion logging', () => {
 
     const result = await cleanItems(['id-0', 'id-vanished'])
 
-    expect(result.filesDeleted).toBe(2) // counters keep their existing behavior
+    expect(result.filesDeleted).toBe(1)
+    expect(result.filesSkipped).toBe(1)
+    expect(result.totalCleaned).toBe(10)
+    expect(result.errors).toContainEqual({ path: join(testDir, 'vanished.tmp'), reason: 'not-found' })
     expect(state.recorded.map((r) => r.path)).toEqual([join(testDir, 'file-0.tmp')])
   })
 
@@ -270,9 +274,11 @@ describe('cleanItems deletion logging', () => {
   it('does not log when no items match the given ids', async () => {
     state.keepDeletionLog = true
     state.items = []
-    await cleanItems(['nope'])
+    const result = await cleanItems(['nope'])
 
     expect(state.recorded).toHaveLength(0)
     expect(state.batches).toBe(0)
+    expect(result.filesSkipped).toBe(1)
+    expect(result.errors).toEqual([{ path: 'nope', reason: 'scan-result-expired' }])
   })
 })

--- a/src/main/services/file-utils.recency.test.ts
+++ b/src/main/services/file-utils.recency.test.ts
@@ -9,7 +9,7 @@ vi.mock('./settings-store', () => ({
   getSettings: () => ({ cleaner: { secureDelete: false, skipRecentMinutes: 60 }, exclusions: state.exclusions }),
 }))
 
-vi.mock('./scan-cache', () => ({ getCachedItems: () => [] }))
+vi.mock('./scan-cache', () => ({ getCachedItems: () => [], removeCachedItems: () => {} }))
 
 import { scanDirectory } from './file-utils'
 

--- a/src/main/services/file-utils.test.ts
+++ b/src/main/services/file-utils.test.ts
@@ -12,6 +12,7 @@ vi.mock('./settings-store', () => ({
 // Mock scan-cache
 vi.mock('./scan-cache', () => ({
   getCachedItems: () => [],
+  removeCachedItems: () => {},
 }))
 
 describe('isExcluded', () => {

--- a/src/main/services/file-utils.ts
+++ b/src/main/services/file-utils.ts
@@ -4,7 +4,7 @@ import type { Dirent, Stats } from 'fs'
 import { join } from 'path'
 import { randomUUID, randomBytes } from 'crypto'
 import type { ScanItem, ScanResult, CleanResult, DeletedFileRecord, DeletionOrigin } from '../../shared/types'
-import { getCachedItems } from './scan-cache'
+import { getCachedItems, removeCachedItems } from './scan-cache'
 import { getSettings } from './settings-store'
 import { recordDeletions } from './deletion-log-store'
 
@@ -91,7 +91,10 @@ export async function safeDelete(filePath: string): Promise<DeleteResult> {
         // If overwrite fails (e.g. permission), still attempt normal deletion
       }
     }
-    await rm(filePath, { force: true, recursive: true })
+    // Recursive rm only retries transient EBUSY/EPERM/ENOTEMPTY failures when
+    // maxRetries is non-zero. Cache trees are frequently touched by antivirus
+    // and indexer processes for a few milliseconds after scanning.
+    await rm(filePath, { force: true, recursive: true, maxRetries: 3, retryDelay: 100 })
     return { path: filePath, success: true }
   } catch (err: any) {
     if (err.code === 'EBUSY' || err.code === 'EPERM') {
@@ -170,14 +173,27 @@ export async function cleanItems(
 ): Promise<CleanResult> {
   // Validate input is a string array
   const validIds = Array.isArray(itemIds)
-    ? itemIds.filter((v): v is string => typeof v === 'string')
+    ? [...new Set(itemIds.filter((v): v is string => typeof v === 'string'))]
     : []
   const items = getCachedItems(validIds)
   let totalCleaned = 0
   let filesDeleted = 0
   let filesSkipped = 0
   const errors: CleanResult['errors'] = []
+  const consumedIds: string[] = []
   let lastReport = 0
+
+  // A missing cache entry used to disappear from the operation entirely. In a
+  // large scan that made tens of thousands of selected files neither deleted
+  // nor reported. Keep this explicit even though current scans are no longer
+  // capacity-evicted, so stale renderer results can never fail silently.
+  const resolvedIds = new Set(items.map((item) => item.id))
+  for (const id of validIds) {
+    if (!resolvedIds.has(id)) {
+      filesSkipped++
+      errors.push({ path: id, reason: 'scan-result-expired' })
+    }
+  }
 
   // Opt-in audit trail of what was removed (issue #247). Buffered so a clean of
   // 100k files doesn't turn into 100k appends, and flushed as we go so a crash
@@ -196,23 +212,37 @@ export async function cleanItems(
     // directory rather than a symlink to one. Null means it was already gone
     // before this clean touched it.
     let rootInfo: Awaited<ReturnType<typeof lstat>> | null = null
-    if (logDeletions) {
-      try {
-        rootInfo = await lstat(item.path)
-      } catch {
-        rootInfo = null
+    try {
+      rootInfo = await lstat(item.path)
+    } catch {
+      rootInfo = null
+    }
+
+    // force:true makes rm report success for an already-vanished file. Counting
+    // its scanned size as reclaimed substantially overstates what this run did.
+    if (!rootInfo) {
+      filesSkipped++
+      errors.push({ path: item.path, reason: 'not-found' })
+      consumedIds.push(item.id)
+      if (onProgress) {
+        onProgress(filesDeleted + filesSkipped, validIds.length, item.path, totalCleaned)
+        lastReport = Date.now()
       }
+      continue
     }
 
     // A scan item is often a whole directory that rm removes recursively, so
     // enumerate what's inside before it's gone. Only on success do these get
     // recorded, so a failed delete never leaves phantom entries behind.
-    const descendants = rootInfo?.isDirectory() ? await listDescendantFiles(item.path) : null
+    const descendants = logDeletions && rootInfo.isDirectory()
+      ? await listDescendantFiles(item.path)
+      : null
 
     const result = await safeDelete(item.path)
     if (result.success) {
       totalCleaned += item.size
       filesDeleted++
+      consumedIds.push(item.id)
       // rm(force) reports success for a path that was already missing, so a
       // temp file that vanished between the scan and the clean would otherwise
       // be logged as something Kudu deleted. Counters keep their existing
@@ -241,14 +271,19 @@ export async function cleanItems(
     if (onProgress) {
       const processed = filesDeleted + filesSkipped
       const now = Date.now()
-      if (now - lastReport > 120 || processed === items.length) {
+      if (now - lastReport > 120 || processed === validIds.length) {
         lastReport = now
-        onProgress(processed, items.length, item.path, totalCleaned)
+        onProgress(processed, validIds.length, item.path, totalCleaned)
       }
     }
   }
 
+  if (onProgress && items.length === 0 && validIds.length > 0) {
+    onProgress(filesSkipped, validIds.length, '', totalCleaned)
+  }
+
   flushPending()
+  removeCachedItems(consumedIds)
 
   const needsElevation = errors.some((e) => e.reason === 'permission-denied')
   return { totalCleaned, filesDeleted, filesSkipped, errors, needsElevation }

--- a/src/main/services/scan-cache.test.ts
+++ b/src/main/services/scan-cache.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { cacheItems, getCachedItem, getCachedItems, clearCache } from './scan-cache'
+import {
+  cacheItems, getCachedItem, getCachedItems, clearCache,
+  clearCachedCategory, removeCachedItems
+} from './scan-cache'
 import type { ScanItem } from '../../shared/types'
 
 function makeItem(id: string): ScanItem {
@@ -60,17 +63,31 @@ describe('scan-cache', () => {
     expect(getCachedItem('a')?.size).toBe(9999)
   })
 
-  it('evicts cache when exceeding max size', () => {
-    // Fill cache with items up to the limit (50,000), then add more to trigger eviction
+  it('keeps every item in a scan larger than the old 50,000 item cap', () => {
     const batch1 = Array.from({ length: 50000 }, (_, i) => makeItem(`old-${i}`))
     cacheItems(batch1)
-    expect(getCachedItem('old-0')).toBeDefined()
+    cacheItems([makeItem('new-item')])
 
-    // Adding 1 more item should trigger eviction of the oldest entry
-    const batch2 = [makeItem('new-item')]
-    cacheItems(batch2)
-    // Oldest item should be evicted to make room
-    expect(getCachedItem('old-0')).toBeUndefined()
+    expect(getCachedItem('old-0')).toBeDefined()
     expect(getCachedItem('new-item')).toBeDefined()
+  })
+
+  it('clears only the requested category before a replacement scan', () => {
+    cacheItems([
+      makeItem('system-old'),
+      { ...makeItem('browser-old'), category: 'browser' },
+    ])
+
+    clearCachedCategory('system')
+
+    expect(getCachedItem('system-old')).toBeUndefined()
+    expect(getCachedItem('browser-old')).toBeDefined()
+  })
+
+  it('removes consumed IDs after cleaning', () => {
+    cacheItems([makeItem('a'), makeItem('b')])
+    removeCachedItems(['a'])
+    expect(getCachedItem('a')).toBeUndefined()
+    expect(getCachedItem('b')).toBeDefined()
   })
 })

--- a/src/main/services/scan-cache.ts
+++ b/src/main/services/scan-cache.ts
@@ -5,21 +5,29 @@ import type { ScanItem } from '../../shared/types'
  * item paths by ID. Each scan replaces the previous cache for that category.
  */
 const itemCache = new Map<string, ScanItem>()
-const MAX_CACHE_SIZE = 50000
 
 export function cacheItems(items: ScanItem[]): void {
-  // Evict oldest entries if cache is getting too large
-  if (itemCache.size + items.length > MAX_CACHE_SIZE) {
-    const toRemove = itemCache.size + items.length - MAX_CACHE_SIZE
-    const keys = itemCache.keys()
-    for (let i = 0; i < toRemove; i++) {
-      const key = keys.next().value
-      if (key !== undefined) itemCache.delete(key)
-    }
-  }
+  // Do not evict live scan results here. The renderer can legitimately hold
+  // more than 50k items (browser caches commonly do), and dropping the oldest
+  // IDs makes Clean silently ignore files that are still visible and selected.
+  // Scanner entry points replace their category via clearCachedCategory(), and
+  // successful clean calls remove their own IDs, which bounds stale entries
+  // without making the displayed scan uncleanable.
   for (const item of items) {
     itemCache.set(item.id, item)
   }
+}
+
+/** Remove results from an older scan while preserving the other categories. */
+export function clearCachedCategory(category: string): void {
+  for (const [id, item] of itemCache) {
+    if (item.category === category) itemCache.delete(id)
+  }
+}
+
+/** Drop IDs once a clean has consumed them. */
+export function removeCachedItems(ids: string[]): void {
+  for (const id of ids) itemCache.delete(id)
 }
 
 export function getCachedItem(id: string): ScanItem | undefined {

--- a/src/renderer/src/pages/CleanerPage.tsx
+++ b/src/renderer/src/pages/CleanerPage.tsx
@@ -219,7 +219,7 @@ export function CleanerPage() {
               categoryBreakdown.push({
                 name: t(cat.labelKey),
                 type: cat.type,
-                found: catItemsAll.length,
+                found: catResults.reduce((sum, scan) => sum + scan.itemCount, 0),
                 cleaned: result.filesDeleted || 0,
                 space: result.totalCleaned || 0
               })
@@ -227,7 +227,13 @@ export function CleanerPage() {
           } catch { /* continue */ }
           activeIndex++
         } else if (catItemsAll.length > 0) {
-          categoryBreakdown.push({ name: t(cat.labelKey), type: cat.type, found: catItemsAll.length, cleaned: 0, space: 0 })
+          categoryBreakdown.push({
+            name: t(cat.labelKey),
+            type: cat.type,
+            found: catResults.reduce((sum, scan) => sum + scan.itemCount, 0),
+            cleaned: 0,
+            space: 0
+          })
         }
       }
 


### PR DESCRIPTION
## What does this PR do?

Updates recycle bin cleanup to report the actual number of deleted and skipped items, reclaimed bytes, partial failures, and elevation requirements. It also improves scan-cache lifecycle management, stale-result handling, deletion retries, and cleanup tracking across cleaner categories.

## Why?

Recycle bin cleanup previously reported a successful deletion even when items remained, overstated reclaimed space, and did not accurately reflect partial failures. Stale or evicted scan results could also be silently skipped during cleanup.

## How to test

- Run the relevant Vitest suites for recycle bin cleanup, file utilities, scan caching, and cleaner IPC handlers.
- On Windows, scan a populated Recycle Bin, clean it, and verify the result reports the actual deleted and remaining item counts and sizes.
- Verify partial cleanup reports skipped items and appropriate errors.
- Verify rescans replace only the relevant category’s cached results.

## Checklist

- [ ] Tested on my platform (Windows / macOS / Linux)
- [ ] `npm test` passes
- [ ] `npm run build` succeeds
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)