### PR TITLE
fix(windows): detect elevation from process token

### DIFF
--- a/src/main/platform/win32/elevation.test.ts
+++ b/src/main/platform/win32/elevation.test.ts
@@ -13,7 +13,7 @@ describe('win32 elevation', () => {
     vi.resetModules()
   })
 
-  it('returns true when net session succeeds (admin)', async () => {
+  it('returns true when the inherited process token is elevated', async () => {
     execFileSyncMock.mockReturnValue(undefined)
 
     const { createWin32Elevation } = await import('./elevation')
@@ -21,12 +21,15 @@ describe('win32 elevation', () => {
     const result = elevation.isAdmin()
 
     expect(result).toBe(true)
-    expect(execFileSyncMock).toHaveBeenCalledWith(
-      'net', ['session'], { stdio: 'ignore', timeout: 5000 }
-    )
+    const [file, args, options] = execFileSyncMock.mock.calls[0]
+    expect(file).toBe('powershell.exe')
+    expect(args).toEqual(expect.arrayContaining(['-NoProfile', '-NonInteractive', '-Command']))
+    expect(args.at(-1)).toContain('WindowsIdentity]::GetCurrent()')
+    expect(args.at(-1)).toContain('WindowsBuiltInRole]::Administrator')
+    expect(options).toEqual({ stdio: 'ignore', timeout: 5000, windowsHide: true })
   })
 
-  it('returns false when net session throws (not admin)', async () => {
+  it('returns false when the inherited process token is not elevated', async () => {
     execFileSyncMock.mockImplementation(() => { throw new Error('Access denied') })
 
     const { createWin32Elevation } = await import('./elevation')
@@ -34,6 +37,17 @@ describe('win32 elevation', () => {
     const result = elevation.isAdmin()
 
     expect(result).toBe(false)
+  })
+
+  it('does not depend on the Server service through net session', async () => {
+    execFileSyncMock.mockReturnValue(undefined)
+
+    const { createWin32Elevation } = await import('./elevation')
+    createWin32Elevation().isAdmin()
+
+    expect(execFileSyncMock).not.toHaveBeenCalledWith(
+      'net', ['session'], expect.anything()
+    )
   })
 
   it('caches the result after first call', async () => {

--- a/src/main/platform/win32/elevation.ts
+++ b/src/main/platform/win32/elevation.ts
@@ -3,13 +3,28 @@ import type { PlatformElevation } from '../types'
 
 let _isAdmin: boolean | null = null
 
+// Check the security token inherited from Kudu rather than probing a Windows
+// service. `net session` also requires the Server (LanmanServer) service, so it
+// reports access denied on elevated systems where that service is disabled.
+const ADMIN_TOKEN_CHECK = [
+  '$identity = [Security.Principal.WindowsIdentity]::GetCurrent()',
+  '$principal = [Security.Principal.WindowsPrincipal]::new($identity)',
+  '$isAdmin = $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)',
+  'if ($isAdmin) { exit 0 }',
+  'exit 1',
+].join('; ')
+
 export function createWin32Elevation(): PlatformElevation {
   return {
     isAdmin(): boolean {
       if (_isAdmin !== null) return _isAdmin
 
       try {
-        execFileSync('net', ['session'], { stdio: 'ignore', timeout: 5000 })
+        execFileSync(
+          'powershell.exe',
+          ['-NoProfile', '-NonInteractive', '-Command', ADMIN_TOKEN_CHECK],
+          { stdio: 'ignore', timeout: 5000, windowsHide: true }
+        )
         _isAdmin = true
       } catch {
         _isAdmin = false


### PR DESCRIPTION
## Summary

- replace the service-dependent `net session` administrator probe with a Windows security-token role check
- keep the elevation result cached while hiding the PowerShell child process
- add regression coverage proving the check no longer depends on the Server service

## Testing

- `npx vitest run src/main/platform/win32/elevation.test.ts`
- `npm test` (124 files, 2,538 tests)
- `npm run build`
- `git diff --check origin/main...HEAD`

Fixes #288
