### PR TITLE
Restore auto-deactivate detection lifecycle

### DIFF
--- a/src/main/ipc/game-mode.ipc.test.ts
+++ b/src/main/ipc/game-mode.ipc.test.ts
@@ -13,6 +13,23 @@ let psOutput: Array<[string, string]> = []
 
 const fakeFs = new Map<string, string>()
 
+const gameDetectorMocks = vi.hoisted(() => ({
+  startGameDetector: vi.fn(),
+  stopGameDetector: vi.fn(),
+  suppressCurrentGame: vi.fn(),
+  isDetectorRunning: vi.fn(() => false),
+}))
+
+const settingsMock = vi.hoisted(() => ({
+  gameMode: {
+    enabledOptimizations: ['net-flush-dns'],
+    customProcessKillList: [] as string[],
+    autoDetect: false,
+    autoDeactivate: true,
+    customGameProcesses: [] as string[],
+  },
+}))
+
 vi.mock('electron', () => ({
   app: { isPackaged: true, getPath: () => 'C:\\kudu-test-userdata' },
   ipcMain: { handle: vi.fn() },
@@ -54,16 +71,11 @@ vi.mock('child_process', () => ({
 vi.mock('../services/exec-utf8', () => ({ psUtf8: (s: string) => s }))
 vi.mock('../services/elevation', () => ({ isAdmin: () => true }))
 vi.mock('../platform', () => ({ getPlatform: () => ({ network: { flushDnsCache: async () => true } }) }))
-vi.mock('../services/game-detector', () => ({
-  startGameDetector: vi.fn(),
-  stopGameDetector: vi.fn(),
-  suppressCurrentGame: vi.fn(),
-  isDetectorRunning: () => false,
-}))
-vi.mock('../services/settings-store', () => ({ getSettings: () => ({ gameMode: { autoDetect: false } }) }))
+vi.mock('../services/game-detector', () => gameDetectorMocks)
+vi.mock('../services/settings-store', () => ({ getSettings: () => settingsMock }))
 
 import { join } from 'path'
-import { deactivateGameMode, discardPendingRestore, getGameModeStatus } from './game-mode.ipc'
+import { deactivateGameMode, discardPendingRestore, getGameModeStatus, initGameDetector } from './game-mode.ipc'
 
 // Built with join() rather than hardcoded so the fake fs keys match on both
 // Windows and the Linux CI runner.
@@ -641,6 +653,63 @@ describe('deactivateGameMode residual handling', () => {
     expect(result.restored).toBe(0)
     expect(result.failed).toBe(0)
     expect(fakeFs.has(SNAPSHOT_PATH)).toBe(false)
+  })
+})
+
+describe('auto-deactivate lifecycle (issue #289)', () => {
+  beforeEach(() => {
+    fakeFs.clear()
+    psCalls.length = 0
+    psFailOn = []
+    psOutput = []
+    gameDetectorMocks.startGameDetector.mockReset()
+    gameDetectorMocks.stopGameDetector.mockReset()
+    settingsMock.gameMode.autoDetect = true
+    settingsMock.gameMode.autoDeactivate = true
+  })
+
+  it('activates on detection and restores on exit', async () => {
+    const sendAutoEvent = vi.fn()
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+
+    try {
+      initGameDetector(() => null, noop, sendAutoEvent)
+      const callbacks = gameDetectorMocks.startGameDetector.mock.calls[0]?.[0]
+
+      expect(callbacks).toBeDefined()
+      await expect(callbacks.onGameDetected('cs2.exe')).resolves.toBe(true)
+      expect(getGameModeStatus().active).toBe(true)
+      expect(sendAutoEvent).toHaveBeenCalledWith({ type: 'game-detected', processName: 'cs2.exe' })
+
+      await callbacks.onGameExited()
+
+      expect(getGameModeStatus().active).toBe(false)
+      expect(sendAutoEvent).toHaveBeenLastCalledWith({ type: 'game-exited', processName: null })
+    } finally {
+      platformSpy.mockRestore()
+    }
+  })
+
+  it('tracks and deactivates a session that was already active when the game was detected', async () => {
+    seedSnapshot()
+    const sendAutoEvent = vi.fn()
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+
+    try {
+      initGameDetector(() => null, noop, sendAutoEvent)
+      const callbacks = gameDetectorMocks.startGameDetector.mock.calls[0]?.[0]
+
+      expect(callbacks).toBeDefined()
+      await expect(callbacks.onGameDetected('cs2.exe')).resolves.toBe(true)
+      expect(sendAutoEvent).toHaveBeenCalledWith({ type: 'game-detected', processName: 'cs2.exe' })
+
+      await callbacks.onGameExited()
+
+      expect(fakeFs.has(SNAPSHOT_PATH)).toBe(false)
+      expect(sendAutoEvent).toHaveBeenLastCalledWith({ type: 'game-exited', processName: null })
+    } finally {
+      platformSpy.mockRestore()
+    }
   })
 })
 

--- a/src/main/ipc/game-mode.ipc.ts
+++ b/src/main/ipc/game-mode.ipc.ts
@@ -889,11 +889,6 @@ function validateGameModeConfig(input: unknown): GameModeConfig | null {
   return obj as unknown as GameModeConfig
 }
 
-// ── Auto-activation tracking ────────────────────────────────────
-
-/** true when Game Mode was activated automatically by the game detector */
-let autoActivated = false
-
 export function registerGameModeIpc(getWindow: WindowGetter): void {
   const sendProgress = (data: GameModeProgress): void => {
     const win = getWindow()
@@ -931,16 +926,14 @@ export function registerGameModeIpc(getWindow: WindowGetter): void {
         snapshot: null,
       }
     }
-    autoActivated = false // manual activation
     return activateGameMode(config, sendProgress)
   })
 
   ipcMain.handle(IPC.GAME_MODE_DEACTIVATE, async () => {
     // If auto-detect is on and a game is still running, suppress re-activation
-    if (autoActivated || isDetectorRunning()) {
+    if (isDetectorRunning()) {
       suppressCurrentGame()
     }
-    autoActivated = false
     return deactivateGameMode(sendProgress)
   })
 
@@ -974,25 +967,29 @@ export function initGameDetector(
   startGameDetector(
     {
       onGameDetected: async (processName) => {
-        // Don't activate if already active
-        if (readSnapshot() !== null) return
+        const existing = readSnapshot()
+        // Track a game that starts while Game Mode is already active. This lets
+        // auto-deactivate honor its UI contract for manually activated sessions
+        // and after a main-process restart, where an in-memory origin flag is lost.
+        if (existing?.active) {
+          sendAutoEvent({ type: 'game-detected', processName })
+          return true
+        }
+        // A pending restore must be cleared before another activation can start.
+        if (existing) return false
 
         const cfg = getSettings().gameMode
-        if (cfg.enabledOptimizations.length === 0) return
+        if (cfg.enabledOptimizations.length === 0) return false
 
-        autoActivated = true
-        await activateGameMode(cfg, sendProgress)
+        const result = await activateGameMode(cfg, sendProgress)
+        if (result.succeeded === 0) return false
         sendAutoEvent({ type: 'game-detected', processName })
+        return true
       },
       onGameExited: async () => {
-        // Only relevant if we auto-activated
-        if (!autoActivated) return
-
-        const wasAutoActivated = autoActivated
-        autoActivated = false
-
         const cfg = getSettings().gameMode
-        if (cfg.autoDeactivate !== false && wasAutoActivated) {
+        const snapshot = readSnapshot()
+        if (cfg.autoDeactivate !== false && snapshot?.active) {
           await deactivateGameMode(sendProgress)
         }
 

--- a/src/main/services/game-detector.test.ts
+++ b/src/main/services/game-detector.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const processListMock = vi.hoisted(() => ({
+  stdout: '',
+  error: null as Error | null,
+}))
+
+vi.mock('child_process', () => ({
+  execFile: (
+    _file: string,
+    _args: string[],
+    _options: unknown,
+    callback: (error: Error | null, result?: { stdout: string; stderr: string }) => void,
+  ) => {
+    if (processListMock.error) {
+      callback(processListMock.error)
+      return
+    }
+    callback(null, { stdout: processListMock.stdout, stderr: '' })
+  },
+}))
+
+import { getDetectedGame, startGameDetector, stopGameDetector } from './game-detector'
+
+describe('game detector lifecycle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    processListMock.stdout = ''
+    processListMock.error = null
+  })
+
+  afterEach(() => {
+    stopGameDetector()
+    vi.useRealTimers()
+  })
+
+  it('retries detection when activation was not accepted', async () => {
+    processListMock.stdout = '"cs2.exe","1234","Console","1","100 K"\r\n'
+    const onGameDetected = vi.fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true)
+    const onGameExited = vi.fn()
+
+    startGameDetector({ onGameDetected, onGameExited }, [])
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(onGameDetected).toHaveBeenCalledTimes(1)
+    expect(getDetectedGame()).toBeNull()
+
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    expect(onGameDetected).toHaveBeenCalledTimes(2)
+    expect(getDetectedGame()).toBe('cs2.exe')
+  })
+
+  it('does not treat a failed process query as a game exit', async () => {
+    processListMock.stdout = '"cs2.exe","1234","Console","1","100 K"\r\n'
+    const onGameDetected = vi.fn().mockResolvedValue(true)
+    const onGameExited = vi.fn()
+
+    startGameDetector({ onGameDetected, onGameExited }, [])
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getDetectedGame()).toBe('cs2.exe')
+
+    processListMock.error = new Error('tasklist unavailable')
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    expect(onGameExited).not.toHaveBeenCalled()
+    expect(getDetectedGame()).toBe('cs2.exe')
+  })
+})

--- a/src/main/services/game-detector.ts
+++ b/src/main/services/game-detector.ts
@@ -58,8 +58,9 @@ export interface GameAutoEvent {
 }
 
 export interface GameDetectorCallbacks {
-  onGameDetected: (processName: string) => void
-  onGameExited: () => void
+  /** Return true once the detected game has been accepted for this session. */
+  onGameDetected: (processName: string) => boolean | Promise<boolean>
+  onGameExited: () => void | Promise<void>
 }
 
 // ── State ──────────────────────────────────────────────────────
@@ -74,7 +75,7 @@ let suppressedGame: string | null = null
 
 // ── Detection ──────────────────────────────────────────────────
 
-async function getRunningProcessNames(): Promise<Set<string>> {
+async function getRunningProcessNames(): Promise<Set<string> | null> {
   try {
     const { stdout } = await execFileAsync('tasklist', ['/FO', 'CSV', '/NH'], {
       timeout: 10_000,
@@ -87,7 +88,8 @@ async function getRunningProcessNames(): Promise<Set<string>> {
     }
     return names
   } catch {
-    return new Set()
+    // A failed tasklist call is not evidence that the tracked game exited.
+    return null
   }
 }
 
@@ -107,14 +109,21 @@ async function poll(customGameProcesses: string[]): Promise<void> {
 
   try {
     const running = await getRunningProcessNames()
+    if (running === null) return
     const game = findGame(running, customGameProcesses)
 
     if (game && !detectedGame) {
       // Game just appeared
       if (game === suppressedGame) return // user manually deactivated this session
-      detectedGame = game
-      suppressedGame = null
-      try { await callbacks.onGameDetected(game) } catch { /* logged by caller */ }
+      try {
+        // Only mark the process as tracked once Game Mode is active (or the
+        // caller confirms an existing active session). Otherwise a transient
+        // activation failure would suppress every retry until the game exits.
+        if (await callbacks.onGameDetected(game)) {
+          detectedGame = game
+          suppressedGame = null
+        }
+      } catch { /* logged by caller */ }
     } else if (!game && detectedGame) {
       // Game just exited
       detectedGame = null


### PR DESCRIPTION
## What does this PR do?

Restores the auto-deactivate lifecycle for detected games by:

- Tracking games detected while Game Mode is already active.
- Confirming successful activation before marking a game as tracked.
- Retrying detection when activation is not accepted.
- Preserving tracked-game state when process enumeration fails.
- Updating IPC and detector tests to cover these scenarios.

## Why?

Fixes issue #289 by ensuring Game Mode reliably deactivates when a detected game exits, including manually activated sessions and sessions spanning a main-process restart. Detection failures and unsuccessful activations no longer incorrectly suppress retries or appear as game exits.

## How to test

1. Run `npm test`.
2. Enable game detection and auto-deactivate.
3. Start a configured game and verify Game Mode activates.
4. Exit the game and verify Game Mode deactivates and emits the expected automatic events.
5. Verify detection retries after an unsuccessful activation and does not treat a failed process query as a game exit.

## Checklist

- [ ] Tested on my platform (Windows / macOS / Linux)
- [ ] `npm test` passes
- [ ] `npm run build` succeeds
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)