### PR TITLE
Fix Windows black screen by upgrading Electron

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "ajv": "^8.18.0",
         "conventional-changelog-angular": "^8.3.1",
         "conventional-changelog-cli": "^5.0.0",
-        "electron": "^41.3.0",
+        "electron": "^41.10.3",
         "electron-builder": "^26.8.1",
         "electron-vite": "^5.0.0",
         "patch-package": "^8.0.1",
@@ -4718,9 +4718,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "41.10.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.10.2.tgz",
-      "integrity": "sha512-vzSetbn05LPfg0gW0p9txpqmkkFyTXzdSHvKIXbtmsK362hkgUQJu+x19GSSS9v/VXeFi5UJI5TYJ1a+Os3CpA==",
+      "version": "41.10.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.10.3.tgz",
+      "integrity": "sha512-MJuSODPw8siv/I8JjhctW/cS/XNldwI4gLRyyWZx6QkoZJUDgbEvitp7IVOnGrHENTQb6Udo+zMpKhFnhlIhdg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "ajv": "^8.18.0",
     "conventional-changelog-angular": "^8.3.1",
     "conventional-changelog-cli": "^5.0.0",
-    "electron": "^41.3.0",
+    "electron": "^41.10.3",
     "electron-builder": "^26.8.1",
     "electron-vite": "^5.0.0",
     "patch-package": "^8.0.1",


### PR DESCRIPTION
## What does this PR do?

Upgrades Electron to version 41.10.3 and removes the cleaner page's unused result-sorting UI, state, logic, and translations.

## Why?

The Electron upgrade addresses the Windows black-screen issue. Removing the obsolete cleaner sorting functionality keeps the page implementation and localization files aligned with the current UI.

## How to test

- Install dependencies with `npm install`.
- Run the application on Windows and verify it launches without a black screen.
- Open the Cleaner page and confirm scan results display correctly.
- Verify category selection and the “Toggle All” action continue to work.

## Checklist

- [ ] Tested on my platform (Windows / macOS / Linux)
- [ ] `npm test` passes
- [ ] `npm run build` succeeds
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)