### PR TITLE
Avoid deleting files in use during scans

### DIFF
--- a/src/main/ipc/system-cleaner.ipc.test.ts
+++ b/src/main/ipc/system-cleaner.ipc.test.ts
@@ -30,12 +30,13 @@ vi.mock('../services/ipc-validation', () => ({
   validateStringArray: (input: unknown) => Array.isArray(input) ? input : null,
 }))
 
+const configuredUserTempPath = join(tmpdir(), '..', 'configured-user-temp')
 const ordinaryPath = join(tmpdir(), '..', 'ordinary-cache')
 vi.mock('../platform', () => ({
   getPlatform: () => ({
     paths: {
       systemCleanTargets: () => [
-        { path: tmpdir(), subcategory: 'User Temp Files' },
+        { path: configuredUserTempPath, subcategory: 'User Temp Files' },
         { path: ordinaryPath, subcategory: 'Ordinary Cache' },
       ],
       protectedEventLogs: () => [],
@@ -66,7 +67,7 @@ describe('system temp scanning', () => {
 
     expect(mockScanDirectory).toHaveBeenNthCalledWith(
       1,
-      tmpdir(),
+      configuredUserTempPath,
       'system',
       'User Temp Files',
       { skipRecentMinutes: 30, deepRecencyCheck: true },

--- a/src/main/ipc/system-cleaner.ipc.test.ts
+++ b/src/main/ipc/system-cleaner.ipc.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+const mockHandle = vi.fn()
+vi.mock('electron', () => ({
+  ipcMain: { handle: (...args: unknown[]) => mockHandle(...args) },
+}))
+
+const mockScanDirectory = vi.fn()
+const mockScanMultipleDirectories = vi.fn()
+vi.mock('../services/file-utils', () => ({
+  scanDirectory: (...args: unknown[]) => mockScanDirectory(...args),
+  scanFile: vi.fn(),
+  scanMultipleDirectories: (...args: unknown[]) => mockScanMultipleDirectories(...args),
+  resolveChildSubdirs: vi.fn(),
+  cleanItems: vi.fn(),
+}))
+
+vi.mock('../services/scan-cache', () => ({
+  cacheItems: vi.fn(),
+  clearCachedCategory: vi.fn(),
+}))
+
+vi.mock('../services/elevation', () => ({ isAdmin: () => true }))
+vi.mock('../services/settings-store', () => ({
+  getSettings: () => ({ cleaner: { skipRecentMinutes: 30 } }),
+}))
+vi.mock('../services/ipc-validation', () => ({
+  validateStringArray: (input: unknown) => Array.isArray(input) ? input : null,
+}))
+
+const ordinaryPath = join(tmpdir(), '..', 'ordinary-cache')
+vi.mock('../platform', () => ({
+  getPlatform: () => ({
+    paths: {
+      systemCleanTargets: () => [
+        { path: tmpdir(), subcategory: 'User Temp Files' },
+        { path: ordinaryPath, subcategory: 'Ordinary Cache' },
+      ],
+      protectedEventLogs: () => [],
+      singleFileCleanTargets: () => [],
+    },
+  }),
+}))
+
+import { registerSystemCleanerIpc } from './system-cleaner.ipc'
+
+function getHandler(channel: string): (...args: unknown[]) => unknown {
+  const call = mockHandle.mock.calls.find((entry) => entry[0] === channel)
+  if (!call) throw new Error(`No handler registered for ${channel}`)
+  return call[1] as (...args: unknown[]) => unknown
+}
+
+describe('system temp scanning', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockScanDirectory.mockResolvedValue({
+      category: 'system', subcategory: 'test', items: [], totalSize: 0, itemCount: 0,
+    })
+  })
+
+  it('uses the configured recency and inspects descendants only for user temp', async () => {
+    registerSystemCleanerIpc(() => null)
+    await getHandler('cleaner:system:scan')()
+
+    expect(mockScanDirectory).toHaveBeenNthCalledWith(
+      1,
+      tmpdir(),
+      'system',
+      'User Temp Files',
+      { skipRecentMinutes: 30, deepRecencyCheck: true },
+    )
+    expect(mockScanDirectory).toHaveBeenNthCalledWith(
+      2,
+      ordinaryPath,
+      'system',
+      'Ordinary Cache',
+      { skipRecentMinutes: 30, deepRecencyCheck: false },
+    )
+    expect(mockScanMultipleDirectories).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/system-cleaner.ipc.ts
+++ b/src/main/ipc/system-cleaner.ipc.ts
@@ -1,6 +1,4 @@
 import { ipcMain } from 'electron'
-import { tmpdir } from 'os'
-import { resolve } from 'path'
 import { IPC } from '../../shared/channels'
 import { getPlatform } from '../platform'
 import { scanDirectory, scanFile, scanMultipleDirectories, resolveChildSubdirs, cleanItems } from '../services/file-utils'
@@ -26,7 +24,6 @@ export function registerSystemCleanerIpc(getWindow: WindowGetter): void {
     const skipRecentMinutes = Number.isFinite(configuredRecency)
       ? Math.max(0, configuredRecency)
       : 60
-    const userTempPath = resolve(tmpdir())
 
     // Find the event logs target path for filtering
     const eventLogsTarget = targets.find((t) => t.subcategory === 'Event Log Archives')
@@ -50,11 +47,7 @@ export function registerSystemCleanerIpc(getWindow: WindowGetter): void {
           const childPaths = await resolveChildSubdirs([target.path], target.childSubdir)
           result = await scanMultipleDirectories(childPaths, category, target.subcategory, skipRecentMinutes)
         } else {
-          const targetPath = resolve(target.path)
-          const isUserTemp =
-            process.platform === 'win32'
-              ? targetPath.toLowerCase() === userTempPath.toLowerCase()
-              : targetPath === userTempPath
+          const isUserTemp = target.subcategory === 'User Temp Files'
           result = await scanDirectory(target.path, category, target.subcategory, {
             skipRecentMinutes,
             // Temp directories are frequently old while a descendant remains

--- a/src/main/ipc/system-cleaner.ipc.ts
+++ b/src/main/ipc/system-cleaner.ipc.ts
@@ -1,9 +1,12 @@
 import { ipcMain } from 'electron'
+import { tmpdir } from 'os'
+import { resolve } from 'path'
 import { IPC } from '../../shared/channels'
 import { getPlatform } from '../platform'
 import { scanDirectory, scanFile, scanMultipleDirectories, resolveChildSubdirs, cleanItems } from '../services/file-utils'
 import { cacheItems, clearCachedCategory } from '../services/scan-cache'
 import { isAdmin } from '../services/elevation'
+import { getSettings } from '../services/settings-store'
 import type { ScanResult, CleanResult } from '../../shared/types'
 import { CleanerType } from '../../shared/enums'
 import type { WindowGetter } from './index'
@@ -19,6 +22,11 @@ export function registerSystemCleanerIpc(getWindow: WindowGetter): void {
     const platform = getPlatform()
     const targets = platform.paths.systemCleanTargets()
     const protectedEventLogs = platform.paths.protectedEventLogs()
+    const configuredRecency = getSettings().cleaner.skipRecentMinutes
+    const skipRecentMinutes = Number.isFinite(configuredRecency)
+      ? Math.max(0, configuredRecency)
+      : 60
+    const userTempPath = resolve(tmpdir())
 
     // Find the event logs target path for filtering
     const eventLogsTarget = targets.find((t) => t.subcategory === 'Event Log Archives')
@@ -40,9 +48,20 @@ export function registerSystemCleanerIpc(getWindow: WindowGetter): void {
         let result: ScanResult
         if (target.childSubdir) {
           const childPaths = await resolveChildSubdirs([target.path], target.childSubdir)
-          result = await scanMultipleDirectories(childPaths, category, target.subcategory)
+          result = await scanMultipleDirectories(childPaths, category, target.subcategory, skipRecentMinutes)
         } else {
-          result = await scanDirectory(target.path, category, target.subcategory)
+          const targetPath = resolve(target.path)
+          const isUserTemp =
+            process.platform === 'win32'
+              ? targetPath.toLowerCase() === userTempPath.toLowerCase()
+              : targetPath === userTempPath
+          result = await scanDirectory(target.path, category, target.subcategory, {
+            skipRecentMinutes,
+            // Temp directories are frequently old while a descendant remains
+            // open for the lifetime of an application. Inspect the contents so
+            // one active file is never hidden inside a recursively deleted item.
+            deepRecencyCheck: isUserTemp,
+          })
         }
 
         // Exclude protected event logs so boot trace data survives cleaning

--- a/src/main/services/file-utils.test.ts
+++ b/src/main/services/file-utils.test.ts
@@ -86,8 +86,12 @@ describe('deleteFailureReason', () => {
     expect(deleteFailureReason({ code: 'ENOTEMPTY' })).toBe('in-use')
   })
 
-  it('reports Windows EPERM as a permission failure', () => {
-    expect(deleteFailureReason({ code: 'EPERM' })).toBe('permission-denied')
+  it('reports Windows EPERM sharing violations as in use', () => {
+    expect(deleteFailureReason({ code: 'EPERM' }, 'win32')).toBe('in-use')
+  })
+
+  it('keeps non-Windows EPERM and EACCES as permission failures', () => {
+    expect(deleteFailureReason({ code: 'EPERM' }, 'linux')).toBe('permission-denied')
     expect(deleteFailureReason({ code: 'EACCES' })).toBe('permission-denied')
   })
 

--- a/src/main/services/file-utils.test.ts
+++ b/src/main/services/file-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { isExcluded } from './file-utils'
+import { deleteFailureReason, isExcluded } from './file-utils'
 
 // Mock settings-store to prevent Electron import
 vi.mock('./settings-store', () => ({
@@ -77,5 +77,21 @@ describe('isExcluded', () => {
   it('extension pattern requires dot', () => {
     // *.log should match .log extension, not just "log" at the end
     expect(isExcluded('C:\\temp\\catalog', ['*.log'])).toBe(false)
+  })
+})
+
+describe('deleteFailureReason', () => {
+  it('only describes busy or changing paths as in use', () => {
+    expect(deleteFailureReason({ code: 'EBUSY' })).toBe('in-use')
+    expect(deleteFailureReason({ code: 'ENOTEMPTY' })).toBe('in-use')
+  })
+
+  it('reports Windows EPERM as a permission failure', () => {
+    expect(deleteFailureReason({ code: 'EPERM' })).toBe('permission-denied')
+    expect(deleteFailureReason({ code: 'EACCES' })).toBe('permission-denied')
+  })
+
+  it('preserves an otherwise unknown filesystem message', () => {
+    expect(deleteFailureReason({ code: 'EIO', message: 'device error' })).toBe('device error')
   })
 })

--- a/src/main/services/file-utils.ts
+++ b/src/main/services/file-utils.ts
@@ -15,9 +15,15 @@ export interface DeleteResult {
 }
 
 /** Translate filesystem failures without conflating permissions with locks. */
-export function deleteFailureReason(err: { code?: string; message?: string }): string {
+export function deleteFailureReason(
+  err: { code?: string; message?: string },
+  platform: NodeJS.Platform = process.platform,
+): string {
   if (err.code === 'EBUSY' || err.code === 'ENOTEMPTY') return 'in-use'
-  if (err.code === 'EPERM' || err.code === 'EACCES') return 'permission-denied'
+  // Windows reports sharing violations as EPERM. Treating them as an access
+  // failure incorrectly prompts for elevation, which cannot release a lock.
+  if (err.code === 'EPERM') return platform === 'win32' ? 'in-use' : 'permission-denied'
+  if (err.code === 'EACCES') return 'permission-denied'
   return err.message || 'unknown-error'
 }
 

--- a/src/main/services/file-utils.ts
+++ b/src/main/services/file-utils.ts
@@ -14,6 +14,13 @@ export interface DeleteResult {
   reason?: string
 }
 
+/** Translate filesystem failures without conflating permissions with locks. */
+export function deleteFailureReason(err: { code?: string; message?: string }): string {
+  if (err.code === 'EBUSY' || err.code === 'ENOTEMPTY') return 'in-use'
+  if (err.code === 'EPERM' || err.code === 'EACCES') return 'permission-denied'
+  return err.message || 'unknown-error'
+}
+
 /**
  * Check if a path matches any of the configured exclusions.
  * Supports exact path prefixes and *.ext glob patterns.
@@ -97,16 +104,10 @@ export async function safeDelete(filePath: string): Promise<DeleteResult> {
     await rm(filePath, { force: true, recursive: true, maxRetries: 3, retryDelay: 100 })
     return { path: filePath, success: true }
   } catch (err: any) {
-    if (err.code === 'EBUSY' || err.code === 'EPERM') {
-      return { path: filePath, success: false, reason: 'in-use' }
-    }
-    if (err.code === 'EACCES') {
-      return { path: filePath, success: false, reason: 'permission-denied' }
-    }
     if (err.code === 'ENOENT') {
       return { path: filePath, success: true }
     }
-    return { path: filePath, success: false, reason: err.message }
+    return { path: filePath, success: false, reason: deleteFailureReason(err) }
   }
 }
 

--- a/src/main/services/yara-engine.test.ts
+++ b/src/main/services/yara-engine.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { YaraEngine } from './yara-engine'
 
 // ─── Test pure conversion logic (replicated to avoid Electron imports) ───
 
@@ -170,5 +174,27 @@ rule Test_Simple {
     // Scan again — should still work (rules not recompiled)
     const match2 = scanner.scan(Buffer.from('another target file'))
     expect(match2.length).toBe(1)
+  })
+})
+
+describe('YaraEngine.scanFile', () => {
+  it('closes the file before passing its contents to the native scanner', () => {
+    const testDir = mkdtempSync(join(tmpdir(), 'kudu-yara-engine-'))
+    try {
+      const filePath = join(testDir, 'sample.bin')
+      writeFileSync(filePath, Buffer.from('sample contents'))
+
+      const scan = vi.fn(() => [])
+      const nativeScanFile = vi.fn(() => [])
+      const engine = new YaraEngine()
+      ;(engine as any)._scanner = { scan, scanFile: nativeScanFile }
+
+      expect(engine.scanFile(filePath)).toEqual([])
+      expect(scan).toHaveBeenCalledOnce()
+      expect(scan.mock.calls[0][0]).toEqual(Buffer.from('sample contents'))
+      expect(nativeScanFile).not.toHaveBeenCalled()
+    } finally {
+      rmSync(testDir, { recursive: true, force: true })
+    }
   })
 })

--- a/src/main/services/yara-engine.ts
+++ b/src/main/services/yara-engine.ts
@@ -196,13 +196,19 @@ export class YaraEngine {
   }
 
   /**
-   * Scan a file directly from disk (avoids reading into JS memory).
+   * Scan a file from an in-memory snapshot.
+   *
+   * The native `scanFile` API keeps an OS file handle while scanning. If a
+   * cleaner runs concurrently, that makes the malware scanner itself an owner
+   * of the file it is trying to remove. `readFileSync` closes its handle before
+   * native pattern matching starts, eliminating that overlap.
    */
   scanFile(filePath: string): YaraMatch[] {
     if (!this._scanner) return []
 
     try {
-      const results = this._scanner.scanFile(filePath)
+      const contents = readFileSync(filePath)
+      const results = this._scanner.scan(contents)
       return results.map(r => this._convertMatch(r))
     } catch (err) {
       console.warn('[yara] File scan error:', err)


### PR DESCRIPTION
## What does this PR do?

Prevents system cleaning from deleting files that are still in use during scans. User temp scans now apply recursive recency checks, filesystem deletion errors distinguish locked files from permission failures, and YARA scans read files into memory before native scanning so file handles are closed.

## Why?

Concurrent malware scanning could keep file handles open while the cleaner recursively deleted directories, causing active files to be missed or deletion failures to be misclassified. This change reduces scan/cleaner contention and improves cleanup error reporting.

## How to test

- Run `npm test`.
- Verify system temp scans use the configured recency window and inspect descendants.
- Verify deletion failures classify busy, permission, and unknown filesystem errors correctly.
- Verify YARA file scans close the file before native pattern matching.

## Checklist

- [ ] Tested on my platform (Windows / macOS / Linux)
- [ ] `npm test` passes
- [ ] `npm run build` succeeds
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.com/)