### PR TITLE
Fix elevated relaunches for Linux AppImages

### DIFF
--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -49,6 +49,7 @@ import {
 import { validateSettingsPartial, validateHistoryEntry, validateDeletionQuery } from '../services/ipc-validation'
 import { createRestorePoint } from '../services/restore-point'
 import { checkForUpdates, downloadUpdate, installUpdate, getUpdateStatus, setAutoDownload, updateCheckInterval } from '../services/auto-updater'
+import { buildLinuxElevationCommand, getLinuxRelaunchExecutable } from '../platform/linux/elevation'
 
 export type WindowGetter = () => BrowserWindow | null
 
@@ -191,17 +192,16 @@ export function registerCleanerIpc(getWindow: WindowGetter): void {
       // pkexec strips the environment for security.  We forward display
       // variables (for GUI) and HOME (so Chromium resolves cache/config
       // paths to the real user dirs instead of /root).
+      // AppImages run from a temporary FUSE mount, so launch the original
+      // AppImage file instead of app.getPath('exe'). The current mount can be
+      // removed as soon as this process exits (issue #290).
       // Use execFile so the app stays visible while the polkit dialog is
-      // open — if the user cancels, we keep running.  The elevated process
-      // is backgrounded with & so pkexec returns after auth succeeds
-      // (same pattern as the macOS osascript path).
-      const sq = (s: string) => `'${s.replace(/'/g, "'\\''")}'`
-      const parts: string[] = []
-      for (const key of ['DISPLAY', 'XAUTHORITY', 'WAYLAND_DISPLAY', 'XDG_RUNTIME_DIR', 'HOME', 'DBUS_SESSION_BUS_ADDRESS']) {
-        if (process.env[key]) parts.push(`${key}=${sq(process.env[key])}`)
-      }
-      parts.push(sq(exePath), '--no-sandbox', `--kudu-data-dir=${sq(userDataDir)}`)
-      execFile('pkexec', ['/bin/sh', '-c', `${parts.join(' ')} > /dev/null 2>&1 &`], (err) => {
+      // open — if the user cancels, we keep running. After authentication,
+      // the backgrounded helper waits for this process to release the
+      // single-instance lock before starting the elevated process.
+      const relaunchPath = getLinuxRelaunchExecutable(exePath)
+      const command = buildLinuxElevationCommand(relaunchPath, userDataDir)
+      execFile('pkexec', ['/bin/sh', '-c', command], (err) => {
         if (!err) {
           app.releaseSingleInstanceLock()
           app.exit(0)

--- a/src/main/platform/linux/elevation.test.ts
+++ b/src/main/platform/linux/elevation.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildLinuxElevationCommand,
+  createLinuxElevation,
+  getLinuxRelaunchExecutable,
+} from './elevation'
+
+describe('linux elevation', () => {
+  describe('isAdmin', () => {
+    it('returns whether the process uid is root', () => {
+      const elevation = createLinuxElevation()
+      const originalGetuid = process.getuid
+
+      try {
+        process.getuid = (() => 0) as typeof process.getuid
+        expect(elevation.isAdmin()).toBe(true)
+
+        process.getuid = (() => 1000) as typeof process.getuid
+        expect(elevation.isAdmin()).toBe(false)
+      } finally {
+        process.getuid = originalGetuid
+      }
+    })
+  })
+
+  describe('getLinuxRelaunchExecutable', () => {
+    it('prefers the original AppImage over its temporary mounted executable', () => {
+      const exePath = '/tmp/.mount_Kudu123/kudu'
+      const appImagePath = '/home/user/Applications/Kudu.AppImage'
+
+      expect(getLinuxRelaunchExecutable(exePath, appImagePath, () => true))
+        .toBe(appImagePath)
+    })
+
+    it('falls back to the executable for non-AppImage installs', () => {
+      const exePath = '/usr/bin/kudu'
+
+      expect(getLinuxRelaunchExecutable(exePath, undefined, () => true))
+        .toBe(exePath)
+    })
+
+    it('ignores stale or non-absolute APPIMAGE values', () => {
+      const exePath = '/usr/bin/kudu'
+
+      expect(getLinuxRelaunchExecutable(exePath, '/missing/Kudu.AppImage', () => false))
+        .toBe(exePath)
+      expect(getLinuxRelaunchExecutable(exePath, 'Kudu.AppImage', () => true))
+        .toBe(exePath)
+    })
+  })
+
+  describe('buildLinuxElevationCommand', () => {
+    it('waits for the current process before launching the elevated app', () => {
+      const command = buildLinuxElevationCommand(
+        '/home/user/Kudu.AppImage',
+        '/home/user/.config/Kudu',
+        { DISPLAY: ':0', HOME: '/home/user' },
+        1234,
+      )
+
+      expect(command).toContain('while kill -0 1234 2>/dev/null; do sleep 0.05; done;')
+      expect(command).toContain("DISPLAY=':0'")
+      expect(command).toContain("HOME='/home/user'")
+      expect(command).toContain("'/home/user/Kudu.AppImage' --no-sandbox")
+      expect(command).toContain("--kudu-data-dir='/home/user/.config/Kudu'")
+      expect(command).toMatch(/ > \/dev\/null 2>&1 &$/)
+    })
+
+    it('quotes paths and forwarded environment values for the shell', () => {
+      const command = buildLinuxElevationCommand(
+        "/home/user/Kudu's AppImage",
+        "/home/user/Kudu's data",
+        { DISPLAY: ":0'unsafe" },
+        42,
+      )
+
+      expect(command).toContain("DISPLAY=':0'\\''unsafe'")
+      expect(command).toContain("'/home/user/Kudu'\\''s AppImage'")
+      expect(command).toContain("--kudu-data-dir='/home/user/Kudu'\\''s data'")
+    })
+  })
+})

--- a/src/main/platform/linux/elevation.ts
+++ b/src/main/platform/linux/elevation.ts
@@ -1,4 +1,56 @@
+import { existsSync } from 'fs'
+import { isAbsolute } from 'path'
 import type { PlatformElevation } from '../types'
+
+/**
+ * AppImages execute Electron from a temporary FUSE mount. Relaunching that
+ * mounted executable is racy because the mount is torn down when the current
+ * AppImage exits. Prefer the original AppImage file, which remains available
+ * long enough for the elevated process to create its own mount.
+ */
+export function getLinuxRelaunchExecutable(
+  exePath: string,
+  appImagePath = process.env.APPIMAGE,
+  pathExists: (path: string) => boolean = existsSync,
+): string {
+  if (appImagePath && isAbsolute(appImagePath) && pathExists(appImagePath)) {
+    return appImagePath
+  }
+  return exePath
+}
+
+const ELEVATION_ENV_KEYS = [
+  'DISPLAY',
+  'XAUTHORITY',
+  'WAYLAND_DISPLAY',
+  'XDG_RUNTIME_DIR',
+  'HOME',
+  'DBUS_SESSION_BUS_ADDRESS',
+] as const
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`
+}
+
+/**
+ * Keep the authenticated helper alive until the current app has exited. This
+ * makes the single-instance lock hand-off deterministic: the old process
+ * releases the lock before the elevated process tries to acquire it.
+ */
+export function buildLinuxElevationCommand(
+  executable: string,
+  userDataDir: string,
+  environment: NodeJS.ProcessEnv = process.env,
+  parentPid = process.pid,
+): string {
+  const parts: string[] = []
+  for (const key of ELEVATION_ENV_KEYS) {
+    if (environment[key]) parts.push(`${key}=${shellQuote(environment[key])}`)
+  }
+  parts.push(shellQuote(executable), '--no-sandbox', `--kudu-data-dir=${shellQuote(userDataDir)}`)
+
+  return `(while kill -0 ${parentPid} 2>/dev/null; do sleep 0.05; done; ${parts.join(' ')}) > /dev/null 2>&1 &`
+}
 
 export function createLinuxElevation(): PlatformElevation {
   return {


### PR DESCRIPTION
## What does this PR do?

Updates Linux elevation handling to relaunch AppImages from their original file path instead of the temporary FUSE mount. The authenticated helper now waits for the original process to exit before starting the elevated instance, ensuring reliable single-instance lock handoff. Adds unit tests for executable selection, shell quoting, environment forwarding, and process waiting.

## Why?

AppImage mounts can be removed when the current process exits, making relaunches from `app.getPath('exe')` race-prone. Using the original AppImage path and waiting for the existing process to release its single-instance lock prevents elevated relaunch failures (issue #290).

## How to test

1. Run the Linux test suite and verify the new elevation tests pass.
2. Launch the application from an AppImage on Linux.
3. Trigger an action requiring elevation and confirm the polkit prompt appears.
4. Authenticate and verify the elevated application relaunches successfully.
5. Confirm non-AppImage Linux installations continue to relaunch correctly.

## Checklist

- [ ] Tested on my platform (Windows / macOS / Linux)
- [ ] `npm test` passes
- [ ] `npm run build` succeeds
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)