### PR TITLE
fix(malware): initialize YARA engine for status

### DIFF
--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -135,10 +135,14 @@ function ensureYaraEngineStarted(): void {
 
 async function _initYaraEngine(): Promise<YaraEngine | null> {
   try {
-    const engine = createYaraEngine()
-    await engine.initialize()
+    // Publish the compiling state before the first await so an immediate
+    // status request cannot mistake a lazy, not-yet-loaded engine for the
+    // regex fallback.
     const ruleFiles = getAllRulePaths()
     _yaraCompileProgress = { loaded: 0, total: ruleFiles.length }
+
+    const engine = createYaraEngine()
+    await engine.initialize()
 
     // loadRules is async and yields to the event loop between chunks,
     // so the UI stays responsive during compilation.
@@ -2065,7 +2069,12 @@ export function registerMalwareScannerIpc(getWindow: WindowGetter): void {
     }
   })
 
-  ipcMain.handle(IPC.MALWARE_YARA_INFO, () => getYaraRulesInfo())
+  ipcMain.handle(IPC.MALWARE_YARA_INFO, () => {
+    // Opening the Database tab should initialize the cached cloud signatures,
+    // not report the still-lazy engine as a regex fallback.
+    ensureYaraEngineStarted()
+    return getYaraRulesInfo()
+  })
 
   ipcMain.handle(IPC.MALWARE_YARA_UPDATE, async () => {
     const result = await fetchAndCacheRules(`${CLOUD_SERVER_URL}${RULES_ENDPOINT}`)
@@ -2078,6 +2087,6 @@ export function registerMalwareScannerIpc(getWindow: WindowGetter): void {
   // Start periodic YARA rule updates — runs for all users, not just cloud-linked
   startPeriodicRuleChecks(CLOUD_SERVER_URL, () => resetYaraEngine())
 
-  // YARA compilation is lazy — happens on first scan or when the user
-  // opens the Database tab and clicks "Check for Updates". No startup cost.
+  // YARA compilation is lazy — happens on first scan or when the Database tab
+  // requests engine status. No startup cost for users who never open it.
 }

--- a/src/main/ipc/malware-scanner.yara-status.test.ts
+++ b/src/main/ipc/malware-scanner.yara-status.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  handle: vi.fn(),
+  initialize: vi.fn(),
+  loadRules: vi.fn(),
+  startPeriodicRuleChecks: vi.fn(),
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => 'C:\\Kudu-Test'),
+  },
+  BrowserWindow: {
+    getAllWindows: vi.fn(() => []),
+  },
+  ipcMain: {
+    handle: (...args: unknown[]) => mocks.handle(...args),
+  },
+  shell: {
+    trashItem: vi.fn(),
+  },
+}))
+
+vi.mock('../services/yara-engine', () => ({
+  createYaraEngine: () => ({
+    initialize: (...args: unknown[]) => mocks.initialize(...args),
+    isReady: () => true,
+    loadRules: (...args: unknown[]) => mocks.loadRules(...args),
+    rulesLoaded: 2,
+    dispose: vi.fn(),
+  }),
+  yaraMatchToThreatFields: vi.fn(),
+}))
+
+vi.mock('../services/yara-rules-store', () => ({
+  RULES_ENDPOINT: '/api/yara-rules',
+  fetchAndCacheRules: vi.fn(),
+  getAllRulePaths: () => ['first.yar', 'second.yar'],
+  getCachedRulePaths: () => ['first.yar', 'second.yar'],
+  getRulesMetadata: () => ({
+    version: 'test-version',
+    updatedAt: '2026-08-23T00:00:00Z',
+    rulesCount: 2,
+    sha256: 'test-hash',
+  }),
+  startPeriodicRuleChecks: (...args: unknown[]) => mocks.startPeriodicRuleChecks(...args),
+}))
+
+import { IPC } from '../../shared/channels'
+import { registerMalwareScannerIpc, resetYaraEngine } from './malware-scanner.ipc'
+
+function getHandler(channel: string): () => unknown {
+  const call = mocks.handle.mock.calls.find(args => args[0] === channel)
+  if (!call) throw new Error(`No handler registered for ${channel}`)
+  return call[1] as () => unknown
+}
+
+describe('malware YARA status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetYaraEngine()
+  })
+
+  it('starts cached-rule compilation before reporting engine status', () => {
+    mocks.initialize.mockReturnValue(new Promise(() => {}))
+
+    registerMalwareScannerIpc(() => null)
+    const info = getHandler(IPC.MALWARE_YARA_INFO)() as {
+      engine: string
+      cachedRules: number
+      compileProgress: { loaded: number; total: number } | null
+    }
+
+    expect(mocks.initialize).toHaveBeenCalledOnce()
+    expect(info.engine).toBe('compiling')
+    expect(info.cachedRules).toBe(2)
+    expect(info.compileProgress).toEqual({ loaded: 0, total: 2 })
+  })
+})


### PR DESCRIPTION
## Summary
- start lazy YARA initialization when the malware Database tab requests engine status
- publish the compiling state before initialization yields so cached cloud signatures are not mislabeled as the regex fallback
- add regression coverage for the first status response

## Validation
- `npx vitest run src/main/ipc/malware-scanner.yara-status.test.ts`
- `npm test` (122 files, 2,533 tests)
- `npm run build`
- `git diff --check`

## Real-install verification
- confirmed Kudu 2.3.0 had 1,752 cached cloud YARA rules (1,452 Windows-applicable)
- confirmed those Windows rules compile successfully on the affected machine