### PR TITLE
Improve Windows Recycle Bin scanning performance

### DIFF
--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -10,6 +10,7 @@ import type { ScanResult, CleanResult } from '../shared/types'
 import { getPlatform } from './platform'
 import { randomUUID } from 'crypto'
 import { psUtf8 } from './services/exec-utf8'
+import { queryRecycleBinStats } from './services/recycle-bin-stats'
 
 // ─── Types ──────────────────────────────────────────────────
 
@@ -273,18 +274,9 @@ async function scanRecycleBin(): Promise<ScanResult[]> {
     if (result.items.length > 0) { cacheItems(result.items); return [result] }
     return []
   }
-  // Windows: COM-based recycle bin
-  const { execFile } = await import('child_process')
-  const { promisify } = await import('util')
-  const execFileAsync = promisify(execFile)
+  // Windows: metadata-only query (does not traverse deleted file contents)
   try {
-    const rbScript = `$shell = New-Object -ComObject Shell.Application; $rb = $shell.NameSpace(0x0a); $items = $rb.Items(); $count = $items.Count; $size = ($items | Measure-Object -Property Size -Sum).Sum; Write-Output "$count|$size"`
-    const { stdout } = await execFileAsync('powershell.exe', [
-      '-NoProfile', '-Command', psUtf8(rbScript)
-    ], { windowsHide: true })
-    const [countStr, sizeStr] = stdout.trim().split('|')
-    const count = parseInt(countStr) || 0
-    const size = parseInt(sizeStr) || 0
+    const { count, size } = await queryRecycleBinStats()
     if (count === 0) return []
     const item = { id: randomUUID(), path: 'Recycle Bin', size, category: CleanerType.RecycleBin, subcategory: 'Recycle Bin', lastModified: Date.now(), selected: true }
     cacheItems([item])
@@ -389,13 +381,7 @@ async function cleanRecycleBin(sizeBytes: number = 0, countBefore: number = 0): 
     ], { windowsHide: true })
     const resultCode = parseInt(emptyStdout.trim()) || 0
 
-    const verifyScript = `$shell = New-Object -ComObject Shell.Application; $rb = $shell.NameSpace(0x0a); $items = $rb.Items(); $count = $items.Count; $size = ($items | Measure-Object -Property Size -Sum).Sum; Write-Output "$count|$size"`
-    const { stdout } = await execFileAsync('powershell.exe', [
-      '-NoProfile', '-Command', psUtf8(verifyScript)
-    ], { windowsHide: true })
-    const [remainingCountStr, remainingSizeStr] = stdout.trim().split('|')
-    const remaining = parseInt(remainingCountStr) || 0
-    const remainingSize = parseInt(remainingSizeStr) || 0
+    const { count: remaining, size: remainingSize } = await queryRecycleBinStats()
 
     if (logDeletions) await recordEmptiedRecycleBin(binContents, 'cli')
     return {

--- a/src/main/ipc/recycle-bin.deletion-log.test.ts
+++ b/src/main/ipc/recycle-bin.deletion-log.test.ts
@@ -46,7 +46,14 @@ vi.mock('../services/file-utils', () => ({
 
 vi.mock('../services/scan-cache', () => ({ cacheItems: vi.fn(), clearCachedCategory: vi.fn() }))
 
-vi.mock('../services/exec-utf8', () => ({ psUtf8: (s: string) => s }))
+vi.mock('../services/exec-utf8', () => ({
+  psUtf8: (s: string) => s,
+  execTracked: async (_file: string, args: string[]) => {
+    const script = args[args.length - 1]
+    state.psScripts.push(script)
+    return { stdout: state.statsOutputs.shift() ?? '0|0', stderr: '' }
+  },
+}))
 
 vi.mock('../services/settings-store', () => ({
   getSettings: () => ({ cleaner: { keepDeletionLog: state.keepDeletionLog } }),

--- a/src/main/ipc/recycle-bin.ipc.test.ts
+++ b/src/main/ipc/recycle-bin.ipc.test.ts
@@ -1,16 +1,7 @@
 import { describe, it, expect } from 'vitest'
-
-// ── Test the pure logic from recycle-bin.ipc.ts ──
-// Replicated here to avoid importing the Electron-dependent module.
+import { parseRecycleBinStats as parseRecycleBinScanOutput } from '../services/recycle-bin-stats'
 
 // ── PowerShell stdout parsing (Windows scan) ──
-
-function parseRecycleBinScanOutput(stdout: string): { count: number; size: number } {
-  const [countStr, sizeStr] = stdout.trim().split('|')
-  const count = parseInt(countStr) || 0
-  const size = parseInt(sizeStr) || 0
-  return { count, size }
-}
 
 describe('recycle bin scan output parsing', () => {
   it('parses valid count|size output', () => {

--- a/src/main/ipc/recycle-bin.ipc.ts
+++ b/src/main/ipc/recycle-bin.ipc.ts
@@ -10,6 +10,7 @@ import { getPlatform } from '../platform'
 import { scanDirectory, cleanItems } from '../services/file-utils'
 import { cacheItems, clearCachedCategory } from '../services/scan-cache'
 import { psUtf8 } from '../services/exec-utf8'
+import { queryRecycleBinStats } from '../services/recycle-bin-stats'
 import {
   isDeletionLoggingEnabled, listRecycleBinContents, recordEmptiedRecycleBin
 } from '../services/recycle-bin-log'
@@ -50,15 +51,9 @@ export function registerRecycleBinIpc(): void {
       }
     }
 
-    // Windows: COM-based recycle bin
+    // Windows: metadata-only query (does not traverse deleted file contents)
     try {
-      const { stdout } = await execFileAsync('powershell.exe', psArgs(
-        `$shell = New-Object -ComObject Shell.Application; $rb = $shell.NameSpace(0x0a); $items = $rb.Items(); $count = $items.Count; $size = ($items | Measure-Object -Property Size -Sum).Sum; Write-Output "$count|$size"`
-      ), { windowsHide: true })
-
-      const [countStr, sizeStr] = stdout.trim().split('|')
-      const count = parseInt(countStr) || 0
-      const size = parseInt(sizeStr) || 0
+      const { count, size } = await queryRecycleBinStats()
 
       lastScannedSize = size
       lastScannedCount = count
@@ -115,12 +110,7 @@ export function registerRecycleBinIpc(): void {
 
       // Verify both count and bytes. SHEmptyRecycleBin returns an HRESULT rather
       // than throwing, and it can partially succeed across multiple drives.
-      const { stdout } = await execFileAsync('powershell.exe', psArgs(
-        `$shell = New-Object -ComObject Shell.Application; $rb = $shell.NameSpace(0x0a); $items = $rb.Items(); $count = $items.Count; $size = ($items | Measure-Object -Property Size -Sum).Sum; Write-Output "$count|$size"`
-      ), { windowsHide: true })
-      const [remainingCountStr, remainingSizeStr] = stdout.trim().split('|')
-      const remaining = parseInt(remainingCountStr) || 0
-      const remainingSize = parseInt(remainingSizeStr) || 0
+      const { count: remaining, size: remainingSize } = await queryRecycleBinStats()
       const totalCleaned = Math.max(0, sizeBeforeClean - remainingSize)
       const filesDeleted = Math.max(0, countBeforeClean - remaining)
 

--- a/src/main/services/cloud-agent.ts
+++ b/src/main/services/cloud-agent.ts
@@ -20,6 +20,7 @@ import { scanAppRule, scanDirectory, scanMultipleDirectories, resolveChildSubdir
 import { cacheItems, clearCachedCategory } from './scan-cache'
 import { BROWSER_CACHE_RECENCY, chromiumBrowsers, chromiumCacheTargets } from './chromium-cache'
 import { psUtf8 } from './exec-utf8'
+import { queryRecycleBinStats } from './recycle-bin-stats'
 import { getPlatform } from '../platform'
 import { CleanerType } from '../../shared/enums'
 import { checkForUpdates, runUpdates, isValidAppIdForSource } from './software-updater'
@@ -2132,15 +2133,9 @@ class CloudAgentService {
           }
           return
         }
-        // Windows: COM-based recycle bin query
+        // Windows: metadata-only query (does not traverse deleted file contents)
         try {
-          const rbScript = `$shell = New-Object -ComObject Shell.Application; $rb = $shell.NameSpace(0x0a); $items = $rb.Items(); $count = $items.Count; $size = ($items | Measure-Object -Property Size -Sum).Sum; Write-Output "$count|$size"`
-          const { stdout } = await execFileAsync('powershell.exe', [
-            '-NoProfile', '-Command', psUtf8(rbScript)
-          ], { windowsHide: true })
-          const [countStr, sizeStr] = stdout.trim().split('|')
-          const count = parseInt(countStr) || 0
-          const size = parseInt(sizeStr) || 0
+          const { count, size } = await queryRecycleBinStats()
           await this.postCommandResult(requestId, true, {
             scanType,
             totalSize: size,

--- a/src/main/services/recycle-bin-stats.test.ts
+++ b/src/main/services/recycle-bin-stats.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const execTracked = vi.hoisted(() => vi.fn())
+
+vi.mock('./exec-utf8', () => ({
+  execTracked,
+  psUtf8: (script: string) => script,
+}))
+
+import { parseRecycleBinStats, queryRecycleBinStats } from './recycle-bin-stats'
+
+describe('parseRecycleBinStats', () => {
+  it('parses count and total bytes', () => {
+    expect(parseRecycleBinStats('5000|10737418240\r\n')).toEqual({
+      count: 5000,
+      size: 10737418240,
+    })
+  })
+
+  it('normalizes missing, malformed, and negative values to zero', () => {
+    expect(parseRecycleBinStats('')).toEqual({ count: 0, size: 0 })
+    expect(parseRecycleBinStats('nope|-1')).toEqual({ count: 0, size: 0 })
+  })
+})
+
+describe('queryRecycleBinStats', () => {
+  beforeEach(() => execTracked.mockReset())
+
+  it('reads only recycle-bin metadata with a bounded execution time', async () => {
+    execTracked.mockResolvedValue({ stdout: '42|1048576\r\n', stderr: '' })
+
+    await expect(queryRecycleBinStats()).resolves.toEqual({ count: 42, size: 1048576 })
+
+    expect(execTracked).toHaveBeenCalledTimes(1)
+    const [file, args, options] = execTracked.mock.calls[0]
+    expect(file).toBe('powershell.exe')
+    expect(args.join(' ')).toContain('Directory.EnumerateFiles')
+    expect(args.join(' ')).toContain('$I*')
+    expect(args.join(' ')).not.toContain('Measure-Object')
+    expect(options).toMatchObject({ windowsHide: true, timeout: 15_000 })
+  })
+})

--- a/src/main/services/recycle-bin-stats.ts
+++ b/src/main/services/recycle-bin-stats.ts
@@ -1,0 +1,70 @@
+import { execTracked, psUtf8 } from './exec-utf8'
+
+export interface RecycleBinStats {
+  count: number
+  size: number
+}
+
+const QUERY_RECYCLE_BIN_SCRIPT = `Add-Type -TypeDefinition 'using System;
+using System.Globalization;
+using System.IO;
+using System.Security.Principal;
+
+public static class KuduRecycleBinMetadata {
+  public static string Query() {
+    long count = 0;
+    long totalSize = 0;
+    string sid = WindowsIdentity.GetCurrent().User.Value;
+
+    foreach (DriveInfo drive in DriveInfo.GetDrives()) {
+      try {
+        if (!drive.IsReady) continue;
+        string directory = Path.Combine(drive.RootDirectory.FullName, "$Recycle.Bin", sid);
+        if (!Directory.Exists(directory)) continue;
+
+        foreach (string path in Directory.EnumerateFiles(directory, "$I*", SearchOption.TopDirectoryOnly)) {
+          try {
+            using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read,
+              FileShare.ReadWrite | FileShare.Delete)) {
+              if (stream.Length < 16) continue;
+              var bytes = new byte[8];
+              stream.Position = 8;
+              if (stream.Read(bytes, 0, bytes.Length) != bytes.Length) continue;
+              long size = BitConverter.ToInt64(bytes, 0);
+              count++;
+              if (size > 0) totalSize += size;
+            }
+          } catch { }
+        }
+      } catch { }
+    }
+
+    return count.ToString(CultureInfo.InvariantCulture) + "|" +
+      totalSize.ToString(CultureInfo.InvariantCulture);
+  }
+}'; Write-Output ([KuduRecycleBinMetadata]::Query())`
+
+export function parseRecycleBinStats(stdout: string): RecycleBinStats {
+  const [countText, sizeText] = stdout.trim().split('|')
+  const count = Number.parseInt(countText, 10)
+  const size = Number.parseInt(sizeText, 10)
+  return {
+    count: Number.isFinite(count) && count > 0 ? count : 0,
+    size: Number.isFinite(size) && size > 0 ? size : 0,
+  }
+}
+
+/**
+ * Read aggregate Windows Recycle Bin statistics from its small `$I` metadata
+ * records. This avoids asking the shell for every item's Size property, which
+ * recursively walks deleted folders and can turn a large-bin scan into hours.
+ */
+export async function queryRecycleBinStats(): Promise<RecycleBinStats> {
+  const { stdout } = await execTracked('powershell.exe', [
+    '-NoProfile',
+    '-NonInteractive',
+    '-Command',
+    psUtf8(QUERY_RECYCLE_BIN_SCRIPT),
+  ], { windowsHide: true, timeout: 15_000 })
+  return parseRecycleBinStats(stdout)
+}

--- a/src/renderer/src/globals.css
+++ b/src/renderer/src/globals.css
@@ -337,8 +337,16 @@ body {
   background: transparent;
   color: var(--text-primary);
   -webkit-font-smoothing: antialiased;
+  -webkit-user-select: none;
+  user-select: none;
   font-size: 13px;
   line-height: 1.55;
+}
+
+input, textarea, [contenteditable="true"], pre, code,
+.select-text, .select-all {
+  -webkit-user-select: text;
+  user-select: text;
 }
 
 ::selection {


### PR DESCRIPTION
## What does this PR do?

- Replaces Shell-based Recycle Bin queries with bounded metadata-only scans of `$I` records.
- Reuses the new statistics service across CLI, IPC, and cloud-agent scans and cleanup verification.
- Adds parsing and query coverage for Recycle Bin statistics.
- Enables text selection in inputs, textareas, code blocks, and explicitly selectable elements.

## Why?

Shell queries can recursively traverse deleted folders when calculating item sizes, causing large Recycle Bin scans to take an excessive amount of time. Reading the small metadata records avoids traversing deleted contents while preserving aggregate count and size reporting.

## How to test

- Run `npm test`.
- Run `npm run build`.
- On Windows, scan and empty a populated Recycle Bin, including one containing deleted folders, and verify that count and size reporting completes promptly.
- Verify that text can be selected in supported fields and code/text regions while other UI content remains non-selectable.

## Checklist

- [ ] Tested on my platform (Windows / macOS / Linux)
- [ ] `npm test` passes
- [ ] `npm run build` succeeds
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)