### PR TITLE
Salvage unlocked files after recursive cleanup failures

### DIFF
--- a/src/main/services/file-utils.delete.test.ts
+++ b/src/main/services/file-utils.delete.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type { ScanItem } from '../../shared/types'
+
+const state = vi.hoisted(() => ({
+  rootPath: '',
+  rootFailuresRemaining: 0,
+  lockedPath: '',
+  items: [] as ScanItem[],
+}))
+
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs/promises')>()
+  return {
+    ...actual,
+    rm: async (...args: Parameters<typeof actual.rm>) => {
+      const path = String(args[0])
+      const options = args[1] as { recursive?: boolean } | undefined
+      if (path === state.rootPath && options?.recursive && state.rootFailuresRemaining > 0) {
+        state.rootFailuresRemaining--
+        throw Object.assign(new Error('sharing violation'), { code: 'EPERM' })
+      }
+      if (path === state.lockedPath) {
+        throw Object.assign(new Error('sharing violation'), { code: 'EPERM' })
+      }
+      return actual.rm(...args)
+    },
+  }
+})
+
+vi.mock('./settings-store', () => ({
+  getSettings: () => ({
+    cleaner: { secureDelete: false, skipRecentMinutes: 60, keepDeletionLog: false },
+    exclusions: [],
+  }),
+}))
+
+vi.mock('./scan-cache', () => ({
+  getCachedItems: () => state.items,
+  removeCachedItems: () => {},
+}))
+
+vi.mock('./deletion-log-store', () => ({ recordDeletions: () => {} }))
+
+import { cleanItems, safeDelete } from './file-utils'
+
+let testDir: string
+
+function createTree(): { root: string; removable: string; locked: string } {
+  const root = join(testDir, 'abandoned-app')
+  const removable = join(root, 'cache.tmp')
+  const locked = join(root, 'resources', 'app.asar')
+  mkdirSync(join(root, 'resources'), { recursive: true })
+  writeFileSync(removable, 'cache')
+  writeFileSync(locked, 'archive')
+  return { root, removable, locked }
+}
+
+describe('granular directory deletion fallback', () => {
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'kudu-delete-'))
+    state.rootPath = ''
+    state.rootFailuresRemaining = 0
+    state.lockedPath = ''
+    state.items = []
+  })
+
+  afterEach(() => {
+    if (testDir && existsSync(testDir)) rmSync(testDir, { recursive: true, force: true })
+  })
+
+  it('removes the whole tree when only the coarse recursive delete fails', async () => {
+    const { root } = createTree()
+    state.rootPath = root
+    // attemptDelete retries once after clearing a Windows read-only attribute.
+    state.rootFailuresRemaining = process.platform === 'win32' ? 2 : 1
+
+    const result = await safeDelete(root)
+
+    expect(result).toEqual({ path: root, success: true })
+    expect(existsSync(root)).toBe(false)
+  })
+
+  it('deletes removable siblings and reports only the exact locked descendant', async () => {
+    const { root, removable, locked } = createTree()
+    state.rootPath = root
+    state.rootFailuresRemaining = process.platform === 'win32' ? 2 : 1
+    state.lockedPath = locked
+    state.items = [{
+      id: 'abandoned-app',
+      path: root,
+      size: 12,
+      category: 'system',
+      subcategory: 'User Temp Files',
+      lastModified: 0,
+      selected: true,
+    }]
+
+    const result = await cleanItems(['abandoned-app'])
+
+    expect(existsSync(removable)).toBe(false)
+    expect(existsSync(locked)).toBe(true)
+    expect(result.filesDeleted).toBe(0)
+    expect(result.filesSkipped).toBe(1)
+    expect(result.errors).toEqual([{ path: locked, reason: 'in-use' }])
+    expect(result.needsElevation).toBe(false)
+  })
+
+  it('unlinks directory junctions without traversing their targets', async () => {
+    const { root } = createTree()
+    const external = join(testDir, 'keep-external')
+    const externalFile = join(external, 'keep.dat')
+    mkdirSync(external)
+    writeFileSync(externalFile, 'keep')
+    try {
+      symlinkSync(external, join(root, 'external-link'), 'junction')
+    } catch {
+      return // Unprivileged Windows without junction creation support.
+    }
+    state.rootPath = root
+    state.rootFailuresRemaining = process.platform === 'win32' ? 2 : 1
+
+    const result = await safeDelete(root)
+
+    expect(result.success).toBe(true)
+    expect(existsSync(root)).toBe(false)
+    expect(existsSync(externalFile)).toBe(true)
+  })
+})

--- a/src/main/services/file-utils.delete.test.ts
+++ b/src/main/services/file-utils.delete.test.ts
@@ -104,8 +104,9 @@ describe('granular directory deletion fallback', () => {
     expect(existsSync(locked)).toBe(true)
     expect(result.filesDeleted).toBe(0)
     expect(result.filesSkipped).toBe(1)
-    expect(result.errors).toEqual([{ path: locked, reason: 'in-use' }])
-    expect(result.needsElevation).toBe(false)
+    const expectedReason = process.platform === 'win32' ? 'in-use' : 'permission-denied'
+    expect(result.errors).toEqual([{ path: locked, reason: expectedReason }])
+    expect(result.needsElevation).toBe(process.platform !== 'win32')
   })
 
   it('unlinks directory junctions without traversing their targets', async () => {

--- a/src/main/services/file-utils.ts
+++ b/src/main/services/file-utils.ts
@@ -1,4 +1,4 @@
-import { chmod, rm, rmdir, stat, lstat, readdir, open, writeFile } from 'fs/promises'
+import { chmod, rm, rmdir, stat, lstat, readdir, open } from 'fs/promises'
 import { existsSync } from 'fs'
 import type { Dirent, Stats } from 'fs'
 import { join } from 'path'

--- a/src/main/services/file-utils.ts
+++ b/src/main/services/file-utils.ts
@@ -1,4 +1,4 @@
-import { rm, stat, lstat, readdir, open, writeFile } from 'fs/promises'
+import { chmod, rm, rmdir, stat, lstat, readdir, open, writeFile } from 'fs/promises'
 import { existsSync } from 'fs'
 import type { Dirent, Stats } from 'fs'
 import { join } from 'path'
@@ -12,6 +12,8 @@ export interface DeleteResult {
   path: string
   success: boolean
   reason?: string
+  /** Exact paths left behind when a recursive directory delete only partially succeeds. */
+  failures?: Array<{ path: string; reason: string }>
 }
 
 /** Translate filesystem failures without conflating permissions with locks. */
@@ -25,6 +27,93 @@ export function deleteFailureReason(
   if (err.code === 'EPERM') return platform === 'win32' ? 'in-use' : 'permission-denied'
   if (err.code === 'EACCES') return 'permission-denied'
   return err.message || 'unknown-error'
+}
+
+type FilesystemFailure = { code?: string; message?: string }
+const GRANULAR_DELETE_ERRORS = new Set(['EBUSY', 'EPERM', 'EACCES', 'ENOTEMPTY'])
+
+async function attemptDelete(
+  filePath: string,
+  operation: () => Promise<void>,
+): Promise<FilesystemFailure | null> {
+  try {
+    await operation()
+    return null
+  } catch (err: any) {
+    if (err.code === 'ENOENT') return null
+
+    // A read-only attribute is also surfaced as EPERM on Windows. Clear it and
+    // retry before deciding the path is locked; a real sharing violation will
+    // simply fail the second attempt too.
+    if (process.platform === 'win32' && err.code === 'EPERM') {
+      try {
+        await chmod(filePath, 0o666)
+        await operation()
+        return null
+      } catch (retryErr: any) {
+        if (retryErr.code === 'ENOENT') return null
+        return retryErr
+      }
+    }
+
+    return err
+  }
+}
+
+function recordDeleteFailure(
+  failures: NonNullable<DeleteResult['failures']>,
+  filePath: string,
+  err: FilesystemFailure,
+): void {
+  failures.push({ path: filePath, reason: deleteFailureReason(err) })
+}
+
+/**
+ * Remove a real directory from the leaves upward without following symlinks.
+ * This is the recovery path after the fast recursive rm failed: one bad child
+ * must not prevent settled siblings from being reclaimed.
+ */
+async function deleteDirectoryBestEffort(
+  dirPath: string,
+  failures: NonNullable<DeleteResult['failures']>,
+): Promise<void> {
+  let entries: Dirent[]
+  try {
+    entries = await readdir(dirPath, { withFileTypes: true })
+  } catch (err: any) {
+    if (err.code !== 'ENOENT') recordDeleteFailure(failures, dirPath, err)
+    return
+  }
+
+  const failuresBeforeChildren = failures.length
+  for (const entry of entries) {
+    const childPath = join(dirPath, entry.name)
+    let info: Awaited<ReturnType<typeof lstat>>
+    try {
+      info = await lstat(childPath)
+    } catch (err: any) {
+      if (err.code !== 'ENOENT') recordDeleteFailure(failures, childPath, err)
+      continue
+    }
+
+    if (info.isDirectory() && !info.isSymbolicLink()) {
+      await deleteDirectoryBestEffort(childPath, failures)
+      continue
+    }
+
+    const failure = await attemptDelete(childPath, () =>
+      rm(childPath, { force: true, maxRetries: 3, retryDelay: 100 })
+    )
+    if (failure) recordDeleteFailure(failures, childPath, failure)
+  }
+
+  const directoryFailure = await attemptDelete(dirPath, () =>
+    rmdir(dirPath, { maxRetries: 3, retryDelay: 100 })
+  )
+  // If a child already explains ENOTEMPTY, avoid also blaming every ancestor.
+  if (directoryFailure && failures.length === failuresBeforeChildren) {
+    recordDeleteFailure(failures, dirPath, directoryFailure)
+  }
 }
 
 /**
@@ -95,25 +184,50 @@ async function secureOverwrite(filePath: string): Promise<void> {
 }
 
 export async function safeDelete(filePath: string): Promise<DeleteResult> {
+  const settings = getSettings()
+  if (settings.cleaner.secureDelete) {
+    try {
+      await secureOverwrite(filePath)
+    } catch {
+      // If overwrite fails (e.g. permission), still attempt normal deletion
+    }
+  }
+
+  // Recursive rm only retries transient EBUSY/EPERM/ENOTEMPTY failures when
+  // maxRetries is non-zero. Cache trees are frequently touched by antivirus
+  // and indexer processes for a few milliseconds after scanning.
+  const initialFailure = await attemptDelete(filePath, () =>
+    rm(filePath, { force: true, recursive: true, maxRetries: 3, retryDelay: 100 })
+  )
+  if (!initialFailure) return { path: filePath, success: true }
+  if (!initialFailure.code || !GRANULAR_DELETE_ERRORS.has(initialFailure.code)) {
+    return { path: filePath, success: false, reason: deleteFailureReason(initialFailure) }
+  }
+
+  let rootInfo: Awaited<ReturnType<typeof lstat>>
   try {
-    const settings = getSettings()
-    if (settings.cleaner.secureDelete) {
-      try {
-        await secureOverwrite(filePath)
-      } catch {
-        // If overwrite fails (e.g. permission), still attempt normal deletion
-      }
-    }
-    // Recursive rm only retries transient EBUSY/EPERM/ENOTEMPTY failures when
-    // maxRetries is non-zero. Cache trees are frequently touched by antivirus
-    // and indexer processes for a few milliseconds after scanning.
-    await rm(filePath, { force: true, recursive: true, maxRetries: 3, retryDelay: 100 })
-    return { path: filePath, success: true }
+    rootInfo = await lstat(filePath)
   } catch (err: any) {
-    if (err.code === 'ENOENT') {
-      return { path: filePath, success: true }
-    }
-    return { path: filePath, success: false, reason: deleteFailureReason(err) }
+    if (err.code === 'ENOENT') return { path: filePath, success: true }
+    return { path: filePath, success: false, reason: deleteFailureReason(initialFailure) }
+  }
+
+  // Files and symlinks have no independent descendants to salvage.
+  if (!rootInfo.isDirectory() || rootInfo.isSymbolicLink()) {
+    return { path: filePath, success: false, reason: deleteFailureReason(initialFailure) }
+  }
+
+  const failures: NonNullable<DeleteResult['failures']> = []
+  await deleteDirectoryBestEffort(filePath, failures)
+  if (failures.length === 0) {
+    return { path: filePath, success: true }
+  }
+
+  return {
+    path: filePath,
+    success: false,
+    reason: failures[0].reason,
+    failures,
   }
 }
 
@@ -271,7 +385,9 @@ export async function cleanItems(
       }
     } else {
       filesSkipped++
-      if (result.reason) {
+      if (result.failures?.length) {
+        errors.push(...result.failures)
+      } else if (result.reason) {
         errors.push({ path: item.path, reason: result.reason })
       }
     }


### PR DESCRIPTION
## What changed

- Keep the fast recursive delete as the normal path.
- When a directory delete fails with a recoverable Windows/filesystem error, retry its contents individually from the leaves upward.
- Clear Windows read-only attributes before classifying an `EPERM` path as locked.
- Delete every removable sibling and report only the exact paths that remain inaccessible.
- Avoid following symlinks and directory junctions during fallback traversal.

## Why

Follow-up to #312. A cleaner item often represents an entire temporary directory. If the single recursive removal returned `EPERM`, Kudu reported that whole directory as `in-use`, even when most or all descendants were removable. This could leave abandoned application extraction trees such as `bramblewatch-biomes-final` behind and obscure which path actually prevented deletion.

## User impact

Abandoned temporary trees are now fully removed when the coarse recursive failure is transient or caused by a removable/read-only descendant. If one file is genuinely locked, Kudu still reclaims everything else and reports that exact file instead of blaming the top-level directory.

## Safety

- Granular recovery is limited to `EBUSY`, `EPERM`, `EACCES`, and `ENOTEMPTY` failures.
- Real directories are traversed only after `lstat`; symlinks and junctions are unlinked without traversing their targets.
- Non-recoverable I/O errors retain the existing fail-fast behavior.

## Validation

- `npm test` — 112 files and 2,477 tests passed.
- `npm run build` — passed.
- Added regressions for full recovery, one genuinely locked descendant, and junction-target preservation.