### PR TITLE
fix(cleaner): speed up Windows Recycle Bin emptying

### DIFF
--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -364,10 +364,7 @@ async function scanDatabaseCli(): Promise<ScanResult[]> {
 async function cleanRecycleBin(sizeBytes: number = 0, countBefore: number = 0): Promise<CleanResult> {
   // On macOS/Linux, trash items are real files cleaned via cleanItems() in the main flow.
   // This function is only called for Windows COM-based recycle bin.
-  const { execFile } = await import('child_process')
-  const { promisify } = await import('util')
-  const execFileAsync = promisify(execFile)
-  // This path empties the bin through PowerShell rather than cleanItems, so it
+  // This path bypasses cleanItems, so it
   // has to do its own deletion logging — same gap as the IPC handler, different
   // implementation. Contents must be read before they're gone.
   const { isDeletionLoggingEnabled, listRecycleBinContents, recordEmptiedRecycleBin } =
@@ -375,13 +372,21 @@ async function cleanRecycleBin(sizeBytes: number = 0, countBefore: number = 0): 
   const logDeletions = isDeletionLoggingEnabled()
   const binContents = logDeletions ? await listRecycleBinContents() : []
   try {
-    const cleanScript = `Add-Type -TypeDefinition 'using System; using System.Runtime.InteropServices; public class RecycleBin { [DllImport("Shell32.dll", CharSet = CharSet.Unicode)] public static extern uint SHEmptyRecycleBin(IntPtr hwnd, string pszRootPath, uint dwFlags); }'; $result = [RecycleBin]::SHEmptyRecycleBin([IntPtr]::Zero, $null, 7); Write-Output $result`
-    const { stdout: emptyStdout } = await execFileAsync('powershell.exe', [
-      '-NoProfile', '-Command', psUtf8(cleanScript)
-    ], { windowsHide: true })
-    const resultCode = parseInt(emptyStdout.trim()) || 0
+    const { emptyRecycleBinFast, finalizeRecycleBinShell } = await import('./services/recycle-bin-cleaner')
+    let resultCode = 0
+    let accessDenied = false
+    try {
+      const fastResult = await emptyRecycleBinFast()
+      accessDenied = fastResult.accessDenied
+    } catch {
+      resultCode = await finalizeRecycleBinShell(60_000)
+    }
 
     const { count: remaining, size: remainingSize } = await queryRecycleBinStats()
+
+    if (remaining === 0) {
+      try { await finalizeRecycleBinShell() } catch { /* shell refresh is best-effort */ }
+    }
 
     if (logDeletions) await recordEmptiedRecycleBin(binContents, 'cli')
     return {
@@ -391,7 +396,7 @@ async function cleanRecycleBin(sizeBytes: number = 0, countBefore: number = 0): 
       errors: remaining > 0
         ? [{ path: 'Recycle Bin', reason: `${remaining} item(s) could not be removed (may be in use or protected)` }]
         : [],
-      needsElevation: remaining > 0 && resultCode === 0x80070005,
+      needsElevation: remaining > 0 && (accessDenied || resultCode === 0x80070005),
     }
   } catch (err: any) {
     return { totalCleaned: 0, filesDeleted: 0, filesSkipped: 0, errors: [{ path: 'Recycle Bin', reason: err.message }], needsElevation: false }

--- a/src/main/ipc/recycle-bin.deletion-log.test.ts
+++ b/src/main/ipc/recycle-bin.deletion-log.test.ts
@@ -15,6 +15,8 @@ const state = vi.hoisted(() => ({
   /** stdout for the post-empty count check */
   statsOutputs: [] as string[],
   emptyThrows: false,
+  fastThrows: false,
+  finalizeTimeouts: [] as number[],
   psScripts: [] as string[],
   recorded: [] as any[],
 }))
@@ -45,6 +47,24 @@ vi.mock('../services/file-utils', () => ({
 }))
 
 vi.mock('../services/scan-cache', () => ({ cacheItems: vi.fn(), clearCachedCategory: vi.fn() }))
+
+vi.mock('../services/recycle-bin-cleaner', () => ({
+  emptyRecycleBinFast: async () => {
+    if (state.fastThrows) throw new Error('fast clean unavailable')
+    return {
+      payloadsFound: 2,
+      payloadsDeleted: 2,
+      payloadsFailed: 0,
+      orphanMetadataDeleted: 0,
+      accessDenied: false,
+    }
+  },
+  finalizeRecycleBinShell: async (timeout = 10_000) => {
+    state.finalizeTimeouts.push(timeout)
+    if (state.emptyThrows) throw new Error('access denied')
+    return 0
+  },
+}))
 
 vi.mock('../services/exec-utf8', () => ({
   psUtf8: (s: string) => s,
@@ -87,6 +107,8 @@ describe('recycle bin deletion logging (Windows)', () => {
     state.enumerations = []
     state.statsOutputs = ['2|4216', '0|0']
     state.emptyThrows = false
+    state.fastThrows = false
+    state.finalizeTimeouts = []
     state.psScripts = []
     state.recorded = []
     registerRecycleBinIpc()
@@ -98,6 +120,7 @@ describe('recycle bin deletion logging (Windows)', () => {
     expect(result.errors).toEqual([])
     expect(state.recorded).toHaveLength(0)
     expect(state.psScripts.some((s) => s.includes('ConvertTo-Json'))).toBe(false)
+    expect(state.finalizeTimeouts).toEqual([10_000])
   })
 
   it('records each emptied item by its original location', async () => {
@@ -164,6 +187,7 @@ describe('recycle bin deletion logging (Windows)', () => {
   it('records nothing when the empty itself fails', async () => {
     state.keepDeletionLog = true
     state.enumerations = [binItems([{ name: 'notes.txt', origin: 'C:\\a' }])]
+    state.fastThrows = true
     state.emptyThrows = true
 
     const result = await scanThenClean()
@@ -171,5 +195,6 @@ describe('recycle bin deletion logging (Windows)', () => {
     expect(result.filesDeleted).toBe(0)
     expect(result.errors).toHaveLength(1)
     expect(state.recorded).toHaveLength(0)
+    expect(state.finalizeTimeouts).toEqual([60_000])
   })
 })

--- a/src/main/ipc/recycle-bin.ipc.ts
+++ b/src/main/ipc/recycle-bin.ipc.ts
@@ -1,6 +1,4 @@
 import { ipcMain } from 'electron'
-import { execFile } from 'child_process'
-import { promisify } from 'util'
 import { existsSync } from 'fs'
 import { IPC } from '../../shared/channels'
 import { CleanerType } from '../../shared/enums'
@@ -9,17 +7,11 @@ import { randomUUID } from 'crypto'
 import { getPlatform } from '../platform'
 import { scanDirectory, cleanItems } from '../services/file-utils'
 import { cacheItems, clearCachedCategory } from '../services/scan-cache'
-import { psUtf8 } from '../services/exec-utf8'
 import { queryRecycleBinStats } from '../services/recycle-bin-stats'
+import { emptyRecycleBinFast, finalizeRecycleBinShell } from '../services/recycle-bin-cleaner'
 import {
   isDeletionLoggingEnabled, listRecycleBinContents, recordEmptiedRecycleBin
 } from '../services/recycle-bin-log'
-
-const execFileAsync = promisify(execFile)
-
-function psArgs(script: string): string[] {
-  return ['-NoProfile', '-NonInteractive', '-Command', psUtf8(script)]
-}
 
 // Windows: track last scanned size (virtual items have no real path)
 let lastScannedSize = 0
@@ -94,7 +86,9 @@ export function registerRecycleBinIpc(): void {
       }
     }
 
-    // Windows: SHEmptyRecycleBin Win32 API
+    // Windows: delete the current user's top-level $R payloads in parallel.
+    // The whole-bin shell call can stall badly on large or interrupted bins;
+    // bounded workers avoid making that shell behavior the normal clean path.
     const sizeBeforeClean = lastScannedSize
     const countBeforeClean = lastScannedCount
     // Capture the contents first — after the bin is emptied there is nothing
@@ -102,17 +96,28 @@ export function registerRecycleBinIpc(): void {
     const logDeletions = isDeletionLoggingEnabled()
     const binContents = logDeletions ? await listRecycleBinContents() : []
     try {
-      // Flags: SHERB_NOCONFIRMATION(1) | SHERB_NOPROGRESSUI(2) | SHERB_NOSOUND(4) = 7
-      const { stdout: emptyStdout } = await execFileAsync('powershell.exe', psArgs(
-        `Add-Type -TypeDefinition 'using System; using System.Runtime.InteropServices; public class RecycleBin { [DllImport("Shell32.dll", CharSet = CharSet.Unicode)] public static extern uint SHEmptyRecycleBin(IntPtr hwnd, string pszRootPath, uint dwFlags); }'; $result = [RecycleBin]::SHEmptyRecycleBin([IntPtr]::Zero, $null, 7); Write-Output $result`
-      ), { windowsHide: true })
-      const resultCode = parseInt(emptyStdout.trim()) || 0
+      let resultCode = 0
+      let accessDenied = false
+      try {
+        const fastResult = await emptyRecycleBinFast()
+        accessDenied = fastResult.accessDenied
+      } catch {
+        // Discovery/initialization failure only: retain a bounded Windows API
+        // fallback without allowing the old shell walk to hang indefinitely.
+        resultCode = await finalizeRecycleBinShell(60_000)
+      }
 
-      // Verify both count and bytes. SHEmptyRecycleBin returns an HRESULT rather
-      // than throwing, and it can partially succeed across multiple drives.
+      // Verify both count and bytes. The direct delete is best-effort and can
+      // partially succeed when a payload is open or protected.
       const { count: remaining, size: remainingSize } = await queryRecycleBinStats()
       const totalCleaned = Math.max(0, sizeBeforeClean - remainingSize)
       const filesDeleted = Math.max(0, countBeforeClean - remaining)
+
+      if (remaining === 0) {
+        // With no payloads left this is a quick no-op that refreshes Windows'
+        // shell state/icon. Never fail an otherwise successful clean on it.
+        try { await finalizeRecycleBinShell() } catch { /* shell refresh is best-effort */ }
+      }
 
       if (logDeletions) await recordEmptiedRecycleBin(binContents, 'local')
 
@@ -123,7 +128,7 @@ export function registerRecycleBinIpc(): void {
         return { totalCleaned, filesDeleted, filesSkipped: 0, errors: [], needsElevation: false }
       } else {
         // Partial clean - some items couldn't be removed
-        const accessDenied = resultCode === 0x80070005
+        accessDenied ||= resultCode === 0x80070005
         return {
           totalCleaned,
           filesDeleted,

--- a/src/main/services/recycle-bin-cleaner.test.ts
+++ b/src/main/services/recycle-bin-cleaner.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const execTracked = vi.hoisted(() => vi.fn())
+
+vi.mock('./exec-utf8', () => ({
+  execTracked,
+  psUtf8: (script: string) => script,
+}))
+
+import {
+  emptyRecycleBinDirectory,
+  emptyRecycleBinFast,
+  finalizeRecycleBinShell,
+  parseRecycleBinDirectories,
+} from './recycle-bin-cleaner'
+
+describe('recycle-bin-cleaner', () => {
+  let tempRoot = ''
+
+  beforeEach(async () => {
+    execTracked.mockReset()
+    tempRoot = await mkdtemp(join(tmpdir(), 'kudu-recycle-clean-'))
+  })
+
+  afterEach(async () => {
+    await rm(tempRoot, { recursive: true, force: true })
+  })
+
+  it('accepts only exact per-user Recycle Bin directories', () => {
+    const encode = (value: string) => Buffer.from(value).toString('base64')
+    expect(parseRecycleBinDirectories([
+      encode('C:\\$Recycle.Bin\\S-1-5-21-100-200-300-1001'),
+      encode('D:\\$Recycle.Bin\\S-1-5-21-100-200-300-1001'),
+      encode('C:\\Windows'),
+      'not-base64!',
+    ].join('\r\n'))).toEqual([
+      'C:\\$Recycle.Bin\\S-1-5-21-100-200-300-1001',
+      'D:\\$Recycle.Bin\\S-1-5-21-100-200-300-1001',
+    ])
+  })
+
+  it('deletes payloads, paired metadata, and orphan metadata but nothing else', async () => {
+    await mkdir(join(tempRoot, '$Rfolder', 'nested'), { recursive: true })
+    await writeFile(join(tempRoot, '$Rfolder', 'nested', 'data.bin'), 'payload')
+    await writeFile(join(tempRoot, '$Ifolder'), 'metadata')
+    await writeFile(join(tempRoot, '$Rfile.txt'), 'payload')
+    await writeFile(join(tempRoot, '$Ifile.txt'), 'metadata')
+    await writeFile(join(tempRoot, '$Iorphan'), 'metadata')
+    await writeFile(join(tempRoot, 'desktop.ini'), 'keep')
+
+    const result = await emptyRecycleBinDirectory(tempRoot)
+
+    expect(result).toMatchObject({
+      payloadsFound: 2,
+      payloadsDeleted: 2,
+      payloadsFailed: 0,
+      orphanMetadataDeleted: 1,
+      accessDenied: false,
+    })
+    expect(await readdir(tempRoot)).toEqual(['desktop.ini'])
+    expect(await readFile(join(tempRoot, 'desktop.ini'), 'utf-8')).toBe('keep')
+  })
+
+  it('discovers current-user directories before deleting them', async () => {
+    execTracked.mockResolvedValue({ stdout: '', stderr: '' })
+
+    await expect(emptyRecycleBinFast()).resolves.toEqual({
+      payloadsFound: 0,
+      payloadsDeleted: 0,
+      payloadsFailed: 0,
+      orphanMetadataDeleted: 0,
+      accessDenied: false,
+    })
+    expect(execTracked).toHaveBeenCalledTimes(1)
+    expect(execTracked.mock.calls[0][1].join(' ')).toContain('WindowsIdentity.GetCurrent().User.Value')
+  })
+
+  it('bounds the Windows shell finalizer', async () => {
+    execTracked.mockResolvedValue({ stdout: '0\r\n', stderr: '' })
+
+    await expect(finalizeRecycleBinShell()).resolves.toBe(0)
+
+    expect(execTracked.mock.calls[0][1].join(' ')).toContain('SHEmptyRecycleBin')
+    expect(execTracked.mock.calls[0][2]).toMatchObject({ timeout: 10_000 })
+  })
+})

--- a/src/main/services/recycle-bin-cleaner.ts
+++ b/src/main/services/recycle-bin-cleaner.ts
@@ -1,0 +1,202 @@
+import { readdir, rm } from 'fs/promises'
+import { join } from 'path'
+import { execTracked, psUtf8 } from './exec-utf8'
+
+const MAX_PARALLEL_DELETES = 8
+
+const QUERY_RECYCLE_BIN_DIRECTORIES_SCRIPT = `Add-Type -TypeDefinition 'using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Principal;
+using System.Text;
+
+public static class KuduRecycleBinDirectories {
+  public static string Query() {
+    var paths = new List<string>();
+    string sid = WindowsIdentity.GetCurrent().User.Value;
+
+    foreach (DriveInfo drive in DriveInfo.GetDrives()) {
+      try {
+        if (!drive.IsReady) continue;
+        string directory = Path.Combine(drive.RootDirectory.FullName, "$Recycle.Bin", sid);
+        if (!Directory.Exists(directory)) continue;
+        paths.Add(Convert.ToBase64String(Encoding.UTF8.GetBytes(directory)));
+      } catch { }
+    }
+
+    return string.Join(Environment.NewLine, paths.ToArray());
+  }
+}'; Write-Output ([KuduRecycleBinDirectories]::Query())`
+
+const EMPTY_RECYCLE_BIN_SHELL_SCRIPT = `Add-Type -TypeDefinition 'using System;
+using System.Runtime.InteropServices;
+
+public static class KuduRecycleBinShell {
+  [DllImport("Shell32.dll", CharSet = CharSet.Unicode)]
+  public static extern uint SHEmptyRecycleBin(IntPtr hwnd, string pszRootPath, uint dwFlags);
+}'; Write-Output ([KuduRecycleBinShell]::SHEmptyRecycleBin([IntPtr]::Zero, $null, 7))`
+
+export interface FastRecycleBinCleanResult {
+  payloadsFound: number
+  payloadsDeleted: number
+  payloadsFailed: number
+  orphanMetadataDeleted: number
+  accessDenied: boolean
+}
+
+/** Accept only the exact per-user bin shape produced by the Windows query. */
+function isRecycleBinDirectory(path: string): boolean {
+  return /^[A-Za-z]:\\\$Recycle\.Bin\\S-1-\d+(?:-\d+)+$/i.test(path)
+}
+
+export function parseRecycleBinDirectories(stdout: string): string[] {
+  const unique = new Map<string, string>()
+  for (const line of stdout.split(/\r?\n/)) {
+    if (!line.trim()) continue
+    try {
+      const path = Buffer.from(line.trim(), 'base64').toString('utf-8')
+      if (isRecycleBinDirectory(path)) unique.set(path.toLowerCase(), path)
+    } catch {
+      // Ignore malformed helper output rather than widening the delete scope.
+    }
+  }
+  return [...unique.values()]
+}
+
+async function mapWithConcurrency<T>(
+  values: T[],
+  limit: number,
+  worker: (value: T) => Promise<void>,
+): Promise<void> {
+  let next = 0
+  const run = async (): Promise<void> => {
+    while (next < values.length) {
+      const index = next++
+      await worker(values[index])
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, values.length) }, run))
+}
+
+/**
+ * Empty one already-validated per-user Recycle Bin directory.
+ *
+ * `$R` payloads are removed in parallel, then their `$I` metadata records are
+ * removed. If a payload fails, its metadata is deliberately retained so the
+ * item is not turned into an invisible orphan. Directory links are safe here:
+ * fs.rm removes the link itself and does not recurse into its target.
+ */
+export async function emptyRecycleBinDirectory(directory: string): Promise<FastRecycleBinCleanResult> {
+  const result: FastRecycleBinCleanResult = {
+    payloadsFound: 0,
+    payloadsDeleted: 0,
+    payloadsFailed: 0,
+    orphanMetadataDeleted: 0,
+    accessDenied: false,
+  }
+
+  const entries = await readdir(directory, { withFileTypes: true })
+  const payloadNames = entries
+    .map((entry) => entry.name)
+    .filter((name) => name.toUpperCase().startsWith('$R'))
+  result.payloadsFound = payloadNames.length
+
+  await mapWithConcurrency(payloadNames, MAX_PARALLEL_DELETES, async (name) => {
+    const payloadPath = join(directory, name)
+    const metadataPath = join(directory, `$I${name.slice(2)}`)
+    try {
+      await rm(payloadPath, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 })
+      result.payloadsDeleted++
+    } catch (err: any) {
+      result.payloadsFailed++
+      if (err?.code === 'EACCES' || err?.code === 'EPERM') result.accessDenied = true
+      return
+    }
+
+    // Metadata is tiny and may already be absent after an interrupted empty.
+    // A metadata failure does not turn the successfully removed payload into
+    // a failed delete; the orphan cleanup below gets another chance at it.
+    try {
+      await rm(metadataPath, { force: true, maxRetries: 3, retryDelay: 50 })
+    } catch (err: any) {
+      if (err?.code === 'EACCES' || err?.code === 'EPERM') result.accessDenied = true
+    }
+  })
+
+  // Remove only metadata whose payload is now absent. This clears the large
+  // phantom `$I` tail left by an interrupted Windows shell empty operation.
+  const remaining = await readdir(directory, { withFileTypes: true })
+  const remainingPayloads = new Set(
+    remaining
+      .map((entry) => entry.name.toUpperCase())
+      .filter((name) => name.startsWith('$R'))
+      .map((name) => name.slice(2)),
+  )
+  const orphanMetadata = remaining
+    .map((entry) => entry.name)
+    .filter((name) => name.toUpperCase().startsWith('$I') && !remainingPayloads.has(name.slice(2).toUpperCase()))
+
+  await mapWithConcurrency(orphanMetadata, MAX_PARALLEL_DELETES, async (name) => {
+    try {
+      await rm(join(directory, name), { force: true, maxRetries: 3, retryDelay: 50 })
+      result.orphanMetadataDeleted++
+    } catch (err: any) {
+      if (err?.code === 'EACCES' || err?.code === 'EPERM') result.accessDenied = true
+    }
+  })
+
+  return result
+}
+
+/** Delete the current user's bin payloads directly instead of shell-walking them serially. */
+export async function emptyRecycleBinFast(): Promise<FastRecycleBinCleanResult> {
+  const { stdout } = await execTracked('powershell.exe', [
+    '-NoProfile',
+    '-NonInteractive',
+    '-Command',
+    psUtf8(QUERY_RECYCLE_BIN_DIRECTORIES_SCRIPT),
+  ], { windowsHide: true, timeout: 15_000 })
+
+  const directories = parseRecycleBinDirectories(stdout)
+  const results = await Promise.all(directories.map(async (directory) => {
+    try {
+      return await emptyRecycleBinDirectory(directory)
+    } catch (err: any) {
+      return {
+        payloadsFound: 0,
+        payloadsDeleted: 0,
+        payloadsFailed: 1,
+        orphanMetadataDeleted: 0,
+        accessDenied: err?.code === 'EACCES' || err?.code === 'EPERM',
+      }
+    }
+  }))
+  return results.reduce<FastRecycleBinCleanResult>((total, current) => ({
+    payloadsFound: total.payloadsFound + current.payloadsFound,
+    payloadsDeleted: total.payloadsDeleted + current.payloadsDeleted,
+    payloadsFailed: total.payloadsFailed + current.payloadsFailed,
+    orphanMetadataDeleted: total.orphanMetadataDeleted + current.orphanMetadataDeleted,
+    accessDenied: total.accessDenied || current.accessDenied,
+  }), {
+    payloadsFound: 0,
+    payloadsDeleted: 0,
+    payloadsFailed: 0,
+    orphanMetadataDeleted: 0,
+    accessDenied: false,
+  })
+}
+
+/**
+ * Ask Windows to finalize/refresh the bin after the direct delete. This is
+ * normally an empty-bin no-op; the timeout keeps it from reintroducing the
+ * unbounded shell walk that the fast path replaces.
+ */
+export async function finalizeRecycleBinShell(timeout = 10_000): Promise<number> {
+  const { stdout } = await execTracked('powershell.exe', [
+    '-NoProfile',
+    '-NonInteractive',
+    '-Command',
+    psUtf8(EMPTY_RECYCLE_BIN_SHELL_SCRIPT),
+  ], { windowsHide: true, timeout })
+  return Number.parseInt(stdout.trim(), 10) || 0
+}

--- a/src/main/services/recycle-bin-stats.test.ts
+++ b/src/main/services/recycle-bin-stats.test.ts
@@ -26,7 +26,7 @@ describe('parseRecycleBinStats', () => {
 describe('queryRecycleBinStats', () => {
   beforeEach(() => execTracked.mockReset())
 
-  it('reads only recycle-bin metadata with a bounded execution time', async () => {
+  it('reads recycle-bin entries without recursively walking payloads', async () => {
     execTracked.mockResolvedValue({ stdout: '42|1048576\r\n', stderr: '' })
 
     await expect(queryRecycleBinStats()).resolves.toEqual({ count: 42, size: 1048576 })
@@ -36,6 +36,10 @@ describe('queryRecycleBinStats', () => {
     expect(file).toBe('powershell.exe')
     expect(args.join(' ')).toContain('Directory.EnumerateFiles')
     expect(args.join(' ')).toContain('$I*')
+    expect(args.join(' ')).toContain('Directory.Exists(payload)')
+    expect(args.join(' ')).toContain('Directory.EnumerateFileSystemEntries')
+    expect(args.join(' ')).toContain('$R*')
+    expect(args.join(' ')).not.toContain('SearchOption.AllDirectories')
     expect(args.join(' ')).not.toContain('Measure-Object')
     expect(options).toMatchObject({ windowsHide: true, timeout: 15_000 })
   })

--- a/src/main/services/recycle-bin-stats.ts
+++ b/src/main/services/recycle-bin-stats.ts
@@ -8,6 +8,7 @@ export interface RecycleBinStats {
 const QUERY_RECYCLE_BIN_SCRIPT = `Add-Type -TypeDefinition 'using System;
 using System.Globalization;
 using System.IO;
+using System.Collections.Generic;
 using System.Security.Principal;
 
 public static class KuduRecycleBinMetadata {
@@ -22,8 +23,18 @@ public static class KuduRecycleBinMetadata {
         string directory = Path.Combine(drive.RootDirectory.FullName, "$Recycle.Bin", sid);
         if (!Directory.Exists(directory)) continue;
 
+        var pairedPayloads = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (string path in Directory.EnumerateFiles(directory, "$I*", SearchOption.TopDirectoryOnly)) {
           try {
+            string name = Path.GetFileName(path);
+            if (name.Length < 3) continue;
+            string payload = Path.Combine(directory, "$R" + name.Substring(2));
+
+            // Interrupted or externally aborted empties can leave thousands
+            // of tiny $I records after their actual $R payloads are gone.
+            // They are not restorable items and must not inflate the scan.
+            if (!File.Exists(payload) && !Directory.Exists(payload)) continue;
+
             using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read,
               FileShare.ReadWrite | FileShare.Delete)) {
               if (stream.Length < 16) continue;
@@ -32,6 +43,21 @@ public static class KuduRecycleBinMetadata {
               if (stream.Read(bytes, 0, bytes.Length) != bytes.Length) continue;
               long size = BitConverter.ToInt64(bytes, 0);
               count++;
+              if (size > 0) totalSize += size;
+              pairedPayloads.Add(payload);
+            }
+          } catch { }
+        }
+
+        // Also surface orphaned $R payloads. Their original metadata and
+        // directory size are unavailable without a costly recursive walk,
+        // but they still occupy the bin and should keep it cleanable.
+        foreach (string payload in Directory.EnumerateFileSystemEntries(directory, "$R*", SearchOption.TopDirectoryOnly)) {
+          try {
+            if (pairedPayloads.Contains(payload)) continue;
+            count++;
+            if (File.Exists(payload)) {
+              long size = new FileInfo(payload).Length;
               if (size > 0) totalSize += size;
             }
           } catch { }
@@ -56,8 +82,10 @@ export function parseRecycleBinStats(stdout: string): RecycleBinStats {
 
 /**
  * Read aggregate Windows Recycle Bin statistics from its small `$I` metadata
- * records. This avoids asking the shell for every item's Size property, which
- * recursively walks deleted folders and can turn a large-bin scan into hours.
+ * records and top-level `$R` payload names. This avoids asking the shell for
+ * every item's Size property, which recursively walks deleted folders and can
+ * turn a large-bin scan into hours. Metadata without a payload is ignored;
+ * payloads without metadata remain visible with their non-recursive size.
  */
 export async function queryRecycleBinStats(): Promise<RecycleBinStats> {
   const { stdout } = await execTracked('powershell.exe', [

--- a/src/renderer/src/pages/CleanerPage.tsx
+++ b/src/renderer/src/pages/CleanerPage.tsx
@@ -233,6 +233,19 @@ export function CleanerPage() {
           .map((item) => item.id)
         if (catItemIds.length > 0) {
           cleanIndexRef.current = activeIndex
+          // Some cleaners (notably the Windows Recycle Bin) perform one
+          // blocking platform operation and therefore have no per-file
+          // callbacks. Announce the category before invoking it so the UI
+          // never leaves the previous cleaner's path and 100% progress on
+          // screen while the next category is still working.
+          store.setProgress({
+            phase: 'cleaning',
+            category: cat.type,
+            currentPath: t(cat.labelKey),
+            progress: (activeIndex / cleanTotalRef.current) * 100,
+            itemsFound: catResults.reduce((sum, scan) => sum + scan.itemCount, 0),
+            sizeFound: totalCleaned
+          })
           try {
             const cleanFn = cleanFns[cat.type]
             if (!cleanFn) continue


### PR DESCRIPTION
## What

- replace the normal Windows whole-bin shell operation with bounded parallel deletion of the current user's top-level Recycle Bin payloads
- remove paired and orphaned metadata safely, while retaining metadata for payloads that could not be deleted
- keep the Windows shell operation as a bounded fallback/final refresh
- report only real payload-backed Recycle Bin entries and show the active cleaner category before blocking platform work
- add service, statistics, IPC fallback, and deletion-log coverage

## Why

`SHEmptyRecycleBin` can spend a very long time walking large or interrupted bins without item-level progress. Stale `$I` metadata can also make the scan report gigabytes of data after the corresponding `$R` payloads are already gone, leaving the UI apparently stuck on the previous cleaner.

## Impact

Deletion is restricted to exact current-user `<drive>:\$Recycle.Bin\<SID>` directories discovered from Windows, uses eight bounded workers, and preserves metadata whenever a payload deletion fails. Shell finalization is time-bounded so the old hang cannot become the normal path again.

## Validation

- `npm ci`
- targeted Recycle Bin tests: 33 passed
- `npm test`: 117 files / 2,512 tests passed
- `npm run build`
- `git diff --check`
- `npm run validate:rules` not required (no rule JSON changes)