### PR TITLE
fix(disk): measure complete folder sizes

### DIFF
--- a/src/main/ipc/disk-analyzer.ipc.test.ts
+++ b/src/main/ipc/disk-analyzer.ipc.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { join, sep } from 'path'
 
 // ── Mocks ──
 
@@ -215,6 +216,38 @@ describe('analyzeDisk (exported)', () => {
   it('returns empty node for null-like input', async () => {
     const result = await analyzeDisk(null as any)
     expect(result).toEqual({ name: '', path: '', size: 0, children: [] })
+  })
+
+  it('includes files nested below the displayed tree depth', async () => {
+    const drive = process.platform === 'win32' ? 'C' : '/'
+    const root = process.platform === 'win32' ? 'C:\\' : sep
+    const games = join(root, 'Games')
+    const publisher = join(games, 'Publisher')
+    const game = join(publisher, 'Game')
+    const content = join(game, 'Content')
+    const payload = join(content, 'payload.bin')
+
+    const directory = (name: string) => ({ name, isDirectory: () => true })
+    const file = (name: string) => ({ name, isDirectory: () => false })
+    const entries = new Map<string, unknown[]>([
+      [root, [directory('Games')]],
+      [games, [directory('Publisher')]],
+      [publisher, [directory('Game')]],
+      [game, [directory('Content')]],
+      [content, [file('payload.bin')]],
+    ])
+
+    mockReaddir.mockImplementation(async (path: string) => entries.get(path) ?? [])
+    mockStat.mockImplementation(async (path: string) => ({
+      isDirectory: () => false,
+      size: path === payload ? 54_800_000_000 : 0,
+    }))
+
+    const result = await analyzeDisk(drive)
+
+    expect(result.size).toBe(54_800_000_000)
+    expect(result.children?.[0].size).toBe(54_800_000_000)
+    expect(result.children?.[0].children?.[0].children?.[0].children).toEqual([])
   })
 })
 

--- a/src/main/ipc/disk-analyzer.ipc.ts
+++ b/src/main/ipc/disk-analyzer.ipc.ts
@@ -31,7 +31,10 @@ async function analyzeDirectory(
   }
 
   if (depth >= MAX_DEPTH) {
-    node.size = await quickSize(dirPath)
+    // Keep the returned tree shallow for the renderer, but continue measuring
+    // the complete subtree. Stopping the size scan here silently omitted every
+    // file nested below the tree depth limit.
+    node.size = await measureDirectorySize(dirPath)
     return node
   }
 
@@ -116,14 +119,20 @@ async function collectFileTypes(
   }
 }
 
-async function quickSize(dirPath: string): Promise<number> {
+async function measureDirectorySize(dirPath: string): Promise<number> {
   let size = 0
   try {
     const entries = await readdir(dirPath, { withFileTypes: true })
     for (const entry of entries) {
       try {
-        const s = await stat(join(dirPath, entry.name))
-        size += s.isDirectory() ? 0 : s.size
+        const fullPath = join(dirPath, entry.name)
+        if (entry.isDirectory()) {
+          size += await measureDirectorySize(fullPath)
+        } else {
+          const s = await stat(fullPath)
+          // Do not count or follow directory symlinks/junctions.
+          if (!s.isDirectory()) size += s.size
+        }
       } catch {
         // Skip
       }


### PR DESCRIPTION
## Summary
- measure folder contents recursively below the analyzer's displayed tree depth
- keep the renderer-facing tree bounded while reporting complete folder totals
- add regression coverage for a 54.8 GB payload nested below the cutoff

## Root cause
The analyzer stopped expanding its tree after three levels, then measured only files directly inside each cutoff folder. Files in deeper subdirectories were silently excluded from parent totals.

## Validation
- `npm test` (117 files, 2,513 tests)
- `npm run build`
- `git diff --check`

Closes #323