### PR TITLE
feat(settings): add toggle to disable software updater reminders

### DIFF
--- a/src/main/services/ipc-validation.test.ts
+++ b/src/main/services/ipc-validation.test.ts
@@ -55,6 +55,16 @@ describe('validateSettingsPartial', () => {
     expect(validateSettingsPartial({ exclusions: ['x'.repeat(501)] })).toBeNull()
   })
 
+  it('accepts softwareUpdaterNotifications boolean', () => {
+    expect(validateSettingsPartial({ softwareUpdaterNotifications: false })).toEqual({
+      softwareUpdaterNotifications: false,
+    })
+  })
+
+  it('rejects non-boolean softwareUpdaterNotifications', () => {
+    expect(validateSettingsPartial({ softwareUpdaterNotifications: 'off' })).toBeNull()
+  })
+
   it('accepts valid ignoredSoftwareUpdates array', () => {
     const input = { ignoredSoftwareUpdates: ['Google.Chrome', 'Mozilla.Firefox'] }
     expect(validateSettingsPartial(input)).toEqual(input)

--- a/src/main/services/ipc-validation.ts
+++ b/src/main/services/ipc-validation.ts
@@ -17,6 +17,7 @@ export function validateSettingsPartial(input: unknown): Record<string, unknown>
     'theme', 'language',
     'minimizeToTray', 'showNotificationOnComplete', 'showThreatNotifications',
     'runAtStartup', 'autoUpdate', 'autoRestart', 'updateCheckIntervalHours',
+    'softwareUpdaterNotifications',
     'cleaner', 'exclusions', 'ignoredSoftwareUpdates', 'backupPath', 'backupMode',
     'windowsPackageManager', 'windowsPackageManagers',
     'schedule', 'schedules', 'cloud', 'gameMode', 'registryIgnoredTweaks'
@@ -37,7 +38,7 @@ export function validateSettingsPartial(input: unknown): Record<string, unknown>
   }
 
   // Validate boolean fields have correct types
-  const boolKeys = ['minimizeToTray', 'showNotificationOnComplete', 'showThreatNotifications', 'runAtStartup', 'autoUpdate', 'autoRestart'] as const
+  const boolKeys = ['minimizeToTray', 'showNotificationOnComplete', 'showThreatNotifications', 'runAtStartup', 'autoUpdate', 'autoRestart', 'softwareUpdaterNotifications'] as const
   for (const bk of boolKeys) {
     if (bk in obj && obj[bk] !== undefined && typeof obj[bk] !== 'boolean') return null
   }

--- a/src/main/services/settings-store.ts
+++ b/src/main/services/settings-store.ts
@@ -46,6 +46,7 @@ const defaults: StoreData = {
     autoUpdate: true,
     autoRestart: true,
     updateCheckIntervalHours: 4,
+    softwareUpdaterNotifications: true,
     cleaner: {
       skipRecentMinutes: 60,
       secureDelete: false,

--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -47,6 +47,7 @@ import { useGameModeStore } from '@/stores/game-mode-store'
 import { useCveStore } from '@/stores/cve-store'
 import { useBreachStore } from '@/stores/breach-store'
 import { usePlatform } from '@/hooks/usePlatform'
+import { useSettingsStore } from '@/stores/settings-store'
 
 interface SubItemDef {
   icon: LucideIcon
@@ -154,6 +155,9 @@ function useBottomNavItems(): NavItemDef[] {
 
 // Map nav paths to badge counts from stores
 function useBadgeCounts(): Record<string, number> {
+  const softwareUpdaterNotifications = useSettingsStore(
+    (s) => s.settings.softwareUpdaterNotifications ?? true
+  )
   const updaterApps = useUpdaterStore((s) => s.apps)
   const driverUpdates = useDriverStore((s) => s.updates)
   const threatSnapshot = useThreatMonitorStore((s) => s.snapshot)
@@ -163,10 +167,11 @@ function useBadgeCounts(): Record<string, number> {
   const breachEmails = useBreachStore((s) => s.emails)
   const breachTotal = breachEmails.reduce((sum, e) => sum + e.breaches.filter((b) => !b.acknowledgedAt).length, 0)
 
-  const updatesCount = updaterApps.length + driverUpdates.length
+  const softwareUpdateCount = softwareUpdaterNotifications ? updaterApps.length : 0
+  const updatesCount = softwareUpdateCount + driverUpdates.length
 
   return {
-    '/updates': updaterApps.length,
+    '/updates': softwareUpdateCount,
     '/software': updatesCount,
     '/drivers': driverUpdates.length,
     '/threat-monitor': threatCount,

--- a/src/renderer/src/hooks/useBackgroundScans.ts
+++ b/src/renderer/src/hooks/useBackgroundScans.ts
@@ -1,32 +1,52 @@
 import { useEffect, useRef } from 'react'
 import { useUpdaterStore } from '@/stores/updater-store'
 import { useDriverStore } from '@/stores/driver-store'
+import { refreshSettings, useSettingsStore } from '@/stores/settings-store'
 
 /**
  * Runs software-update and driver-update scans silently in the background
  * on first app launch. Populates stores so badge counts appear in the sidebar.
  */
 export function useBackgroundScans(): void {
-  const ran = useRef(false)
+  const driverRan = useRef(false)
+  const softwareRan = useRef(false)
+  const ignoredLoaded = useRef(false)
+  const settingsLoaded = useSettingsStore((s) => s.loaded)
+  const ignoredSoftwareUpdates = useSettingsStore((s) => s.settings.ignoredSoftwareUpdates)
+  const softwareUpdaterNotifications = useSettingsStore(
+    (s) => s.settings.softwareUpdaterNotifications ?? true
+  )
 
+  // The software check waits on hydrated settings; retry once if the eager
+  // hydration in settings-store lost its IPC, so a transient failure doesn't
+  // defer that check for the whole session.
   useEffect(() => {
-    if (ran.current) return
-    ran.current = true
+    if (settingsLoaded) return
+    const id = setTimeout(refreshSettings, 2000)
+    return () => clearTimeout(id)
+  }, [settingsLoaded])
 
-    // Software update check (silent — no toasts)
-    // Load ignored IDs first so setApps() can partition correctly
-    const runSoftwareCheck = async () => {
-      try {
-        const settings = await window.kudu.settingsGet()
-        if (settings.ignoredSoftwareUpdates?.length) {
-          useUpdaterStore.getState().loadIgnoredIds(settings.ignoredSoftwareUpdates)
-        }
-        if (settings.softwareUpdaterNotifications === false) return
-      } catch { /* best-effort */ }
+  // Load ignored IDs first so setApps() can partition correctly. This runs even
+  // when reminders are off, since manual checks on the updater page still need it.
+  useEffect(() => {
+    if (!settingsLoaded || ignoredLoaded.current) return
+    ignoredLoaded.current = true
+    if (ignoredSoftwareUpdates?.length) {
+      useUpdaterStore.getState().loadIgnoredIds(ignoredSoftwareUpdates)
+    }
+  }, [settingsLoaded, ignoredSoftwareUpdates])
 
-      const store = useUpdaterStore.getState()
-      if (store.hasChecked || store.loading) return
-      store.setLoading(true)
+  // Software update check (silent — no toasts). Deferred while reminders are
+  // off, and started on the off-to-on transition without needing a restart.
+  useEffect(() => {
+    if (!settingsLoaded || !softwareUpdaterNotifications || softwareRan.current) return
+
+    const store = useUpdaterStore.getState()
+    if (store.hasChecked || store.loading) return
+    softwareRan.current = true
+    store.setLoading(true)
+
+    void (async () => {
       try {
         const result = await window.kudu.softwareUpdateCheck()
         const s = useUpdaterStore.getState()
@@ -40,11 +60,16 @@ export function useBackgroundScans(): void {
       } finally {
         useUpdaterStore.getState().setLoading(false)
       }
-    }
+    })()
+  }, [settingsLoaded, softwareUpdaterNotifications])
 
-    // Driver update scan only (we skip the stale-packages scan since it's heavier
-    // and less relevant for the badge — the badge shows available driver *updates*)
-    const runDriverUpdateScan = async () => {
+  // Driver update scan only (we skip the stale-packages scan since it's heavier
+  // and less relevant for the badge — the badge shows available driver *updates*)
+  useEffect(() => {
+    if (driverRan.current) return
+    driverRan.current = true
+
+    void (async () => {
       const store = useDriverStore.getState()
       if (store.hasScanned || store.updateScanning) return
       store.setUpdateScanning(true)
@@ -58,10 +83,6 @@ export function useBackgroundScans(): void {
         s.setUpdateScanning(false)
         s.setUpdateProgress(null)
       }
-    }
-
-    // Run both in parallel
-    runSoftwareCheck()
-    runDriverUpdateScan()
+    })()
   }, [])
 }

--- a/src/renderer/src/hooks/useBackgroundScans.ts
+++ b/src/renderer/src/hooks/useBackgroundScans.ts
@@ -21,6 +21,7 @@ export function useBackgroundScans(): void {
         if (settings.ignoredSoftwareUpdates?.length) {
           useUpdaterStore.getState().loadIgnoredIds(settings.ignoredSoftwareUpdates)
         }
+        if (settings.softwareUpdaterNotifications === false) return
       } catch { /* best-effort */ }
 
       const store = useUpdaterStore.getState()

--- a/src/renderer/src/locales/en/settings.json
+++ b/src/renderer/src/locales/en/settings.json
@@ -22,6 +22,8 @@
   "updateCheckEvery4Hours": "Every 4 hours",
   "updateCheckEvery12Hours": "Every 12 hours",
   "updateCheckOnceADay": "Once a day",
+  "softwareUpdaterNotificationsLabel": "Software updater reminders",
+  "softwareUpdaterNotificationsDesc": "Check for third-party app updates in the background and show badge counts in the sidebar. You can still check manually from the Software Updater page.",
   "windowsPackageManagerLabel": "Windows package manager",
   "windowsPackageManagerDesc": "Choose which package manager to use for software updates",
   "sectionCloudDashboard": "Cloud",

--- a/src/renderer/src/locales/it/settings.json
+++ b/src/renderer/src/locales/it/settings.json
@@ -22,6 +22,8 @@
   "updateCheckEvery4Hours": "Ogni 4 ore",
   "updateCheckEvery12Hours": "Ogni 12 ore",
   "updateCheckOnceADay": "Una volta al giorno",
+  "softwareUpdaterNotificationsLabel": "Promemoria aggiornamenti software",
+  "softwareUpdaterNotificationsDesc": "Controlla in background gli aggiornamenti delle app di terze parti e mostra i badge nella barra laterale. Puoi comunque controllare manualmente dalla pagina Aggiornamenti software.",
   "windowsPackageManagerLabel": "Gestore pacchetti di Windows",
   "windowsPackageManagerDesc": "Scegli quale gestore pacchetti utilizzare per gli aggiornamenti software",
   "sectionCloudDashboard": "Cloud",

--- a/src/renderer/src/pages/DashboardPage.tsx
+++ b/src/renderer/src/pages/DashboardPage.tsx
@@ -470,7 +470,9 @@ export function DashboardPage() {
     setStepProgress({ current: ++step, total: totalSteps })
     const startupHighImpact = await runStartupCheck()
     setStepProgress({ current: ++step, total: totalSteps })
-    const updatesAvailable = await runSoftwareUpdateCheck()
+    const updatesAvailable = useSettingsStore.getState().settings.softwareUpdaterNotifications === false
+      ? 0
+      : await runSoftwareUpdateCheck()
 
     const oneClickResult: OneClickResult = {
       spaceRecovered: space + drivers.space, filesCleaned: files, registryFixed: regFixed,

--- a/src/renderer/src/pages/DashboardPage.tsx
+++ b/src/renderer/src/pages/DashboardPage.tsx
@@ -88,6 +88,7 @@ export function DashboardPage() {
   const scanStore = useScanStore()
   const updaterHasChecked = useUpdaterStore((s) => s.hasChecked)
   const updaterApps = useUpdaterStore((s) => s.apps)
+  const updaterRemindersEnabled = useSettingsStore((s) => s.settings.softwareUpdaterNotifications ?? true)
   const serviceHasScanned = useServiceStore((s) => s.hasScanned)
   const startupItems = useStartupStore((s) => s.items)
   const startupHasLoaded = useStartupStore((s) => s.hasLoaded)
@@ -207,7 +208,7 @@ export function DashboardPage() {
     }))
 
     const sessionTools = [
-      { key: 'updater', label: t('toolLabelUpdater'), icon: Download, color: '#06b6d4', active: updaterHasChecked },
+      ...(updaterRemindersEnabled ? [{ key: 'updater', label: t('toolLabelUpdater'), icon: Download, color: '#06b6d4', active: updaterHasChecked }] : []),
       { key: 'services', label: t('toolLabelServices'), icon: Server, color: '#ec4899', active: serviceHasScanned },
       { key: 'startup', label: t('toolLabelStartup'), icon: Zap, color: '#22c55e', active: startupHasLoaded }
     ]
@@ -526,10 +527,11 @@ export function DashboardPage() {
   // ── Render ─────────────────────────────────────────────────
 
   const startupAttentionCount = startupItems.filter((item) => item.enabled && item.impact === 'high').length
-  const pendingUpdateCount = updaterApps.length
+  const pendingUpdateCount = updaterRemindersEnabled ? updaterApps.length : 0
   const unresolvedThreatCount = (lastMalwareScan?.unresolvedThreats ?? 0) + knownActiveThreats
   const hasProtectionBaseline = !!lastMalwareScan
-  const hasCompletedCoreChecks = updaterHasChecked && startupHasLoaded && hasProtectionBaseline
+  const updaterNeedsAttention = updaterRemindersEnabled && (!updaterHasChecked || pendingUpdateCount > 0)
+  const hasCompletedCoreChecks = (!updaterRemindersEnabled || updaterHasChecked) && startupHasLoaded && hasProtectionBaseline
   const primaryDrive = drives.find((drive) => drive.isSystem)
   const primaryDriveUsedPercent = primaryDrive?.totalSize
     ? Math.round((primaryDrive.usedSpace / primaryDrive.totalSize) * 100)
@@ -537,7 +539,7 @@ export function DashboardPage() {
   const freeMemory = perf ? Math.max(0, perf.memTotalBytes - perf.memUsedBytes) : 0
   const hour = new Date().getHours()
   const greeting = hour < 12 ? 'Good morning' : hour < 18 ? 'Good afternoon' : 'Good evening'
-  const attentionCount = Number(!updaterHasChecked || pendingUpdateCount > 0)
+  const attentionCount = Number(updaterNeedsAttention)
     + Number(!startupHasLoaded || startupAttentionCount > 0)
     + Number(!hasProtectionBaseline || unresolvedThreatCount > 0)
   const healthHeadline = unresolvedThreatCount > 0
@@ -684,11 +686,13 @@ export function DashboardPage() {
           </div>
 
           <div className="kudu-attention-list">
-            <button type="button" onClick={() => navigate('/updates')}>
-              <span className="kudu-attention-icon"><Download /></span>
-              <span><b>{!updaterHasChecked ? 'Check app updates' : pendingUpdateCount > 0 ? `${pendingUpdateCount} app ${pendingUpdateCount === 1 ? 'update' : 'updates'}` : 'Apps are up to date'}</b><small>{!updaterHasChecked ? 'Security and reliability fixes' : pendingUpdateCount > 0 ? 'Updates are ready to install' : 'Latest check completed'}</small></span>
-              <em>{!updaterHasChecked ? '5 MIN' : pendingUpdateCount > 0 ? 'REVIEW' : 'DONE'}</em>
-            </button>
+            {updaterRemindersEnabled && (
+              <button type="button" onClick={() => navigate('/updates')}>
+                <span className="kudu-attention-icon"><Download /></span>
+                <span><b>{!updaterHasChecked ? 'Check app updates' : pendingUpdateCount > 0 ? `${pendingUpdateCount} app ${pendingUpdateCount === 1 ? 'update' : 'updates'}` : 'Apps are up to date'}</b><small>{!updaterHasChecked ? 'Security and reliability fixes' : pendingUpdateCount > 0 ? 'Updates are ready to install' : 'Latest check completed'}</small></span>
+                <em>{!updaterHasChecked ? '5 MIN' : pendingUpdateCount > 0 ? 'REVIEW' : 'DONE'}</em>
+              </button>
+            )}
             <button type="button" onClick={() => navigate('/startup')}>
               <span className="kudu-attention-icon"><Zap /></span>
               <span><b>{!startupHasLoaded ? 'Check startup apps' : startupAttentionCount > 0 ? `${startupAttentionCount} startup ${startupAttentionCount === 1 ? 'app' : 'apps'}` : 'Startup looks good'}</b><small>{!startupHasLoaded ? 'Review what launches when you sign in' : startupAttentionCount > 0 ? 'High-impact apps may slow sign-in' : 'No high-impact apps found'}</small></span>

--- a/src/renderer/src/pages/SettingsPage.tsx
+++ b/src/renderer/src/pages/SettingsPage.tsx
@@ -112,7 +112,7 @@ export function SettingsPage() {
         <Row label={t('autoRestartLabel')} desc={t('autoRestartDesc')}>
           <Toggle checked={settings.autoRestart} onChange={(v) => save({ autoRestart: v })} />
         </Row>
-        <Row label={t('updateCheckIntervalLabel')} desc={t('updateCheckIntervalDesc')} last>
+        <Row label={t('updateCheckIntervalLabel')} desc={t('updateCheckIntervalDesc')}>
           <select value={settings.updateCheckIntervalHours}
             onChange={(e) => save({ updateCheckIntervalHours: Number(e.target.value) })}
             className={selectStyle} style={selectBorder}>
@@ -121,6 +121,12 @@ export function SettingsPage() {
             <option value={12}>{t('updateCheckEvery12Hours')}</option>
             <option value={24}>{t('updateCheckOnceADay')}</option>
           </select>
+        </Row>
+        <Row label={t('softwareUpdaterNotificationsLabel')} desc={t('softwareUpdaterNotificationsDesc')} last>
+          <Toggle
+            checked={settings.softwareUpdaterNotifications ?? true}
+            onChange={(v) => save({ softwareUpdaterNotifications: v })}
+          />
         </Row>
       </Section>
 

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -18,6 +18,7 @@ const defaultSettings: KuduSettings = {
   autoUpdate: true,
   autoRestart: true,
   updateCheckIntervalHours: 4,
+  softwareUpdaterNotifications: true,
   cleaner: {
     skipRecentMinutes: 60,
     secureDelete: false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -693,6 +693,11 @@ export interface KuduSettings {
   autoRestart: boolean
   /** How often (in hours) to check for updates in the background */
   updateCheckIntervalHours: number
+  /**
+   * When false, skip background third-party software update checks and hide
+   * sidebar badge counts. Manual checks from the Software Updater page still work.
+   */
+  softwareUpdaterNotifications: boolean
   cleaner: {
     skipRecentMinutes: number
     secureDelete: boolean


### PR DESCRIPTION
## Summary
- Adds a **Software updater reminders** toggle in Settings (General) to disable background third-party update checks and sidebar badge counts.
- Full clean skips the software-update step when reminders are off; manual checks on the Software Updater page still work.
- Addresses [discussion #340](https://github.com/AdventDevInc/kudu/discussions/340).

## Test plan
- [ ] Open Settings → General → turn off **Software updater reminders**
- [ ] Restart app: no background software update scan; no badge on Updates / Software in the sidebar
- [ ] Open Software Updater page: manual **Check for updates** still works
- [ ] Run full clean with reminders off: result should not include available software updates
- [ ] Turn reminders back on: badge and background scan behave as before