### PR TITLE
fix(malware): stop quarantining Helium chrome.exe and Logi Options+ updater

### DIFF
--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -116,10 +116,10 @@ const TRUSTED_PATHS = [
   'zoom', 'microsoft', 'google', 'mozilla', 'adobe', 'oracle',
   'nvidia', 'amd', 'intel', 'steam', 'valve', 'epic games',
   'discord', 'slack', 'spotify', 'dropbox', 'brave', 'opera',
-  'jetbrains', 'visual studio', 'vs code', 'vscode',
+  'jetbrains', 'microsoft visual studio', 'microsoft vs code', 'vscode',
   'github', 'git', 'python', 'java',
   '1password', 'bitwarden', 'lastpass', 'keepass',
-  'obs studio', 'vlc', 'gimp', 'blender', 'audacity',
+  'obs-studio', 'vlc', 'gimp', 'blender', 'audacity',
   'logitech', 'logioptionsplus', 'razer', 'corsair', 'steelseries',
   // Chromium forks Kudu already cleans — Helium ships chrome.exe under imput/
   'imput', 'helium', 'thorium', 'supermium', 'cromite', 'catsxp',
@@ -129,6 +129,12 @@ const TRUSTED_PATHS = [
 // Dependency trees legitimately hold packed helper binaries but live anywhere on
 // disk, so they are matched as a path component without an installation root.
 const TRUSTED_ANYWHERE_DIRS = ['node_modules']
+
+// Scratch trees nested inside installation roots (%LOCALAPPDATA%\Temp above all)
+// are the drop locations Kudu scans hardest. Nothing below one is installed
+// software, so a vendor-named folder there — `…\Local\Temp\google\dropper.exe` —
+// must never buy its way out of the content scans.
+const NEVER_TRUSTED_DIRS = ['temp', 'tmp', 'downloads', 'cache', '$recycle.bin']
 
 function normalizeForTrust(p: string): string {
   return p.toLowerCase().replace(/\\/g, '/').replace(/\/{2,}/g, '/').replace(/\/$/, '')
@@ -162,6 +168,9 @@ function toExecutablePath(command: string): string {
 function isTrustedPublisherPath(filePath: string): boolean {
   const normalized = normalizeForTrust(toExecutablePath(filePath))
   const dirs = normalized.split('/').slice(0, -1)
+  // Checked before anything else, so a scratch directory can't be dressed up as
+  // either a vendor install or a dependency tree.
+  if (dirs.some(d => NEVER_TRUSTED_DIRS.includes(d))) return false
   if (dirs.some(d => TRUSTED_ANYWHERE_DIRS.includes(d))) return true
 
   // Roots are pre-sorted longest-first so the most specific one wins — otherwise

--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -103,7 +103,9 @@ function getSystemDirs(): string[] {
   return getPlatform().paths.malwareSystemDirs()
 }
 
-// Trusted publisher paths — skip PE heuristic analysis for known legit software
+// Trusted publisher paths — skip signature/heuristic file scans for known legit
+// software. Chromium-based browsers and vendor updaters are often packed and
+// import injection-capable APIs, which trips PE heuristics (see #156, #231).
 const TRUSTED_PATHS = [
   'zoom', 'microsoft', 'google', 'mozilla', 'adobe', 'oracle',
   'nvidia', 'amd', 'intel', 'steam', 'valve', 'epic games',
@@ -112,8 +114,16 @@ const TRUSTED_PATHS = [
   'github', 'git', 'node_modules', 'python', 'java',
   '1password', 'bitwarden', 'lastpass', 'keepass',
   'obs studio', 'vlc', 'gimp', 'blender', 'audacity',
-  'logitech', 'razer', 'corsair', 'steelseries',
+  'logitech', 'logioptionsplus', 'razer', 'corsair', 'steelseries',
+  // Chromium forks Kudu already cleans — Helium ships chrome.exe under imput/
+  'imput', 'helium', 'thorium', 'supermium', 'cromite', 'catsxp',
+  'vivaldi', 'chromium', 'arcsoft', 'librewolf', 'waterfox', 'floorp',
 ]
+
+function isTrustedPublisherPath(filePath: string): boolean {
+  const lower = filePath.toLowerCase()
+  return TRUSTED_PATHS.some(tp => lower.includes(tp))
+}
 
 // ─── YARA engine (lazy-initialized singleton) ────────────────
 
@@ -734,8 +744,7 @@ async function scanRegistryPersistence(): Promise<RegistryPersistenceResult[]> {
         const valueLower = value.toLowerCase()
 
         // Skip known-safe publishers
-        const isTrusted = TRUSTED_PATHS.some(tp => valueLower.includes(tp))
-        if (isTrusted) continue
+        if (isTrustedPublisherPath(value)) continue
 
         // Flag entries pointing to temp directories
         const tempIndicators = ['\\temp\\', '\\tmp\\', '%temp%', '%tmp%', '\\appdata\\local\\temp\\']
@@ -834,8 +843,7 @@ async function analyzeTaskFile(filePath: string, taskName: string, results: Sche
     const fullCmd = command + ' ' + args
 
     // Skip trusted paths
-    const isTrusted = TRUSTED_PATHS.some(tp => commandLower.includes(tp))
-    if (isTrusted) return
+    if (isTrustedPublisherPath(command)) return
 
     // Flag tasks executing from temp directories
     const tempPaths = ['\\temp\\', '\\tmp\\', '%temp%', '%tmp%', '\\appdata\\local\\temp\\']
@@ -1389,6 +1397,10 @@ export async function scanMalware(
       if (!fileStat) return
       const fileSize = fileStat.size
 
+      // Installed vendor software — skip YARA/PE/LNK heuristics that false-positive
+      // on packed Chromium binaries (Helium's chrome.exe) and vendor updaters (#231).
+      if (isTrustedPublisherPath(filePath)) return
+
       // ── Suspicious filename check (always runs, regardless of YARA) ──
       const dirLower = filePath.toLowerCase().replace(/\\/g, '/')
       const isInSystemDir = systemDirs.some(sd => dirLower.startsWith(sd.toLowerCase().replace(/\\/g, '/')))
@@ -1465,10 +1477,7 @@ export async function scanMalware(
       }
       if (fileBuffer && !threats.some(t => t.path === filePath)) {
         // PE heuristic analysis
-        const pathLower = filePath.toLowerCase()
-        const isTrustedPath = TRUSTED_PATHS.some(tp => pathLower.includes(tp))
-
-        if (shouldAnalyzePE && isPEFile(fileBuffer) && !isTrustedPath) {
+        if (shouldAnalyzePE && isPEFile(fileBuffer)) {
           const pe = await analyzePE(fileBuffer)
           if (pe) {
             // High section entropy (isPacked) and high overall file entropy

--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -103,15 +103,21 @@ function getSystemDirs(): string[] {
   return getPlatform().paths.malwareSystemDirs()
 }
 
-// Trusted publisher paths — skip signature/heuristic file scans for known legit
+// Trusted publisher directories — skip signature/heuristic scans for known legit
 // software. Chromium-based browsers and vendor updaters are often packed and
 // import injection-capable APIs, which trips PE heuristics (see #156, #231).
+//
+// These names only earn trust as a whole path component *beneath an installation
+// root* (see isTrustedPublisherPath). Matching them as substrings of the full path
+// would trust anything merely containing a vendor name — `Downloads\github-payload.exe`,
+// or every file under a user profile named `git` — and Windows has no native-AV
+// phase, so that would let a chosen name bypass the file detectors outright.
 const TRUSTED_PATHS = [
   'zoom', 'microsoft', 'google', 'mozilla', 'adobe', 'oracle',
   'nvidia', 'amd', 'intel', 'steam', 'valve', 'epic games',
   'discord', 'slack', 'spotify', 'dropbox', 'brave', 'opera',
   'jetbrains', 'visual studio', 'vs code', 'vscode',
-  'github', 'git', 'node_modules', 'python', 'java',
+  'github', 'git', 'python', 'java',
   '1password', 'bitwarden', 'lastpass', 'keepass',
   'obs studio', 'vlc', 'gimp', 'blender', 'audacity',
   'logitech', 'logioptionsplus', 'razer', 'corsair', 'steelseries',
@@ -120,9 +126,54 @@ const TRUSTED_PATHS = [
   'vivaldi', 'chromium', 'arcsoft', 'librewolf', 'waterfox', 'floorp',
 ]
 
+// Dependency trees legitimately hold packed helper binaries but live anywhere on
+// disk, so they are matched as a path component without an installation root.
+const TRUSTED_ANYWHERE_DIRS = ['node_modules']
+
+function normalizeForTrust(p: string): string {
+  return p.toLowerCase().replace(/\\/g, '/').replace(/\/{2,}/g, '/').replace(/\/$/, '')
+}
+
+// Resolved once — this runs for every discovered file during a scan.
+let _trustedInstallRoots: string[] | null = null
+function getTrustedInstallRoots(): string[] {
+  if (!_trustedInstallRoots) {
+    _trustedInstallRoots = getPlatform().paths.malwareTrustedInstallRoots()
+      .map(normalizeForTrust)
+      .sort((a, b) => b.length - a.length)
+  }
+  return _trustedInstallRoots
+}
+
+// Registry Run values and scheduled-task commands hold `"C:\...\app.exe" --flag`
+// and unexpanded %ENV% references; reduce them to a bare path before matching.
+function toExecutablePath(command: string): string {
+  const trimmed = command.trim()
+  const quoted = trimmed.startsWith('"') ? trimmed.slice(1).split('"')[0] : null
+  const bare = quoted ?? (trimmed.match(/^(.*?\.(?:exe|com|scr|bat|cmd|ps1|dll))(?:\s|$)/i)?.[1] ?? trimmed.split(/\s+/)[0])
+  return bare.replace(/%([^%]+)%/g, (whole, name: string) => process.env[name] ?? whole)
+}
+
+/**
+ * True when the file sits beneath a known installation root and a trusted
+ * publisher name appears as a whole directory component below that root.
+ * Requiring both is what keeps `Downloads\google\malware.exe` untrusted.
+ */
 function isTrustedPublisherPath(filePath: string): boolean {
-  const lower = filePath.toLowerCase()
-  return TRUSTED_PATHS.some(tp => lower.includes(tp))
+  const normalized = normalizeForTrust(toExecutablePath(filePath))
+  const dirs = normalized.split('/').slice(0, -1)
+  if (dirs.some(d => TRUSTED_ANYWHERE_DIRS.includes(d))) return true
+
+  // Roots are pre-sorted longest-first so the most specific one wins — otherwise
+  // `LocalAppData\Programs` would also expose `Programs` as a publisher component.
+  const root = getTrustedInstallRoots().find(r => normalized.startsWith(r + '/'))
+  if (!root) return false
+
+  return normalized
+    .slice(root.length + 1)
+    .split('/')
+    .slice(0, -1)
+    .some(d => TRUSTED_PATHS.includes(d))
 }
 
 // ─── YARA engine (lazy-initialized singleton) ────────────────
@@ -1397,9 +1448,11 @@ export async function scanMalware(
       if (!fileStat) return
       const fileSize = fileStat.size
 
-      // Installed vendor software — skip YARA/PE/LNK heuristics that false-positive
+      // Installed vendor software — suppress the content scans that false-positive
       // on packed Chromium binaries (Helium's chrome.exe) and vendor updaters (#231).
-      if (isTrustedPublisherPath(filePath)) return
+      // The filename and double-extension checks below still run, so a payload
+      // dropped into a vendor directory can't evade every detector at once.
+      const isTrusted = isTrustedPublisherPath(filePath)
 
       // ── Suspicious filename check (always runs, regardless of YARA) ──
       const dirLower = filePath.toLowerCase().replace(/\\/g, '/')
@@ -1426,7 +1479,7 @@ export async function scanMalware(
       }
 
       // ── Signature matching via YARA engine (rules downloaded from cloud) ──
-      if (yaraEngine && fileSize <= MAX_READ_SIZE && !threats.some(t => t.path === filePath)) {
+      if (yaraEngine && !isTrusted && fileSize <= MAX_READ_SIZE && !threats.some(t => t.path === filePath)) {
         const matches = await yaraEngine.scanFileAsync(filePath)
         for (const match of matches) {
           if (threats.some(t => t.path === filePath)) break
@@ -1469,8 +1522,9 @@ export async function scanMalware(
 
       // ── PE + LNK heuristic analysis ──
       // Read file buffer only for PE/LNK analysis (Windows executables and shortcuts)
-      const needsBuffer = (shouldAnalyzePE && (ext === '.exe' || ext === '.dll' || ext === '.scr' || ext === '.sys' || ext === '.drv'))
-        || (process.platform === 'win32' && ext === '.lnk')
+      const needsBuffer = !isTrusted && (
+        (shouldAnalyzePE && (ext === '.exe' || ext === '.dll' || ext === '.scr' || ext === '.sys' || ext === '.drv'))
+        || (process.platform === 'win32' && ext === '.lnk'))
       let fileBuffer: Buffer | null = null
       if (needsBuffer && fileSize <= MAX_READ_SIZE && !threats.some(t => t.path === filePath)) {
         fileBuffer = await readFile(filePath).catch(() => null)

--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -128,6 +128,9 @@ const TRUSTED_PATHS = [
 
 // Dependency trees legitimately hold packed helper binaries but live anywhere on
 // disk, so they are matched as a path component without an installation root.
+// Only ever below a package directory (`node_modules/<pkg>/…`, `node_modules/.bin/…`):
+// nothing real ships an executable directly in `node_modules`, so requiring the
+// extra level costs nothing and denies `Desktop\node_modules\payload.exe`.
 const TRUSTED_ANYWHERE_DIRS = ['node_modules']
 
 // Scratch trees nested inside installation roots (%LOCALAPPDATA%\Temp above all)
@@ -182,7 +185,7 @@ function publisherTrust(filePath: string): PublisherTrust {
   // Checked before anything else, so a scratch directory can't be dressed up as
   // either a vendor install or a dependency tree.
   if (dirs.some(d => NEVER_TRUSTED_DIRS.includes(d))) return 'none'
-  if (dirs.some(d => TRUSTED_ANYWHERE_DIRS.includes(d))) return 'heuristics'
+  if (dirs.slice(0, -1).some(d => TRUSTED_ANYWHERE_DIRS.includes(d))) return 'heuristics'
 
   const match = getTrustedRoots().find(({ root }) => normalized.startsWith(root + '/'))
   if (!match) return 'none'

--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -108,7 +108,7 @@ function getSystemDirs(): string[] {
 // import injection-capable APIs, which trips PE heuristics (see #156, #231).
 //
 // These names only earn trust as a whole path component *beneath an installation
-// root* (see isTrustedPublisherPath). Matching them as substrings of the full path
+// root* (see publisherTrust). Matching them as substrings of the full path
 // would trust anything merely containing a vendor name — `Downloads\github-payload.exe`,
 // or every file under a user profile named `git` — and Windows has no native-AV
 // phase, so that would let a chosen name bypass the file detectors outright.
@@ -136,19 +136,63 @@ const TRUSTED_ANYWHERE_DIRS = ['node_modules']
 // must never buy its way out of the content scans.
 const NEVER_TRUSTED_DIRS = ['temp', 'tmp', 'downloads', 'cache', '$recycle.bin']
 
+/**
+ * How much of the file scan a trusted location may suppress.
+ *
+ * `full` is reserved for install roots that need elevation to write to, so a
+ * trusted path there implies the vendor really did install it. Locations a
+ * normal user process can write — `%LocalAppData%`, `node_modules` — only reach
+ * `heuristics`: they skip the PE/LNK scoring that false-positives on packed
+ * binaries (#156, #231), but signature matching still runs, so dropping a
+ * payload beside a per-user install does not buy an attacker a YARA bypass.
+ */
+type PublisherTrust = 'none' | 'heuristics' | 'full'
+
 function normalizeForTrust(p: string): string {
   return p.toLowerCase().replace(/\\/g, '/').replace(/\/{2,}/g, '/').replace(/\/$/, '')
 }
 
 // Resolved once — this runs for every discovered file during a scan.
-let _trustedInstallRoots: string[] | null = null
-function getTrustedInstallRoots(): string[] {
-  if (!_trustedInstallRoots) {
-    _trustedInstallRoots = getPlatform().paths.malwareTrustedInstallRoots()
-      .map(normalizeForTrust)
-      .sort((a, b) => b.length - a.length)
+let _trustedRoots: { root: string; trust: PublisherTrust }[] | null = null
+function getTrustedRoots(): { root: string; trust: PublisherTrust }[] {
+  if (!_trustedRoots) {
+    const paths = getPlatform().paths
+    _trustedRoots = [
+      ...paths.malwareTrustedInstallRoots().map(r => ({ root: normalizeForTrust(r), trust: 'full' as const })),
+      ...paths.malwareTrustedUserInstallRoots().map(r => ({ root: normalizeForTrust(r), trust: 'heuristics' as const })),
+    ]
+      // Longest first so the most specific root wins — otherwise a nested root
+      // such as `LocalAppData\Programs` would also expose `Programs` itself as a
+      // candidate publisher component.
+      .sort((a, b) => b.root.length - a.root.length)
   }
-  return _trustedInstallRoots
+  return _trustedRoots
+}
+
+/**
+ * Trust granted to a file path. A vendor name only counts as a whole directory
+ * component beneath a known installation root; requiring both is what keeps
+ * `Downloads\google\malware.exe` untrusted.
+ *
+ * Takes a plain path — call publisherTrustForCommand for registry/task values.
+ */
+function publisherTrust(filePath: string): PublisherTrust {
+  const normalized = normalizeForTrust(filePath)
+  const dirs = normalized.split('/').slice(0, -1)
+  // Checked before anything else, so a scratch directory can't be dressed up as
+  // either a vendor install or a dependency tree.
+  if (dirs.some(d => NEVER_TRUSTED_DIRS.includes(d))) return 'none'
+  if (dirs.some(d => TRUSTED_ANYWHERE_DIRS.includes(d))) return 'heuristics'
+
+  const match = getTrustedRoots().find(({ root }) => normalized.startsWith(root + '/'))
+  if (!match) return 'none'
+
+  const hasVendorDir = normalized
+    .slice(match.root.length + 1)
+    .split('/')
+    .slice(0, -1)
+    .some(d => TRUSTED_PATHS.includes(d))
+  return hasVendorDir ? match.trust : 'none'
 }
 
 // Registry Run values and scheduled-task commands hold `"C:\...\app.exe" --flag`
@@ -160,29 +204,8 @@ function toExecutablePath(command: string): string {
   return bare.replace(/%([^%]+)%/g, (whole, name: string) => process.env[name] ?? whole)
 }
 
-/**
- * True when the file sits beneath a known installation root and a trusted
- * publisher name appears as a whole directory component below that root.
- * Requiring both is what keeps `Downloads\google\malware.exe` untrusted.
- */
-function isTrustedPublisherPath(filePath: string): boolean {
-  const normalized = normalizeForTrust(toExecutablePath(filePath))
-  const dirs = normalized.split('/').slice(0, -1)
-  // Checked before anything else, so a scratch directory can't be dressed up as
-  // either a vendor install or a dependency tree.
-  if (dirs.some(d => NEVER_TRUSTED_DIRS.includes(d))) return false
-  if (dirs.some(d => TRUSTED_ANYWHERE_DIRS.includes(d))) return true
-
-  // Roots are pre-sorted longest-first so the most specific one wins — otherwise
-  // `LocalAppData\Programs` would also expose `Programs` as a publisher component.
-  const root = getTrustedInstallRoots().find(r => normalized.startsWith(r + '/'))
-  if (!root) return false
-
-  return normalized
-    .slice(root.length + 1)
-    .split('/')
-    .slice(0, -1)
-    .some(d => TRUSTED_PATHS.includes(d))
+function isTrustedPublisherCommand(command: string): boolean {
+  return publisherTrust(toExecutablePath(command)) !== 'none'
 }
 
 // ─── YARA engine (lazy-initialized singleton) ────────────────
@@ -804,7 +827,7 @@ async function scanRegistryPersistence(): Promise<RegistryPersistenceResult[]> {
         const valueLower = value.toLowerCase()
 
         // Skip known-safe publishers
-        if (isTrustedPublisherPath(value)) continue
+        if (isTrustedPublisherCommand(value)) continue
 
         // Flag entries pointing to temp directories
         const tempIndicators = ['\\temp\\', '\\tmp\\', '%temp%', '%tmp%', '\\appdata\\local\\temp\\']
@@ -903,7 +926,7 @@ async function analyzeTaskFile(filePath: string, taskName: string, results: Sche
     const fullCmd = command + ' ' + args
 
     // Skip trusted paths
-    if (isTrustedPublisherPath(command)) return
+    if (isTrustedPublisherCommand(command)) return
 
     // Flag tasks executing from temp directories
     const tempPaths = ['\\temp\\', '\\tmp\\', '%temp%', '%tmp%', '\\appdata\\local\\temp\\']
@@ -1459,9 +1482,10 @@ export async function scanMalware(
 
       // Installed vendor software — suppress the content scans that false-positive
       // on packed Chromium binaries (Helium's chrome.exe) and vendor updaters (#231).
-      // The filename and double-extension checks below still run, so a payload
-      // dropped into a vendor directory can't evade every detector at once.
-      const isTrusted = isTrustedPublisherPath(filePath)
+      // The filename and double-extension checks below always run, and per-user
+      // install dirs only reach 'heuristics', so a payload dropped next to an
+      // app the user installed still faces the signature engine.
+      const trust = publisherTrust(filePath)
 
       // ── Suspicious filename check (always runs, regardless of YARA) ──
       const dirLower = filePath.toLowerCase().replace(/\\/g, '/')
@@ -1488,7 +1512,7 @@ export async function scanMalware(
       }
 
       // ── Signature matching via YARA engine (rules downloaded from cloud) ──
-      if (yaraEngine && !isTrusted && fileSize <= MAX_READ_SIZE && !threats.some(t => t.path === filePath)) {
+      if (yaraEngine && trust !== 'full' && fileSize <= MAX_READ_SIZE && !threats.some(t => t.path === filePath)) {
         const matches = await yaraEngine.scanFileAsync(filePath)
         for (const match of matches) {
           if (threats.some(t => t.path === filePath)) break
@@ -1531,7 +1555,7 @@ export async function scanMalware(
 
       // ── PE + LNK heuristic analysis ──
       // Read file buffer only for PE/LNK analysis (Windows executables and shortcuts)
-      const needsBuffer = !isTrusted && (
+      const needsBuffer = trust === 'none' && (
         (shouldAnalyzePE && (ext === '.exe' || ext === '.dll' || ext === '.scr' || ext === '.sys' || ext === '.drv'))
         || (process.platform === 'win32' && ext === '.lnk'))
       let fileBuffer: Buffer | null = null

--- a/src/main/ipc/malware-scanner.test.ts
+++ b/src/main/ipc/malware-scanner.test.ts
@@ -223,13 +223,47 @@ describe('suspicious filename detection', () => {
 const TRUSTED_PATHS = [
   'zoom', 'microsoft', 'google', 'mozilla', 'adobe', 'oracle',
   'nvidia', 'amd', 'intel', 'steam', 'valve', 'discord', 'slack',
-  'spotify', 'github', 'git', 'node_modules', 'python', 'java',
+  'spotify', 'github', 'git', 'python', 'java',
   '1password', 'bitwarden', 'imput', 'helium', 'logioptionsplus',
 ]
 
+const TRUSTED_ANYWHERE_DIRS = ['node_modules']
+
+const INSTALL_ROOTS = [
+  'C:\\Program Files',
+  'C:\\Program Files (x86)',
+  'C:\\ProgramData',
+  'C:\\Users\\Test\\AppData\\Local\\Programs',
+  'C:\\Users\\Test\\AppData\\Local',
+  'C:\\Users\\Test\\AppData\\Roaming',
+]
+
+function normalizeForTrust(p: string): string {
+  return p.toLowerCase().replace(/\\/g, '/').replace(/\/{2,}/g, '/').replace(/\/$/, '')
+}
+
+function toExecutablePath(command: string): string {
+  const trimmed = command.trim()
+  const quoted = trimmed.startsWith('"') ? trimmed.slice(1).split('"')[0] : null
+  const bare = quoted ?? (trimmed.match(/^(.*?\.(?:exe|com|scr|bat|cmd|ps1|dll))(?:\s|$)/i)?.[1] ?? trimmed.split(/\s+/)[0])
+  return bare
+}
+
 function isTrustedPath(filePath: string): boolean {
-  const lower = filePath.toLowerCase()
-  return TRUSTED_PATHS.some((t) => lower.includes(t))
+  const normalized = normalizeForTrust(toExecutablePath(filePath))
+  const dirs = normalized.split('/').slice(0, -1)
+  if (dirs.some((d) => TRUSTED_ANYWHERE_DIRS.includes(d))) return true
+
+  const root = INSTALL_ROOTS.map(normalizeForTrust)
+    .filter((r) => normalized.startsWith(r + '/'))
+    .sort((a, b) => b.length - a.length)[0]
+  if (!root) return false
+
+  return normalized
+    .slice(root.length + 1)
+    .split('/')
+    .slice(0, -1)
+    .some((d) => TRUSTED_PATHS.includes(d))
 }
 
 describe('trusted path detection', () => {
@@ -251,6 +285,34 @@ describe('trusted path detection', () => {
 
   it('does not trust random paths', () => {
     expect(isTrustedPath('C:\\Users\\Test\\Downloads\\malware.exe')).toBe(false)
+  })
+
+  it('does not trust a filename that merely embeds a vendor name', () => {
+    expect(isTrustedPath('C:\\Users\\Test\\Downloads\\github-payload.exe')).toBe(false)
+  })
+
+  it('does not trust a vendor-named directory outside an installation root', () => {
+    expect(isTrustedPath('C:\\Users\\Test\\Downloads\\google\\malware.exe')).toBe(false)
+  })
+
+  it('does not trust a user profile whose name contains a vendor token', () => {
+    expect(isTrustedPath('C:\\Users\\gitlover\\Downloads\\malware.exe')).toBe(false)
+  })
+
+  it('does not trust a vendor name as a partial directory component', () => {
+    expect(isTrustedPath('C:\\Program Files\\googleish\\malware.exe')).toBe(false)
+  })
+
+  it('does not trust a payload dropped directly in an installation root', () => {
+    expect(isTrustedPath('C:\\ProgramData\\malware.exe')).toBe(false)
+  })
+
+  it('unwraps quoted commands with arguments', () => {
+    expect(isTrustedPath('"C:\\Program Files\\Microsoft\\Teams\\teams.exe" --startup')).toBe(true)
+  })
+
+  it('does not let trailing arguments smuggle in a vendor name', () => {
+    expect(isTrustedPath('C:\\Users\\Test\\Downloads\\dropper.exe /target:google')).toBe(false)
   })
 })
 

--- a/src/main/ipc/malware-scanner.test.ts
+++ b/src/main/ipc/malware-scanner.test.ts
@@ -232,13 +232,17 @@ const TRUSTED_ANYWHERE_DIRS = ['node_modules']
 
 const NEVER_TRUSTED_DIRS = ['temp', 'tmp', 'downloads', 'cache', '$recycle.bin']
 
-const INSTALL_ROOTS = [
-  'C:\\Program Files',
-  'C:\\Program Files (x86)',
-  'C:\\ProgramData',
-  'C:\\Users\\Test\\AppData\\Local\\Programs',
-  'C:\\Users\\Test\\AppData\\Local',
-  'C:\\Users\\Test\\AppData\\Roaming',
+type PublisherTrust = 'none' | 'heuristics' | 'full'
+
+// Roots needing elevation to write to grant full trust; per-user install roots
+// only suppress heuristics.
+const TRUSTED_ROOTS: { root: string; trust: PublisherTrust }[] = [
+  { root: 'C:\\Program Files', trust: 'full' },
+  { root: 'C:\\Program Files (x86)', trust: 'full' },
+  { root: 'C:\\ProgramData', trust: 'full' },
+  { root: 'C:\\Users\\Test\\AppData\\Local\\Programs', trust: 'heuristics' },
+  { root: 'C:\\Users\\Test\\AppData\\Local', trust: 'heuristics' },
+  { root: 'C:\\Users\\Test\\AppData\\Roaming', trust: 'heuristics' },
 ]
 
 function normalizeForTrust(p: string): string {
@@ -248,26 +252,34 @@ function normalizeForTrust(p: string): string {
 function toExecutablePath(command: string): string {
   const trimmed = command.trim()
   const quoted = trimmed.startsWith('"') ? trimmed.slice(1).split('"')[0] : null
-  const bare = quoted ?? (trimmed.match(/^(.*?\.(?:exe|com|scr|bat|cmd|ps1|dll))(?:\s|$)/i)?.[1] ?? trimmed.split(/\s+/)[0])
-  return bare
+  return quoted ?? (trimmed.match(/^(.*?\.(?:exe|com|scr|bat|cmd|ps1|dll))(?:\s|$)/i)?.[1] ?? trimmed.split(/\s+/)[0])
 }
 
-function isTrustedPath(filePath: string): boolean {
-  const normalized = normalizeForTrust(toExecutablePath(filePath))
+function publisherTrust(filePath: string): PublisherTrust {
+  const normalized = normalizeForTrust(filePath)
   const dirs = normalized.split('/').slice(0, -1)
-  if (dirs.some((d) => NEVER_TRUSTED_DIRS.includes(d))) return false
-  if (dirs.some((d) => TRUSTED_ANYWHERE_DIRS.includes(d))) return true
+  if (dirs.some((d) => NEVER_TRUSTED_DIRS.includes(d))) return 'none'
+  if (dirs.some((d) => TRUSTED_ANYWHERE_DIRS.includes(d))) return 'heuristics'
 
-  const root = INSTALL_ROOTS.map(normalizeForTrust)
-    .filter((r) => normalized.startsWith(r + '/'))
-    .sort((a, b) => b.length - a.length)[0]
-  if (!root) return false
+  const match = TRUSTED_ROOTS.map((r) => ({ ...r, root: normalizeForTrust(r.root) }))
+    .sort((a, b) => b.root.length - a.root.length)
+    .find((r) => normalized.startsWith(r.root + '/'))
+  if (!match) return 'none'
 
-  return normalized
-    .slice(root.length + 1)
+  const hasVendorDir = normalized
+    .slice(match.root.length + 1)
     .split('/')
     .slice(0, -1)
     .some((d) => TRUSTED_PATHS.includes(d))
+  return hasVendorDir ? match.trust : 'none'
+}
+
+function isTrustedPath(filePath: string): boolean {
+  return publisherTrust(filePath) !== 'none'
+}
+
+function isTrustedCommand(command: string): boolean {
+  return publisherTrust(toExecutablePath(command)) !== 'none'
 }
 
 describe('trusted path detection', () => {
@@ -311,12 +323,8 @@ describe('trusted path detection', () => {
     expect(isTrustedPath('C:\\ProgramData\\malware.exe')).toBe(false)
   })
 
-  it('unwraps quoted commands with arguments', () => {
-    expect(isTrustedPath('"C:\\Program Files\\Microsoft\\Teams\\teams.exe" --startup')).toBe(true)
-  })
-
-  it('does not let trailing arguments smuggle in a vendor name', () => {
-    expect(isTrustedPath('C:\\Users\\Test\\Downloads\\dropper.exe /target:google')).toBe(false)
+  it('keeps a raw path with spaces intact, whatever its extension', () => {
+    expect(isTrustedPath('C:\\Program Files\\Google\\driver.sys')).toBe(true)
   })
 
   it('does not trust a vendor-named folder in Temp, which sits under an install root', () => {
@@ -330,6 +338,35 @@ describe('trusted path detection', () => {
   it('trusts multi-word vendor directories under an install root', () => {
     expect(isTrustedPath('C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\devenv.exe')).toBe(true)
     expect(isTrustedPath('C:\\Users\\Test\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe')).toBe(true)
+  })
+})
+
+describe('publisher trust level', () => {
+  it('grants full trust under roots that need elevation to write', () => {
+    expect(publisherTrust('C:\\Program Files\\Google\\Chrome\\chrome.exe')).toBe('full')
+  })
+
+  it('grants only heuristic trust to per-user installs', () => {
+    expect(publisherTrust('C:\\Users\\Test\\AppData\\Local\\imput\\Helium\\Application\\chrome.exe'))
+      .toBe('heuristics')
+  })
+
+  it('grants only heuristic trust to node_modules', () => {
+    expect(publisherTrust('/home/user/project/node_modules/esbuild/bin/esbuild')).toBe('heuristics')
+  })
+
+  it('does not let a user-writable vendor directory suppress signature scans', () => {
+    expect(publisherTrust('C:\\Users\\Test\\AppData\\Local\\Google\\payload.exe')).not.toBe('full')
+  })
+})
+
+describe('trusted command detection', () => {
+  it('unwraps quoted commands with arguments', () => {
+    expect(isTrustedCommand('"C:\\Program Files\\Microsoft\\Teams\\teams.exe" --startup')).toBe(true)
+  })
+
+  it('does not let trailing arguments smuggle in a vendor name', () => {
+    expect(isTrustedCommand('C:\\Users\\Test\\Downloads\\dropper.exe /target:google')).toBe(false)
   })
 })
 

--- a/src/main/ipc/malware-scanner.test.ts
+++ b/src/main/ipc/malware-scanner.test.ts
@@ -259,7 +259,7 @@ function publisherTrust(filePath: string): PublisherTrust {
   const normalized = normalizeForTrust(filePath)
   const dirs = normalized.split('/').slice(0, -1)
   if (dirs.some((d) => NEVER_TRUSTED_DIRS.includes(d))) return 'none'
-  if (dirs.some((d) => TRUSTED_ANYWHERE_DIRS.includes(d))) return 'heuristics'
+  if (dirs.slice(0, -1).some((d) => TRUSTED_ANYWHERE_DIRS.includes(d))) return 'heuristics'
 
   const match = TRUSTED_ROOTS.map((r) => ({ ...r, root: normalizeForTrust(r.root) }))
     .sort((a, b) => b.root.length - a.root.length)
@@ -333,6 +333,10 @@ describe('trusted path detection', () => {
 
   it('does not trust a node_modules tree planted in Temp', () => {
     expect(isTrustedPath('C:\\Users\\Test\\AppData\\Local\\Temp\\node_modules\\dropper.exe')).toBe(false)
+  })
+
+  it('does not trust an executable sitting directly in node_modules', () => {
+    expect(isTrustedPath('C:\\Users\\Victim\\Desktop\\node_modules\\payload.exe')).toBe(false)
   })
 
   it('trusts multi-word vendor directories under an install root', () => {

--- a/src/main/ipc/malware-scanner.test.ts
+++ b/src/main/ipc/malware-scanner.test.ts
@@ -224,7 +224,7 @@ const TRUSTED_PATHS = [
   'zoom', 'microsoft', 'google', 'mozilla', 'adobe', 'oracle',
   'nvidia', 'amd', 'intel', 'steam', 'valve', 'discord', 'slack',
   'spotify', 'github', 'git', 'node_modules', 'python', 'java',
-  '1password', 'bitwarden',
+  '1password', 'bitwarden', 'imput', 'helium', 'logioptionsplus',
 ]
 
 function isTrustedPath(filePath: string): boolean {
@@ -239,6 +239,14 @@ describe('trusted path detection', () => {
 
   it('trusts node_modules', () => {
     expect(isTrustedPath('/home/user/project/node_modules/esbuild/bin')).toBe(true)
+  })
+
+  it('trusts Helium browser install paths (#231)', () => {
+    expect(isTrustedPath('C:\\Users\\Test\\AppData\\Local\\imput\\Helium\\Application\\chrome.exe')).toBe(true)
+  })
+
+  it('trusts Logi Options+ updater paths (#231)', () => {
+    expect(isTrustedPath('C:\\Program Files\\LogiOptionsPlus\\logiupdate.exe')).toBe(true)
   })
 
   it('does not trust random paths', () => {

--- a/src/main/ipc/malware-scanner.test.ts
+++ b/src/main/ipc/malware-scanner.test.ts
@@ -225,9 +225,12 @@ const TRUSTED_PATHS = [
   'nvidia', 'amd', 'intel', 'steam', 'valve', 'discord', 'slack',
   'spotify', 'github', 'git', 'python', 'java',
   '1password', 'bitwarden', 'imput', 'helium', 'logioptionsplus',
+  'microsoft visual studio', 'microsoft vs code',
 ]
 
 const TRUSTED_ANYWHERE_DIRS = ['node_modules']
+
+const NEVER_TRUSTED_DIRS = ['temp', 'tmp', 'downloads', 'cache', '$recycle.bin']
 
 const INSTALL_ROOTS = [
   'C:\\Program Files',
@@ -252,6 +255,7 @@ function toExecutablePath(command: string): string {
 function isTrustedPath(filePath: string): boolean {
   const normalized = normalizeForTrust(toExecutablePath(filePath))
   const dirs = normalized.split('/').slice(0, -1)
+  if (dirs.some((d) => NEVER_TRUSTED_DIRS.includes(d))) return false
   if (dirs.some((d) => TRUSTED_ANYWHERE_DIRS.includes(d))) return true
 
   const root = INSTALL_ROOTS.map(normalizeForTrust)
@@ -313,6 +317,19 @@ describe('trusted path detection', () => {
 
   it('does not let trailing arguments smuggle in a vendor name', () => {
     expect(isTrustedPath('C:\\Users\\Test\\Downloads\\dropper.exe /target:google')).toBe(false)
+  })
+
+  it('does not trust a vendor-named folder in Temp, which sits under an install root', () => {
+    expect(isTrustedPath('C:\\Users\\Test\\AppData\\Local\\Temp\\google\\dropper.exe')).toBe(false)
+  })
+
+  it('does not trust a node_modules tree planted in Temp', () => {
+    expect(isTrustedPath('C:\\Users\\Test\\AppData\\Local\\Temp\\node_modules\\dropper.exe')).toBe(false)
+  })
+
+  it('trusts multi-word vendor directories under an install root', () => {
+    expect(isTrustedPath('C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\devenv.exe')).toBe(true)
+    expect(isTrustedPath('C:\\Users\\Test\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe')).toBe(true)
   })
 })
 

--- a/src/main/platform/darwin/paths.ts
+++ b/src/main/platform/darwin/paths.ts
@@ -79,11 +79,16 @@ export function createDarwinPaths(): PlatformPaths {
     malwareTrustedInstallRoots(): string[] {
       return [
         '/Applications',
-        join(HOME, 'Applications'),
         '/Library',
-        LIBRARY,
         '/usr/local',
         '/opt',
+      ]
+    },
+
+    malwareTrustedUserInstallRoots(): string[] {
+      return [
+        join(HOME, 'Applications'),
+        LIBRARY,
       ]
     },
 

--- a/src/main/platform/darwin/paths.ts
+++ b/src/main/platform/darwin/paths.ts
@@ -76,6 +76,17 @@ export function createDarwinPaths(): PlatformPaths {
       ]
     },
 
+    malwareTrustedInstallRoots(): string[] {
+      return [
+        '/Applications',
+        join(HOME, 'Applications'),
+        '/Library',
+        LIBRARY,
+        '/usr/local',
+        '/opt',
+      ]
+    },
+
     uninstallLeftoverDirs(): UninstallLeftoverDir[] {
       return [
         { id: 'app-support', name: 'Application Support', path: APP_SUPPORT },

--- a/src/main/platform/linux/paths.ts
+++ b/src/main/platform/linux/paths.ts
@@ -63,6 +63,17 @@ export function createLinuxPaths(): PlatformPaths {
       return ['/usr', '/lib', '/lib64', '/sbin', '/bin', '/opt']
     },
 
+    malwareTrustedInstallRoots(): string[] {
+      return [
+        '/usr',
+        '/usr/local',
+        '/opt',
+        '/snap',
+        '/var/lib/flatpak',
+        LOCAL_SHARE,
+      ]
+    },
+
     uninstallLeftoverDirs(): UninstallLeftoverDir[] {
       return [
         { id: 'config', name: 'Config', path: CONFIG },

--- a/src/main/platform/linux/paths.ts
+++ b/src/main/platform/linux/paths.ts
@@ -70,8 +70,11 @@ export function createLinuxPaths(): PlatformPaths {
         '/opt',
         '/snap',
         '/var/lib/flatpak',
-        LOCAL_SHARE,
       ]
+    },
+
+    malwareTrustedUserInstallRoots(): string[] {
+      return [LOCAL_SHARE]
     },
 
     uninstallLeftoverDirs(): UninstallLeftoverDir[] {

--- a/src/main/platform/types.ts
+++ b/src/main/platform/types.ts
@@ -150,8 +150,18 @@ export interface PlatformPaths {
   /** System directories to exclude from suspicious filename checks */
   malwareSystemDirs(): string[]
 
-  /** Installation roots beneath which a trusted-publisher directory is honoured */
+  /**
+   * Installation roots that need elevation to write to. A trusted-publisher
+   * directory beneath one of these is taken at face value.
+   */
   malwareTrustedInstallRoots(): string[]
+
+  /**
+   * Installation roots any user process can write to (per-user app installs).
+   * A trusted-publisher directory here only suppresses heuristics, never
+   * signature matching.
+   */
+  malwareTrustedUserInstallRoots(): string[]
 
   /** Directories to scan for uninstall leftovers */
   uninstallLeftoverDirs(): UninstallLeftoverDir[]

--- a/src/main/platform/types.ts
+++ b/src/main/platform/types.ts
@@ -150,6 +150,9 @@ export interface PlatformPaths {
   /** System directories to exclude from suspicious filename checks */
   malwareSystemDirs(): string[]
 
+  /** Installation roots beneath which a trusted-publisher directory is honoured */
+  malwareTrustedInstallRoots(): string[]
+
   /** Directories to scan for uninstall leftovers */
   uninstallLeftoverDirs(): UninstallLeftoverDir[]
 

--- a/src/main/platform/win32/paths.test.ts
+++ b/src/main/platform/win32/paths.test.ts
@@ -277,6 +277,19 @@ describe('win32 paths', () => {
     })
   })
 
+  describe('malwareTrustedInstallRoots', () => {
+    const roots = paths.malwareTrustedInstallRoots()
+
+    it('includes Program Files and the per-user install roots', () => {
+      expect(roots.some((r) => r.includes('Program Files'))).toBe(true)
+      expect(roots.some((r) => r.includes('AppData'))).toBe(true)
+    })
+
+    it('does not include user drop locations like Downloads', () => {
+      expect(roots.some((r) => r.includes('Downloads'))).toBe(false)
+    })
+  })
+
   describe('uninstallLeftoverDirs', () => {
     const dirs = paths.uninstallLeftoverDirs()
 

--- a/src/main/platform/win32/paths.test.ts
+++ b/src/main/platform/win32/paths.test.ts
@@ -280,8 +280,20 @@ describe('win32 paths', () => {
   describe('malwareTrustedInstallRoots', () => {
     const roots = paths.malwareTrustedInstallRoots()
 
-    it('includes Program Files and the per-user install roots', () => {
+    it('includes Program Files', () => {
       expect(roots.some((r) => r.includes('Program Files'))).toBe(true)
+    })
+
+    it('holds only roots that need elevation to write to', () => {
+      expect(roots.some((r) => r.includes('AppData'))).toBe(false)
+      expect(roots.some((r) => r.includes('Downloads'))).toBe(false)
+    })
+  })
+
+  describe('malwareTrustedUserInstallRoots', () => {
+    const roots = paths.malwareTrustedUserInstallRoots()
+
+    it('includes the per-user install locations', () => {
       expect(roots.some((r) => r.includes('AppData'))).toBe(true)
     })
 

--- a/src/main/platform/win32/paths.ts
+++ b/src/main/platform/win32/paths.ts
@@ -72,6 +72,18 @@ export function createWin32Paths(): PlatformPaths {
       ]
     },
 
+    malwareTrustedInstallRoots(): string[] {
+      return [
+        PROGRAMFILES,
+        PROGRAMFILES_X86,
+        PROGRAMDATA,
+        // Per-user installs — Chromium forks and vendor updaters live here
+        join(LOCALAPPDATA, 'Programs'),
+        LOCALAPPDATA,
+        APPDATA,
+      ]
+    },
+
     uninstallLeftoverDirs(): UninstallLeftoverDir[] {
       return [
         { id: 'localappdata', name: 'AppData Local', path: LOCALAPPDATA },

--- a/src/main/platform/win32/paths.ts
+++ b/src/main/platform/win32/paths.ts
@@ -77,7 +77,13 @@ export function createWin32Paths(): PlatformPaths {
         PROGRAMFILES,
         PROGRAMFILES_X86,
         PROGRAMDATA,
-        // Per-user installs — Chromium forks and vendor updaters live here
+      ]
+    },
+
+    malwareTrustedUserInstallRoots(): string[] {
+      // Per-user installs — Chromium forks and vendor updaters live here, but so
+      // can anything the user runs, hence the reduced trust.
+      return [
         join(LOCALAPPDATA, 'Programs'),
         LOCALAPPDATA,
         APPDATA,


### PR DESCRIPTION
## Summary
- Expands malware scanner trusted publisher paths for Helium (imput/helium) and Logi Options+ (logioptionsplus), plus other Chromium forks Kudu already cleans.
- Skips YARA/PE/LNK file scans under trusted install paths to avoid false positives during Full Clean (discussion #231).

## Test plan
- [x] npm run validate:rules
- [x] npm test
- [x] npm run build
- [ ] Manual: run Full Clean on Windows with Helium and Logi Options+ installed; confirm chrome.exe and logiupdate.exe are not quarantined
- [ ] Manual: confirm a file in Downloads is still scanned normally
