### PR TITLE
Mark Phone Service as caution for wireless headset support

### DIFF
--- a/src/shared/service-safety-kb.test.ts
+++ b/src/shared/service-safety-kb.test.ts
@@ -25,6 +25,12 @@ describe('lookupServiceSafety', () => {
     expect(result.category).toBe('print')
   })
 
+  it('does not recommend disabling Phone Service used by wireless headset dongles', () => {
+    const result = lookupServiceSafety('PhoneSvc')
+    expect(result.safety).toBe('caution')
+    expect(result.note).toContain('Audeze Maxwell')
+  })
+
   it('strips per-user suffix before lookup', () => {
     // CDPUserSvc_abc12 → CDPUserSvc
     const result = lookupServiceSafety('CDPUserSvc_1a2b3c')

--- a/src/shared/service-safety-kb.ts
+++ b/src/shared/service-safety-kb.ts
@@ -115,9 +115,9 @@ export const SERVICE_SAFETY_KB: Record<string, ServiceSafetyEntry> = {
     note: 'Windows Insider Service'
   },
   phonesvc: {
-    safety: 'safe',
+    safety: 'caution',
     category: 'misc',
-    note: 'Phone Service'
+    note: 'Phone Service — required by some wireless headset dongles, including Audeze Maxwell'
   },
   icssvc: {
     safety: 'safe',


### PR DESCRIPTION
## What does this PR do?

Updates the service-safety knowledge base to mark Phone Service (`PhoneSvc`) as caution instead of safe, noting its use by wireless headset dongles such as Audeze Maxwell. Adds a regression test for the updated classification.

## Why?

Disabling Phone Service can affect some wireless headset dongles. The caution classification helps prevent users from disabling a service they may need for headset functionality.

## How to test

Run `npm test` and verify the `lookupServiceSafety('PhoneSvc')` test passes with a `caution` safety level and an Audeze Maxwell note.

## Checklist

- [ ] Tested on my platform (Windows / macOS / Linux)
- [ ] `npm test` passes
- [ ] `npm run build` succeeds
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)