### PR TITLE
fix(main): keep long-running tasks responsive

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -10,7 +10,8 @@ export default defineConfig({
     build: {
       rollupOptions: {
         input: {
-          index: resolve(__dirname, 'src/main/index.ts')
+          index: resolve(__dirname, 'src/main/index.ts'),
+          'yara-worker': resolve(__dirname, 'src/main/workers/yara-worker.ts')
         }
       }
     }

--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -24,6 +24,7 @@ import { getSettings, getMalwareAllowlist, addMalwareAllowlistEntry, removeMalwa
 import { isExcluded } from '../services/file-utils'
 import { createYaraEngine, yaraMatchToThreatFields, type YaraEngine } from '../services/yara-engine'
 import { getAllRulePaths, getCachedRulePaths, getRulesMetadata, startPeriodicRuleChecks, fetchAndCacheRules, RULES_ENDPOINT } from '../services/yara-rules-store'
+import { CooperativeScheduler } from '../services/cooperative-scheduler'
 
 const execFileAsync = promisify(execFile)
 const CLOUD_SERVER_URL = 'https://cloud.usekudu.com'
@@ -210,10 +211,14 @@ function getYaraRulesInfo(): YaraRulesInfo {
 
 // ─── Heuristic checks ─────────────────────────────────────────
 
-function calculateEntropy(buffer: Buffer): number {
+async function calculateEntropy(buffer: Buffer): Promise<number> {
   if (buffer.length === 0) return 0
   const freq = new Array(256).fill(0)
-  for (const byte of buffer) freq[byte]++
+  const scheduler = new CooperativeScheduler()
+  for (let i = 0; i < buffer.length; i++) {
+    freq[buffer[i]]++
+    if ((i & 0x3ffff) === 0) await scheduler.yieldIfNeeded()
+  }
   let entropy = 0
   for (const f of freq) {
     if (f === 0) continue
@@ -295,14 +300,14 @@ interface PEAnalysis {
   sectionEntropies: { name: string; entropy: number }[]
 }
 
-function analyzePE(buffer: Buffer): PEAnalysis | null {
+async function analyzePE(buffer: Buffer): Promise<PEAnalysis | null> {
   if (!isPEFile(buffer)) return null
 
   const result: PEAnalysis = {
     isPacked: false,
     hasSuspiciousImports: [],
     hasWritableExecutable: false,
-    entropy: calculateEntropy(buffer),
+    entropy: await calculateEntropy(buffer),
     sectionEntropies: []
   }
 
@@ -342,7 +347,7 @@ function analyzePE(buffer: Buffer): PEAnalysis | null {
       // Calculate section entropy
       if (rawPtr > 0 && rawSize > 0 && rawPtr + rawSize <= buffer.length) {
         const sectionData = buffer.subarray(rawPtr, rawPtr + Math.min(rawSize, 65536))
-        const secEntropy = calculateEntropy(sectionData)
+        const secEntropy = await calculateEntropy(sectionData)
         result.sectionEntropies.push({ name, entropy: secEntropy })
 
         // High entropy section = likely packed or encrypted
@@ -1184,7 +1189,15 @@ function getAppDir(): string {
 
 // ─── Main scan logic ─────────────────────────────────────────
 
-async function collectFiles(dirPath: string, maxDepth: number, maxFiles: number, files: string[], scannableExts: Set<string>, exclusions: string[]): Promise<void> {
+async function collectFiles(
+  dirPath: string,
+  maxDepth: number,
+  maxFiles: number,
+  files: string[],
+  scannableExts: Set<string>,
+  exclusions: string[],
+  scheduler = new CooperativeScheduler(),
+): Promise<void> {
   if (maxDepth <= 0 || files.length >= maxFiles) return
 
   try {
@@ -1199,13 +1212,14 @@ async function collectFiles(dirPath: string, maxDepth: number, maxFiles: number,
       if (entry.isDirectory()) {
         if (SKIP_DIRS.has(entry.name.toLowerCase())) continue
         if (fullPath.toLowerCase().startsWith(getAppDir())) continue
-        await collectFiles(fullPath, maxDepth - 1, maxFiles, files, scannableExts, exclusions)
+        await collectFiles(fullPath, maxDepth - 1, maxFiles, files, scannableExts, exclusions, scheduler)
       } else if (entry.isFile()) {
         const ext = extname(entry.name).toLowerCase()
         if (scannableExts.has(ext) || hasDoubleExtension(entry.name)) {
           files.push(fullPath)
         }
       }
+      await scheduler.yieldIfNeeded()
     }
   } catch {
     // Skip inaccessible directories
@@ -1358,7 +1372,7 @@ export async function scanMalware(
 
       // ── Signature matching via YARA engine (rules downloaded from cloud) ──
       if (yaraEngine && fileSize <= MAX_READ_SIZE && !threats.some(t => t.path === filePath)) {
-        const matches = yaraEngine.scanFile(filePath)
+        const matches = await yaraEngine.scanFileAsync(filePath)
         for (const match of matches) {
           if (threats.some(t => t.path === filePath)) break
           // filenameOnly rules should only match outside system dirs on Windows
@@ -1412,7 +1426,7 @@ export async function scanMalware(
         const isTrustedPath = TRUSTED_PATHS.some(tp => pathLower.includes(tp))
 
         if (shouldAnalyzePE && isPEFile(fileBuffer) && !isTrustedPath) {
-          const pe = analyzePE(fileBuffer)
+          const pe = await analyzePE(fileBuffer)
           if (pe) {
             // High section entropy (isPacked) and high overall file entropy
             // measure the same property — compressed/encrypted code — so count

--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -120,21 +120,44 @@ const TRUSTED_PATHS = [
 let _yaraEngine: YaraEngine | null = null
 let _yaraInitPromise: Promise<YaraEngine | null> | null = null
 let _yaraCompileProgress: { loaded: number; total: number } | null = null
+let _yaraGeneration = 0
 
 async function getYaraEngine(): Promise<YaraEngine | null> {
-  if (_yaraInitPromise) return _yaraInitPromise
-  _yaraInitPromise = _initYaraEngine()
-  return _yaraInitPromise
+  if (!_yaraInitPromise) _yaraInitPromise = _initYaraEngine(_yaraGeneration)
+  const pending = _yaraInitPromise
+  const engine = await pending
+  // A rules refresh may retire an initialization that was already underway.
+  // Follow the replacement promise instead of handing a scan the retired one.
+  if (!engine && pending !== _yaraInitPromise) return getYaraEngine()
+  return engine
+}
+
+async function acquireYaraEngine(): Promise<{
+  engine: YaraEngine
+  release: () => void
+} | null> {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const engine = await getYaraEngine()
+    if (!engine) return null
+    try {
+      return { engine, release: engine.acquire() }
+    } catch {
+      // A refresh retired this generation between await and acquire. Retry
+      // against the replacement singleton rather than scanning without YARA.
+    }
+  }
+  return null
 }
 
 /** Start engine compilation in the background (non-blocking). */
 function ensureYaraEngineStarted(): void {
   if (!_yaraInitPromise) {
-    _yaraInitPromise = _initYaraEngine()
+    _yaraInitPromise = _initYaraEngine(_yaraGeneration)
   }
 }
 
-async function _initYaraEngine(): Promise<YaraEngine | null> {
+async function _initYaraEngine(generation: number): Promise<YaraEngine | null> {
+  let engine: YaraEngine | null = null
   try {
     // Publish the compiling state before the first await so an immediate
     // status request cannot mistake a lazy, not-yet-loaded engine for the
@@ -142,12 +165,13 @@ async function _initYaraEngine(): Promise<YaraEngine | null> {
     const ruleFiles = getAllRulePaths()
     _yaraCompileProgress = { loaded: 0, total: ruleFiles.length }
 
-    const engine = createYaraEngine()
+    engine = createYaraEngine()
     await engine.initialize()
 
     // loadRules is async and yields to the event loop between chunks,
     // so the UI stays responsive during compilation.
     const result = await engine.loadRules(ruleFiles, [], (loaded, total) => {
+      if (generation !== _yaraGeneration) return
       _yaraCompileProgress = { loaded, total }
       // Push progress to all renderer windows
       for (const win of BrowserWindow.getAllWindows()) {
@@ -157,6 +181,10 @@ async function _initYaraEngine(): Promise<YaraEngine | null> {
       }
     })
 
+    if (generation !== _yaraGeneration) {
+      engine.retire()
+      return null
+    }
     _yaraCompileProgress = null
     // Diagnostics go to stderr so the CLI's --json mode keeps stdout parseable.
     console.error(`[yara] Loaded ${result.loaded} rule files (${result.errors.length} errors)`)
@@ -171,7 +199,8 @@ async function _initYaraEngine(): Promise<YaraEngine | null> {
     _yaraEngine = engine
     return engine
   } catch (err) {
-    _yaraCompileProgress = null
+    engine?.retire()
+    if (generation === _yaraGeneration) _yaraCompileProgress = null
     console.warn('[yara] Init failed:', err)
     return null
   }
@@ -183,9 +212,19 @@ async function _initYaraEngine(): Promise<YaraEngine | null> {
  * using it. The old instance is released once no scan references it.
  */
 export function resetYaraEngine(): void {
+  const previousEngine = _yaraEngine
+  const previousInit = _yaraInitPromise
+  _yaraGeneration++
   _yaraEngine = null
   _yaraInitPromise = null
   _yaraCompileProgress = null
+  if (previousEngine) {
+    previousEngine.retire()
+  } else if (previousInit) {
+    // Initialization owns a worker before it publishes _yaraEngine. Retire it
+    // when it settles so refreshes cannot leak a pre-publication worker.
+    void previousInit.then((engine) => engine?.retire())
+  }
 }
 
 function getYaraRulesInfo(): YaraRulesInfo {
@@ -1231,6 +1270,8 @@ async function collectFiles(
 export async function scanMalware(
   onProgress?: (data: MalwareScanProgress) => void
 ): Promise<MalwareScanResult> {
+  let releaseYaraEngine: (() => void) | null = null
+  try {
     const startTime = Date.now()
     const threats: MalwareThreat[] = []
     const engines: string[] = ['Heuristic Analysis', 'YARA Rules Engine', 'Script Analysis', 'System Integrity', 'Persistence Scan']
@@ -1292,7 +1333,9 @@ export async function scanMalware(
     // Compile YARA rules — shows progress via the loadRules onProgress callback.
     // Rules are downloaded from the cloud on first launch and updated periodically.
     sendProgress({ step: 'init', stepLabel: 'Compiling signature rules...', engine: 'YARA Rules Engine' })
-    yaraEngine = await getYaraEngine()
+    const yaraLease = await acquireYaraEngine()
+    yaraEngine = yaraLease?.engine ?? null
+    releaseYaraEngine = yaraLease?.release ?? null
     sendProgress({
       step: 'init',
       stepLabel: 'Initializing scan engines...',
@@ -1824,6 +1867,9 @@ export async function scanMalware(
       duration: Date.now() - startTime,
       engines
     }
+  } finally {
+    releaseYaraEngine?.()
+  }
 }
 
 export async function quarantineMalware(paths: string[], meta?: QuarantineMeta[]): Promise<MalwareActionResult> {

--- a/src/main/ipc/malware-scanner.yara-status.test.ts
+++ b/src/main/ipc/malware-scanner.yara-status.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   handle: vi.fn(),
   initialize: vi.fn(),
   loadRules: vi.fn(),
+  retire: vi.fn(),
   startPeriodicRuleChecks: vi.fn(),
 }))
 
@@ -29,6 +30,7 @@ vi.mock('../services/yara-engine', () => ({
     loadRules: (...args: unknown[]) => mocks.loadRules(...args),
     rulesLoaded: 2,
     dispose: vi.fn(),
+    retire: (...args: unknown[]) => mocks.retire(...args),
   }),
   yaraMatchToThreatFields: vi.fn(),
 }))
@@ -58,8 +60,8 @@ function getHandler(channel: string): () => unknown {
 
 describe('malware YARA status', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
     resetYaraEngine()
+    vi.clearAllMocks()
   })
 
   it('starts cached-rule compilation before reporting engine status', () => {
@@ -76,5 +78,18 @@ describe('malware YARA status', () => {
     expect(info.engine).toBe('compiling')
     expect(info.cachedRules).toBe(2)
     expect(info.compileProgress).toEqual({ loaded: 0, total: 2 })
+  })
+
+  it('retires the compiled engine when refreshed', async () => {
+    mocks.initialize.mockResolvedValue(undefined)
+    mocks.loadRules.mockResolvedValue({ loaded: 2, errors: [] })
+
+    registerMalwareScannerIpc(() => null)
+    getHandler(IPC.MALWARE_YARA_INFO)()
+    await vi.waitFor(() => expect(mocks.loadRules).toHaveBeenCalledOnce())
+
+    resetYaraEngine()
+
+    expect(mocks.retire).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/services/cooperative-scheduler.test.ts
+++ b/src/main/services/cooperative-scheduler.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { CooperativeScheduler } from './cooperative-scheduler'
+
+describe('CooperativeScheduler', () => {
+  it('gives queued main-loop work a turn once the interval is reached', async () => {
+    const scheduler = new CooperativeScheduler(0)
+    let mainLoopRan = false
+    setImmediate(() => { mainLoopRan = true })
+
+    await scheduler.yieldIfNeeded()
+
+    expect(mainLoopRan).toBe(true)
+  })
+})

--- a/src/main/services/cooperative-scheduler.ts
+++ b/src/main/services/cooperative-scheduler.ts
@@ -1,0 +1,16 @@
+/**
+ * Give Electron's main loop a macrotask turn during very large bookkeeping
+ * loops. Promise-based filesystem calls yield to microtasks, which can still
+ * starve window and IPC events when thousands resolve back-to-back.
+ */
+export class CooperativeScheduler {
+  private lastYield = Date.now()
+
+  constructor(private readonly intervalMs = 12) {}
+
+  async yieldIfNeeded(): Promise<void> {
+    if (Date.now() - this.lastYield < this.intervalMs) return
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    this.lastYield = Date.now()
+  }
+}

--- a/src/main/services/file-utils.ts
+++ b/src/main/services/file-utils.ts
@@ -8,6 +8,7 @@ import type { AppCacheDef, DirectFileMatch, RecursivePathMatch } from '../platfo
 import { getCachedItems, removeCachedItems } from './scan-cache'
 import { getSettings } from './settings-store'
 import { recordDeletions } from './deletion-log-store'
+import { CooperativeScheduler } from './cooperative-scheduler'
 
 export interface DeleteResult {
   path: string
@@ -269,9 +270,12 @@ async function listDescendantFiles(dirPath: string): Promise<{ paths: string[]; 
   const paths: string[] = []
   let truncated = 0
   const queue: Array<[string, Dirent[]]> = [[dirPath, rootEntries]]
+  const scheduler = new CooperativeScheduler()
 
-  while (queue.length > 0) {
-    const [dir, entries] = queue.shift()!
+  // Use an index instead of shift(): shifting a six-figure directory queue is
+  // quadratic and can monopolize Electron's main thread for minutes.
+  for (let queueIndex = 0; queueIndex < queue.length; queueIndex++) {
+    const [dir, entries] = queue[queueIndex]
     for (const entry of entries) {
       if (paths.length >= MAX_LOGGED_DESCENDANTS) {
         truncated++
@@ -286,6 +290,7 @@ async function listDescendantFiles(dirPath: string): Promise<{ paths: string[]; 
           // Unreadable subdirectory — its own path is already recorded.
         }
       }
+      await scheduler.yieldIfNeeded()
     }
   }
 
@@ -311,6 +316,7 @@ export async function cleanItems(
   const errors: CleanResult['errors'] = []
   const consumedIds: string[] = []
   let lastReport = 0
+  const scheduler = new CooperativeScheduler()
 
   // A missing cache entry used to disappear from the operation entirely. In a
   // large scan that made tens of thousands of selected files neither deleted
@@ -322,6 +328,7 @@ export async function cleanItems(
       filesSkipped++
       errors.push({ path: id, reason: 'scan-result-expired' })
     }
+    await scheduler.yieldIfNeeded()
   }
 
   // Opt-in audit trail of what was removed (issue #247). Buffered so a clean of
@@ -361,6 +368,7 @@ export async function cleanItems(
   }
 
   const processItem = async (item: ScanItem): Promise<void> => {
+    await scheduler.yieldIfNeeded()
     // lstat, not stat: it answers both questions the log depends on in one
     // call — whether the path is still there at all, and whether it is a real
     // directory rather than a symlink to one. Null means it was already gone
@@ -462,6 +470,7 @@ export async function cleanItems(
         onProgress(processed, validIds.length, item.path, totalCleaned)
       }
     }
+    await scheduler.yieldIfNeeded()
   }
 
   // Files in independent cache roots can be removed concurrently. The small,
@@ -475,6 +484,7 @@ export async function cleanItems(
     const group = groupsByPath.get(key) || []
     group.push(item)
     groupsByPath.set(key, group)
+    await scheduler.yieldIfNeeded()
   }
   const itemGroups = [...groupsByPath.values()]
   let nextGroup = 0

--- a/src/main/services/yara-engine.test.ts
+++ b/src/main/services/yara-engine.test.ts
@@ -217,4 +217,50 @@ describe('YaraEngine.scanFile', () => {
       rmSync(testDir, { recursive: true, force: true })
     }
   })
+
+  it('rebuilds an inline scanner instead of silently disabling YARA after a worker failure', async () => {
+    const testDir = mkdtempSync(join(tmpdir(), 'kudu-yara-recovery-'))
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const filePath = join(testDir, 'sample.bin')
+      writeFileSync(filePath, Buffer.from('contains recovery_marker'))
+      const engine = new YaraEngine({ background: false })
+      await engine.initialize()
+      await engine.loadRules([], [
+        'rule Recovery_Test { strings: $a = "recovery_marker" condition: $a }',
+      ])
+
+      // Model an initialized worker disappearing, then make its restart fail so
+      // the correctness-first inline fallback is exercised.
+      const release = engine.acquire()
+      ;(engine as any)._scanner = null
+      vi.spyOn(engine as any, '_initializeWorker').mockRejectedValue(new Error('worker crashed'))
+      ;(engine as any)._failWorker(new Error('worker exited'))
+      engine.retire()
+
+      const matches = await engine.scanFileAsync(filePath)
+      expect(matches.map((match) => match.ruleName)).toContain('Recovery_Test')
+      expect(engine.isReady()).toBe(true)
+      release()
+      expect(engine.isReady()).toBe(false)
+    } finally {
+      warn.mockRestore()
+      rmSync(testDir, { recursive: true, force: true })
+    }
+  })
+
+  it('terminates a retired worker only after its active scan lease is released', () => {
+    const engine = new YaraEngine({ background: false })
+    const terminate = vi.fn(async () => 0)
+    ;(engine as any)._worker = { terminate }
+    ;(engine as any)._ready = true
+
+    const release = engine.acquire()
+    engine.retire()
+    expect(terminate).not.toHaveBeenCalled()
+
+    release()
+    expect(terminate).toHaveBeenCalledOnce()
+    expect(engine.isReady()).toBe(false)
+  })
 })

--- a/src/main/services/yara-engine.test.ts
+++ b/src/main/services/yara-engine.test.ts
@@ -197,4 +197,24 @@ describe('YaraEngine.scanFile', () => {
       rmSync(testDir, { recursive: true, force: true })
     }
   })
+
+  it('uses the native async matcher for responsive inline fallback scans', async () => {
+    const testDir = mkdtempSync(join(tmpdir(), 'kudu-yara-engine-'))
+    try {
+      const filePath = join(testDir, 'sample.bin')
+      writeFileSync(filePath, Buffer.from('sample contents'))
+
+      const scan = vi.fn(() => [])
+      const scanAsync = vi.fn(async () => [])
+      const engine = new YaraEngine({ background: false })
+      ;(engine as any)._scanner = { scan, scanAsync }
+
+      await expect(engine.scanFileAsync(filePath)).resolves.toEqual([])
+      expect(scanAsync).toHaveBeenCalledOnce()
+      expect(scanAsync.mock.calls[0][0]).toEqual(Buffer.from('sample contents'))
+      expect(scan).not.toHaveBeenCalled()
+    } finally {
+      rmSync(testDir, { recursive: true, force: true })
+    }
+  })
 })

--- a/src/main/services/yara-engine.ts
+++ b/src/main/services/yara-engine.ts
@@ -59,6 +59,11 @@ export class YaraEngine {
   private _pending = new Map<number, PendingWorkerRequest>()
   private _nextRequestId = 1
   private readonly _background: boolean
+  private _lastRuleConfig: { ruleFilePaths: string[]; extraSources: string[] } | null = null
+  private _recoveryPromise: Promise<void> | null = null
+  private _leases = 0
+  private _retired = false
+  private _disposed = false
   private _ready = false
   private _rulesLoaded = 0
 
@@ -164,6 +169,56 @@ export class YaraEngine {
     this._ready = false
     for (const pending of this._pending.values()) pending.reject(error)
     this._pending.clear()
+    if (this._canRecover()) {
+      void this._startRecovery(error).catch(() => {})
+    }
+  }
+
+  private _canRecover(): boolean {
+    return !this._disposed
+      && this._lastRuleConfig !== null
+      && (!this._retired || this._leases > 0)
+  }
+
+  private _startRecovery(cause: Error): Promise<void> {
+    if (this._recoveryPromise) return this._recoveryPromise
+    const recovery = this._recoverAfterWorkerFailure(cause)
+    this._recoveryPromise = recovery
+    void recovery
+      .catch((error) => console.warn('[yara] Background recovery failed:', error))
+      .finally(() => {
+        if (this._recoveryPromise === recovery) this._recoveryPromise = null
+      })
+    return recovery
+  }
+
+  private async _recoverAfterWorkerFailure(cause: Error): Promise<void> {
+    const config = this._lastRuleConfig
+    if (!config || !this._canRecover()) throw cause
+
+    console.warn('[yara] Worker failed; restarting scanner:', cause.message)
+    try {
+      await this._initializeWorker()
+      if (!this._canRecover()) throw new Error('YARA engine retired during recovery')
+      const result = await this._requestWorker<{ loaded: number; errors: string[] }>({
+        type: 'load-rules',
+        ruleFilePaths: config.ruleFilePaths,
+        extraSources: config.extraSources,
+      })
+      if (result.loaded === 0) throw new Error('Recovered YARA worker loaded no rules')
+      this._rulesLoaded = result.loaded
+      this._ready = true
+      return
+    } catch (workerError) {
+      if (!this._canRecover()) throw workerError
+      console.warn('[yara] Worker restart failed; using inline fallback:', workerError)
+      if (this._worker) void this._worker.terminate()
+      this._worker = null
+      this._scanner = null
+      this._initializeInline()
+      const result = await this._loadRulesInline(config.ruleFilePaths, config.extraSources)
+      if (result.loaded === 0) throw new Error('Inline YARA fallback loaded no rules')
+    }
   }
 
   private _requestWorker<T>(
@@ -207,9 +262,27 @@ export class YaraEngine {
         extraSources,
       }, onProgress)
       this._rulesLoaded = result.loaded
+      if (result.loaded > 0) this._rememberRules(ruleFilePaths, extraSources)
       return result
     }
 
+    const result = await this._loadRulesInline(ruleFilePaths, extraSources, onProgress)
+    if (result.loaded > 0) this._rememberRules(ruleFilePaths, extraSources)
+    return result
+  }
+
+  private _rememberRules(ruleFilePaths: string[], extraSources: string[]): void {
+    this._lastRuleConfig = {
+      ruleFilePaths: [...ruleFilePaths],
+      extraSources: [...extraSources],
+    }
+  }
+
+  private async _loadRulesInline(
+    ruleFilePaths: string[],
+    extraSources: string[] = [],
+    onProgress?: (loaded: number, total: number) => void,
+  ): Promise<{ loaded: number; errors: string[] }> {
     if (!this._scanner) {
       return { loaded: 0, errors: ['YARA engine not initialized'] }
     }
@@ -349,6 +422,10 @@ export class YaraEngine {
 
   /** Run native file matching away from Electron's main thread when available. */
   async scanFileAsync(filePath: string): Promise<YaraMatch[]> {
+    if (this._recoveryPromise) await this._recoveryPromise
+    if (!this._worker && !this._scanner && this._canRecover()) {
+      await this._startRecovery(new Error('YARA scanner backend is unavailable'))
+    }
     if (this._worker) {
       return this._requestWorker<YaraMatch[]>({ type: 'scan-file', filePath })
     }
@@ -380,7 +457,29 @@ export class YaraEngine {
     }
   }
 
+  /** Keep a retired engine alive until an in-flight malware scan releases it. */
+  acquire(): () => void {
+    if (this._retired || this._disposed) throw new Error('YARA engine is retired')
+    this._leases++
+    let released = false
+    return () => {
+      if (released) return
+      released = true
+      this._leases = Math.max(0, this._leases - 1)
+      if (this._retired && this._leases === 0) this.dispose()
+    }
+  }
+
+  retire(): void {
+    if (this._retired || this._disposed) return
+    this._retired = true
+    if (this._leases === 0) this.dispose()
+  }
+
   dispose(): void {
+    if (this._disposed) return
+    this._disposed = true
+    this._retired = true
     if (this._worker) {
       void this._worker.terminate()
       this._worker = null
@@ -390,6 +489,7 @@ export class YaraEngine {
     }
     this._pending.clear()
     this._scanner = null
+    this._lastRuleConfig = null
     this._ready = false
     this._rulesLoaded = 0
   }

--- a/src/main/services/yara-engine.ts
+++ b/src/main/services/yara-engine.ts
@@ -1,5 +1,6 @@
-import { readFileSync } from 'fs'
-import { basename } from 'path'
+import { existsSync, readFileSync } from 'fs'
+import { basename, join } from 'path'
+import { Worker, isMainThread } from 'worker_threads'
 
 // ─── Types ───────────────────────────────────────────────────
 
@@ -36,17 +37,55 @@ interface YaraXScanner {
 
 interface YaraXModule {
   create(): YaraXScanner
+  compile(source: string): YaraXScanner
+}
+
+interface PendingWorkerRequest {
+  resolve: (value: any) => void
+  reject: (error: Error) => void
+  onProgress?: (loaded: number, total: number) => void
+}
+
+interface YaraEngineOptions {
+  /** Disable the worker inside the worker entry itself and in focused tests. */
+  background?: boolean
 }
 
 // ─── Engine ──────────────────────────────────────────────────
 
 export class YaraEngine {
   private _scanner: YaraXScanner | null = null
+  private _worker: Worker | null = null
+  private _pending = new Map<number, PendingWorkerRequest>()
+  private _nextRequestId = 1
+  private readonly _background: boolean
   private _ready = false
   private _rulesLoaded = 0
 
+  constructor(options: YaraEngineOptions = {}) {
+    // Vitest runs the source directly, where the bundled worker entry does not
+    // exist. Electron main/CLI builds use the worker by default.
+    this._background = options.background ?? (Boolean(process.versions.electron) && isMainThread)
+  }
+
   /** Create the scanner instance. Call once before loading rules. */
   async initialize(): Promise<void> {
+    if (this._background) {
+      try {
+        await this._initializeWorker()
+        return
+      } catch (error) {
+        // A missing/corrupt worker bundle must degrade scanner performance, not
+        // disable protection. Keep the inline path as a last-resort fallback.
+        console.warn('[yara] Background worker unavailable, using inline engine:', error)
+        this._worker = null
+      }
+    }
+
+    this._initializeInline()
+  }
+
+  private _initializeInline(): void {
     try {
       const yarax: YaraXModule = require('@litko/yara-x')
       this._scanner = yarax.create()
@@ -58,8 +97,90 @@ export class YaraEngine {
     }
   }
 
+  private _initializeWorker(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      // Rollup emits shared main-process code under out/main/chunks while the
+      // configured worker entry stays at out/main/yara-worker.js. Keep the
+      // adjacent candidate for unchunked/dev layouts as well.
+      const adjacentWorker = join(__dirname, 'yara-worker.js')
+      const workerPath = existsSync(adjacentWorker)
+        ? adjacentWorker
+        : join(__dirname, '..', 'yara-worker.js')
+      const worker = new Worker(workerPath)
+      let settled = false
+
+      const failStartup = (error: Error): void => {
+        if (settled) return
+        settled = true
+        reject(error)
+      }
+
+      worker.once('error', failStartup)
+      worker.on('message', (message: any) => {
+        if (message?.type === 'ready' && !settled) {
+          settled = true
+          worker.removeListener('error', failStartup)
+          worker.on('error', (error) => this._failWorker(error))
+          this._worker = worker
+          this._ready = true
+          resolve()
+          return
+        }
+        if (message?.type === 'startup-error' && !settled) {
+          void worker.terminate()
+          failStartup(new Error(message.error || 'YARA worker failed to start'))
+          return
+        }
+        this._handleWorkerMessage(message)
+      })
+      worker.once('exit', (code) => {
+        if (!settled) {
+          failStartup(new Error(`YARA worker exited during startup (${code})`))
+        } else if (code !== 0 && this._worker === worker) {
+          this._failWorker(new Error(`YARA worker exited unexpectedly (${code})`))
+        }
+      })
+    })
+  }
+
+  private _handleWorkerMessage(message: any): void {
+    if (!message || typeof message.id !== 'number') return
+    const pending = this._pending.get(message.id)
+    if (!pending) return
+    if (message.type === 'progress') {
+      pending.onProgress?.(message.loaded, message.total)
+      return
+    }
+    this._pending.delete(message.id)
+    if (message.type === 'error') {
+      pending.reject(new Error(message.error || 'YARA worker request failed'))
+    } else if (message.type === 'result') {
+      pending.resolve(message.result)
+    }
+  }
+
+  private _failWorker(error: Error): void {
+    this._worker = null
+    this._ready = false
+    for (const pending of this._pending.values()) pending.reject(error)
+    this._pending.clear()
+  }
+
+  private _requestWorker<T>(
+    message: Record<string, unknown>,
+    onProgress?: (loaded: number, total: number) => void,
+  ): Promise<T> {
+    const worker = this._worker
+    if (!worker) return Promise.reject(new Error('YARA worker is not running'))
+    const id = this._nextRequestId++
+    return new Promise<T>((resolve, reject) => {
+      this._pending.set(id, { resolve, reject, onProgress })
+      worker.postMessage({ ...message, id })
+    })
+  }
+
   isReady(): boolean {
-    return this._ready && this._scanner !== null
+    return this._ready && (this._scanner !== null || this._worker !== null)
   }
 
   /**
@@ -79,6 +200,16 @@ export class YaraEngine {
     extraSources: string[] = [],
     onProgress?: (loaded: number, total: number) => void,
   ): Promise<{ loaded: number; errors: string[] }> {
+    if (this._worker) {
+      const result = await this._requestWorker<{ loaded: number; errors: string[] }>({
+        type: 'load-rules',
+        ruleFilePaths,
+        extraSources,
+      }, onProgress)
+      this._rulesLoaded = result.loaded
+      return result
+    }
+
     if (!this._scanner) {
       return { loaded: 0, errors: ['YARA engine not initialized'] }
     }
@@ -216,6 +347,22 @@ export class YaraEngine {
     }
   }
 
+  /** Run native file matching away from Electron's main thread when available. */
+  async scanFileAsync(filePath: string): Promise<YaraMatch[]> {
+    if (this._worker) {
+      return this._requestWorker<YaraMatch[]>({ type: 'scan-file', filePath })
+    }
+    if (!this._scanner) return []
+    try {
+      const contents = readFileSync(filePath)
+      const results = await this._scanner.scanAsync(contents)
+      return results.map(r => this._convertMatch(r))
+    } catch (err) {
+      console.warn('[yara] Async file scan error:', err)
+      return []
+    }
+  }
+
   private _convertMatch(r: YaraXMatch): YaraMatch {
     const metadata: YaraMatch['metadata'] = {}
     if (r.meta.detectionName) metadata.detectionName = String(r.meta.detectionName)
@@ -234,6 +381,14 @@ export class YaraEngine {
   }
 
   dispose(): void {
+    if (this._worker) {
+      void this._worker.terminate()
+      this._worker = null
+    }
+    for (const pending of this._pending.values()) {
+      pending.reject(new Error('YARA engine disposed'))
+    }
+    this._pending.clear()
     this._scanner = null
     this._ready = false
     this._rulesLoaded = 0

--- a/src/main/workers/yara-worker.ts
+++ b/src/main/workers/yara-worker.ts
@@ -1,0 +1,64 @@
+import { parentPort } from 'worker_threads'
+import { YaraEngine } from '../services/yara-engine'
+
+if (!parentPort) {
+  throw new Error('YARA worker must be launched as a worker thread')
+}
+
+const engine = new YaraEngine({ background: false })
+
+interface WorkerRequest {
+  id: number
+  type: 'load-rules' | 'scan-file' | 'dispose'
+  ruleFilePaths?: string[]
+  extraSources?: string[]
+  filePath?: string
+}
+
+async function handleRequest(request: WorkerRequest): Promise<void> {
+  try {
+    if (request.type === 'load-rules') {
+      const result = await engine.loadRules(
+        request.ruleFilePaths ?? [],
+        request.extraSources ?? [],
+        (loaded, total) => parentPort!.postMessage({
+          type: 'progress',
+          id: request.id,
+          loaded,
+          total,
+        }),
+      )
+      parentPort!.postMessage({ type: 'result', id: request.id, result })
+      return
+    }
+
+    if (request.type === 'scan-file') {
+      const result = request.filePath ? engine.scanFile(request.filePath) : []
+      parentPort!.postMessage({ type: 'result', id: request.id, result })
+      return
+    }
+
+    engine.dispose()
+    parentPort!.postMessage({ type: 'result', id: request.id, result: null })
+  } catch (error) {
+    parentPort!.postMessage({
+      type: 'error',
+      id: request.id,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+engine.initialize()
+  .then(() => {
+    parentPort!.on('message', (request: WorkerRequest) => {
+      void handleRequest(request)
+    })
+    parentPort!.postMessage({ type: 'ready' })
+  })
+  .catch((error) => {
+    parentPort!.postMessage({
+      type: 'startup-error',
+      error: error instanceof Error ? error.message : String(error),
+    })
+  })


### PR DESCRIPTION
## Summary
- run YARA rule compilation and file matching in a dedicated worker thread
- cooperatively yield during malware discovery, PE entropy analysis, and large cleaner bookkeeping loops
- replace quadratic deletion-log directory queue handling with a linear traversal
- preserve the inline YARA fallback if the packaged worker cannot start

## Validation
- `npm test` (123 files, 2,535 tests)
- `npm run build`
- packaged YARA worker-manager compile-and-scan smoke test
- `git diff --check`