### PR TITLE
fix(cleaner): restore bounded estimates and retryable lookup errors

### DIFF
--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -11,7 +11,6 @@ import { CleanerType } from '../shared/enums'
 import type { ScanResult, CleanResult } from '../shared/types'
 import { getPlatform } from './platform'
 import { randomUUID } from 'crypto'
-import { psUtf8 } from './services/exec-utf8'
 import { queryRecycleBinStats } from './services/recycle-bin-stats'
 
 // ─── Types ──────────────────────────────────────────────────

--- a/src/main/ipc/program-uninstaller.ipc.ts
+++ b/src/main/ipc/program-uninstaller.ipc.ts
@@ -86,7 +86,6 @@ export function registerProgramUninstallerIpc(getWindow: WindowGetter): void {
       })
 
       const leftovers = await scanLeftoversForProgram(program)
-      const leftoversSize = leftovers.reduce((sum, item) => sum + item.size, 0)
 
       if (leftovers.length === 0) {
         return {

--- a/src/main/rules/loader.ts
+++ b/src/main/rules/loader.ts
@@ -175,7 +175,6 @@ function resolvePathArray(arr: string[], vars: Record<string, string>, platform:
 
 export function buildCleanerPaths(json: RulesJsonSet, platform: 'win32' | 'darwin' | 'linux'): CleanerPaths {
   const vars = buildVariables(platform)
-  const j = platform === 'win32' ? path.win32.join : path.posix.join
 
   return {
     systemCleanTargets(): CleanTarget[] {

--- a/src/main/services/cleanup-measurement.test.ts
+++ b/src/main/services/cleanup-measurement.test.ts
@@ -24,6 +24,17 @@ describe('cleanup measurements', () => {
     state.items = [item(file, 9000)]
     expect((await cleanItems(['one'])).totalCleaned).toBe(37)
   })
+  it('honors explicit depth limits without truncating default cleanup sizing', async () => {
+    const p = await root()
+    await mkdir(join(p, 'a', 'b'), { recursive: true })
+    await writeFile(join(p, 'top'), Buffer.alloc(10))
+    await writeFile(join(p, 'a', 'middle'), Buffer.alloc(20))
+    await writeFile(join(p, 'a', 'b', 'deep'), Buffer.alloc(30))
+    expect(await getDirectorySize(p, 0)).toBe(0)
+    expect(await getDirectorySize(p, 1)).toBe(10)
+    expect(await getDirectorySize(p, 2)).toBe(30)
+    expect(await getDirectorySize(p)).toBe(60)
+  })
   it('does not double-count overlapping parent and child selections', async () => {
     const p = await root(); const file = join(p, 'data'); await writeFile(file, Buffer.alloc(37))
     state.items = [item(file, 37, 'child'), item(p, 37, 'parent')]

--- a/src/main/services/cleanup-measurement.ts
+++ b/src/main/services/cleanup-measurement.ts
@@ -5,22 +5,35 @@ import { CooperativeScheduler } from './cooperative-scheduler'
 /** Logical file bytes, not allocated/free-volume bytes (compression and links differ). */
 export interface MeasuredEntry { path: string; size: number }
 
-export async function measureCleanupTree(root: string): Promise<MeasuredEntry[]> {
-  const entries: MeasuredEntry[] = []
-  const queue = [root]
+async function* walkCleanupTree(root: string, maxDepth = Infinity): AsyncGenerator<MeasuredEntry> {
+  const queue: Array<{ path: string; depth: number }> = [{ path: root, depth: 0 }]
   const scheduler = new CooperativeScheduler()
   while (queue.length) {
-    const path = queue.pop()!
+    const { path, depth } = queue.pop()!
     try {
       const info = await lstat(path)
-      entries.push({ path, size: info.isFile() ? info.size : 0 })
-      if (info.isDirectory() && !info.isSymbolicLink()) {
-        for (const child of await readdir(path)) queue.push(join(path, child))
+      yield { path, size: info.isFile() ? info.size : 0 }
+      if (info.isDirectory() && !info.isSymbolicLink() && depth < maxDepth) {
+        for (const child of await readdir(path)) queue.push({ path: join(path, child), depth: depth + 1 })
       }
     } catch { /* Unreadable entries never contribute estimated reclaimed bytes. */ }
     await scheduler.yieldIfNeeded()
   }
+}
+
+/** A snapshot is needed only when cleanup must reconcile individual removals. */
+export async function measureCleanupTree(root: string): Promise<MeasuredEntry[]> {
+  const entries: MeasuredEntry[] = []
+  for await (const entry of walkCleanupTree(root)) entries.push(entry)
   return entries
+}
+
+/** Sum without retaining a full path snapshot; callers may bound estimates. */
+export async function cleanupTreeSize(root: string, maxDepth = Infinity): Promise<number> {
+  if (Number.isNaN(maxDepth) || maxDepth <= 0) return 0
+  let size = 0
+  for await (const entry of walkCleanupTree(root, maxDepth)) size += entry.size
+  return size
 }
 
 /** A failed recursive removal can still have removed most of its children. */

--- a/src/main/services/cloud-agent.ts
+++ b/src/main/services/cloud-agent.ts
@@ -6,8 +6,6 @@ import { existsSync, readFileSync, readdirSync, statSync, openSync, readSync, cl
 import { readdir } from 'fs/promises'
 import { randomUUID } from 'crypto'
 import { join } from 'path'
-import { execFile } from 'child_process'
-import { promisify } from 'util'
 import { lookup } from 'dns/promises'
 import PusherImport from 'pusher-js'
 // pusher-js v8.5+ exports the constructor as a named export (`module.exports.Pusher`),
@@ -19,7 +17,6 @@ import { getSettings, setSettings, getMachineId } from './settings-store'
 import { scanAppRule, scanDirectory, scanMultipleDirectories, resolveChildSubdirs, cleanItems } from './file-utils'
 import { cacheItems, clearCachedCategory } from './scan-cache'
 import { BROWSER_CACHE_RECENCY, chromiumBrowsers, chromiumCacheTargets } from './chromium-cache'
-import { psUtf8 } from './exec-utf8'
 import { queryRecycleBinStats } from './recycle-bin-stats'
 import { getPlatform } from '../platform'
 import { CleanerType } from '../../shared/enums'
@@ -28,7 +25,7 @@ import { scanRegistry, fixRegistryEntries } from '../ipc/registry-cleaner.ipc'
 import { scanMalware } from '../ipc/malware-scanner.ipc'
 import { scanPrivacy } from '../ipc/privacy-shield.ipc'
 import { scanServices } from '../ipc/service-manager.ipc'
-import { scanDriverUpdates, installDriverUpdates, scanDrivers, cleanDrivers } from '../ipc/driver-manager.ipc'
+import { scanDriverUpdates, installDriverUpdates, cleanDrivers } from '../ipc/driver-manager.ipc'
 import { scanNetwork } from '../ipc/network-cleanup.ipc'
 import { listStartupItems as listStartupItemsWin32, toggleStartupItem as toggleStartupItemWin32 } from '../ipc/startup-manager.ipc'
 import { applyPrivacySettings } from '../ipc/privacy-shield.ipc'
@@ -56,7 +53,6 @@ import { resetYaraEngine } from '../ipc/malware-scanner.ipc'
 import { threatMonitor } from './threat-monitor'
 import { isLikelyFalsePositive, deduplicateCves } from './cve-filter'
 
-const execFileAsync = promisify(execFile)
 const DEFAULT_SERVER_URL = 'https://cloud.usekudu.com'
 
 /**

--- a/src/main/services/file-utils.clean-log.test.ts
+++ b/src/main/services/file-utils.clean-log.test.ts
@@ -190,7 +190,7 @@ describe('cleanItems deletion logging', () => {
     }
   })
 
-  it('does not expand a directory when logging is off', async () => {
+  it('measures and deletes a directory without recording logs when logging is off', async () => {
     const dir = join(testDir, 'cache')
     mkdirSync(dir, { recursive: true })
     writeFileSync(join(dir, 'top.dat'), 'a', 'utf-8')
@@ -199,7 +199,9 @@ describe('cleanItems deletion logging', () => {
       subcategory: 'App Cache', lastModified: 0, selected: true,
     }]
 
-    await cleanItems(['dir-0'])
+    const result = await cleanItems(['dir-0'])
+    expect(result.totalCleaned).toBe(1)
+    expect(existsSync(dir)).toBe(false)
     expect(state.recorded).toHaveLength(0)
   })
 
@@ -246,7 +248,7 @@ describe('cleanItems deletion logging', () => {
     expect(state.recorded.map((r) => r.path)).toEqual([join(testDir, 'file-0.tmp')])
   })
 
-  it('does not expand a symlinked directory, which rm only unlinks', async () => {
+  it('preserves a scan item replaced by a directory link without logging a deletion', async (ctx) => {
     state.keepDeletionLog = true
     const target = join(testDir, 'real-target')
     mkdirSync(target, { recursive: true })
@@ -255,8 +257,12 @@ describe('cleanItems deletion logging', () => {
     const link = join(testDir, 'link-to-target')
     try {
       symlinkSync(target, link, 'junction')
-    } catch {
-      return // Unprivileged Windows without Developer Mode — nothing to assert.
+    } catch (err: any) {
+      if (process.platform === 'win32' && ['EPERM', 'EACCES'].includes(err.code)) {
+        ctx.skip('Windows does not permit creating the test junction')
+        return
+      }
+      throw err
     }
 
     state.items = [{

--- a/src/main/services/file-utils.delete.test.ts
+++ b/src/main/services/file-utils.delete.test.ts
@@ -9,6 +9,8 @@ const state = vi.hoisted(() => ({
   rootFailuresRemaining: 0,
   lockedPath: '',
   permissionPaths: new Set<string>(),
+  statFailurePath: '',
+  consumed: [] as string[],
   trackConcurrency: false,
   activeDeletes: 0,
   maxActiveDeletes: 0,
@@ -19,6 +21,10 @@ vi.mock('fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs/promises')>()
   return {
     ...actual,
+    lstat: async (...args: Parameters<typeof actual.lstat>) => {
+      if (String(args[0]) === state.statFailurePath) throw Object.assign(new Error('access denied'), { code: 'EACCES' })
+      return actual.lstat(...args)
+    },
     rm: async (...args: Parameters<typeof actual.rm>) => {
       const path = String(args[0])
       const options = args[1] as { recursive?: boolean } | undefined
@@ -51,7 +57,7 @@ vi.mock('./settings-store', () => ({
 
 vi.mock('./scan-cache', () => ({
   getCachedItems: () => state.items,
-  removeCachedItems: () => {},
+  removeCachedItems: (ids: string[]) => { state.consumed.push(...ids) },
 }))
 
 vi.mock('./deletion-log-store', () => ({ recordDeletions: () => {} }))
@@ -85,6 +91,8 @@ describe('granular directory deletion fallback', () => {
     state.rootFailuresRemaining = 0
     state.lockedPath = ''
     state.permissionPaths.clear()
+    state.statFailurePath = ''
+    state.consumed = []
     state.trackConcurrency = false
     state.activeDeletes = 0
     state.maxActiveDeletes = 0
@@ -105,6 +113,21 @@ describe('granular directory deletion fallback', () => {
 
     expect(result).toEqual({ path: root, success: true })
     expect(existsSync(root)).toBe(false)
+  })
+
+  it('reports lookup permission failures without consuming the retryable scan item', async () => {
+    const { removable } = createTree()
+    state.items = [{ id: 'retry', path: removable, size: 5, category: 'system', subcategory: 'Temp', lastModified: 0, selected: true }]
+    state.statFailurePath = removable
+    const progress = vi.fn()
+    const result = await cleanItems(['retry'], progress)
+    expect(result).toMatchObject({ totalCleaned: 0, filesSkipped: 1, needsElevation: true, errors: [{ path: removable, reason: 'permission-denied' }] })
+    expect(state.consumed).toEqual([])
+    expect(existsSync(removable)).toBe(true)
+    expect(progress).toHaveBeenLastCalledWith(1, 1, removable, 0)
+    state.statFailurePath = ''
+    expect((await cleanItems(['retry'])).totalCleaned).toBe(5)
+    expect(state.consumed).toEqual(['retry'])
   })
 
   it('deletes removable siblings and reports only the exact locked descendant', async () => {
@@ -178,7 +201,7 @@ describe('granular directory deletion fallback', () => {
     expect(state.maxActiveDeletes).toBe(8)
   })
 
-  it('unlinks directory junctions without traversing their targets', async () => {
+  it('unlinks directory junctions without traversing their targets', async (ctx) => {
     const { root } = createTree()
     const external = join(testDir, 'keep-external')
     const externalFile = join(external, 'keep.dat')
@@ -186,8 +209,12 @@ describe('granular directory deletion fallback', () => {
     writeFileSync(externalFile, 'keep')
     try {
       symlinkSync(external, join(root, 'external-link'), 'junction')
-    } catch {
-      return // Unprivileged Windows without junction creation support.
+    } catch (err: any) {
+      if (process.platform === 'win32' && ['EPERM', 'EACCES'].includes(err.code)) {
+        ctx.skip('Windows does not permit creating the test junction')
+        return
+      }
+      throw err
     }
     state.rootPath = root
     state.rootFailuresRemaining = process.platform === 'win32' ? 2 : 1

--- a/src/main/services/file-utils.test.ts
+++ b/src/main/services/file-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { deleteFailureReason, isExcluded } from './file-utils'
 
 // Mock settings-store to prevent Electron import

--- a/src/main/services/file-utils.ts
+++ b/src/main/services/file-utils.ts
@@ -9,7 +9,7 @@ import { getCachedItems, removeCachedItems } from './scan-cache'
 import { getSettings } from './settings-store'
 import { recordDeletions } from './deletion-log-store'
 import { CooperativeScheduler } from './cooperative-scheduler'
-import { measureCleanupTree, removedCleanupEntries } from './cleanup-measurement'
+import { cleanupTreeSize, measureCleanupTree, removedCleanupEntries } from './cleanup-measurement'
 
 export interface DeleteResult {
   path: string
@@ -113,7 +113,7 @@ async function deleteDirectoryBestEffort(
   }
 
   const directoryFailure = await attemptDelete(dirPath, () =>
-    rmdir(dirPath, { maxRetries: 3, retryDelay: 100 })
+    rmdir(dirPath)
   )
   // If a child already explains ENOTEMPTY, avoid also blaming every ancestor.
   if (directoryFailure && failures.length === failuresBeforeChildren) {
@@ -353,23 +353,16 @@ export async function cleanItems(
       return
     }
     await scheduler.yieldIfNeeded()
-    // lstat, not stat: it answers both questions the log depends on in one
-    // call — whether the path is still there at all, and whether it is a real
-    // directory rather than a symlink to one. Null means it was already gone
-    // before this clean touched it.
-    let rootInfo: Awaited<ReturnType<typeof lstat>> | null = null
+    // Distinguish vanished entries from lookup failures so permission errors
+    // remain retryable and can correctly request elevation.
+    let rootInfo: Awaited<ReturnType<typeof lstat>>
     try {
       rootInfo = await lstat(item.path)
-    } catch {
-      rootInfo = null
-    }
-
-    // force:true makes rm report success for an already-vanished file. Counting
-    // its scanned size as reclaimed substantially overstates what this run did.
-    if (!rootInfo) {
+    } catch (err: any) {
+      const missing = err.code === 'ENOENT'
       filesSkipped++
-      errors.push({ path: item.path, reason: 'not-found' })
-      consumedIds.push(item.id)
+      errors.push({ path: item.path, reason: missing ? 'not-found' : deleteFailureReason(err) })
+      if (missing) consumedIds.push(item.id)
       if (onProgress) {
         onProgress(filesDeleted + filesSkipped, validIds.length, item.path, totalCleaned)
         lastReport = Date.now()
@@ -404,12 +397,12 @@ export async function cleanItems(
       return
     }
 
-    // A scan item is often a whole directory that rm removes recursively, so
-    // enumerate what's inside before it's gone. Only on success do these get
-    // recorded, so a failed delete never leaves phantom entries behind.
+    // Snapshot current file sizes for full or partial cleanup accounting.
     const measured = await measureCleanupTree(item.path)
     const measuredSize = measured.reduce((sum, entry) => sum + entry.size, 0)
-    const descendantEntries = measured.filter(entry => entry.path !== item.path)
+    const descendantEntries = logDeletions && rootInfo.isDirectory()
+      ? measured.filter(entry => entry.path !== item.path)
+      : []
     const descendants = logDeletions && rootInfo.isDirectory()
       ? { paths: descendantEntries.slice(0, MAX_LOGGED_DESCENDANTS).map(entry => entry.path), truncated: Math.max(0, descendantEntries.length - MAX_LOGGED_DESCENDANTS) }
       : null
@@ -434,11 +427,7 @@ export async function cleanItems(
       totalCleaned += measuredSize
       filesDeleted++
       consumedIds.push(item.id)
-      // rm(force) reports success for a path that was already missing, so a
-      // temp file that vanished between the scan and the clean would otherwise
-      // be logged as something Kudu deleted. Counters keep their existing
-      // behavior; only the audit trail is held to what we actually removed.
-      if (logDeletions && rootInfo) {
+      if (logDeletions) {
         const ts = new Date().toISOString()
         const category = item.subcategory || item.category
         const record: DeletedFileRecord = { ts, path: item.path, size: measuredSize, category, origin }
@@ -484,8 +473,6 @@ export async function cleanItems(
   // Files in independent cache roots can be removed concurrently. The small,
   // fixed worker pool keeps disk pressure bounded while preventing hundreds of
   // locked or protected paths from serializing their retry delays.
-  // Keep duplicate path records on the same worker. Two rules can legitimately
-  // resolve to one cache path, and racing force-deletes would overstate bytes.
   // Serialize ancestor/descendant selections as well as identical paths.
   // Otherwise concurrent recursive deletes can both claim the same bytes.
   const canonical = (path: string): string => {
@@ -559,6 +546,9 @@ export interface ScanRecencyOptions {
   /** Skip entries modified within this many minutes (default 60) */
   skipRecentMinutes?: number
   /**
+   * Legacy compatibility flag. Descendant checks are always enabled, including
+   * when older rule consumers pass false.
+   *
    * Judge a directory by its contents rather than by its own mtime.
    *
    * A directory's mtime moves whenever an entry is added or removed inside it,
@@ -1097,7 +1087,7 @@ export async function resolveRecursivePathMatches(
   return [...resolved]
 }
 
-/** Full logical size without following links; maxDepth is retained for API compatibility. */
-export async function getDirectorySize(dirPath: string, _maxDepth?: number): Promise<number> {
-  return (await measureCleanupTree(dirPath)).reduce((sum, entry) => sum + entry.size, 0)
+/** Full logical size by default; explicit depth limits keep app estimates bounded. */
+export async function getDirectorySize(dirPath: string, maxDepth?: number): Promise<number> {
+  return cleanupTreeSize(dirPath, maxDepth)
 }


### PR DESCRIPTION
Directory-size estimates ignored explicit depth limits after the cleanup accounting merge, causing application estimates to traverse entire installations. Restore those limits while preserving full-depth cleanup measurements, and sum size-only requests without retaining every path.

Cleanup also treated every initial filesystem lookup failure as a missing file and discarded its scan ID. Permission failures now request elevation and remain retryable; only missing entries are consumed.

Remove confirmed unused imports and locals in the cleaner entry points, avoid allocating descendant log entries when logging is disabled, remove unsupported directory-removal retry options, and correct stale comments. Strengthen existing deletion-log assertions and make junction setup failures explicit skips only for Windows permission limits.

Validation:
- `npm test`: 128 files, 2,592 tests passed, including depth-limit and permission-retry regressions.
- `npm run build`: passed.
- CLI smoke tests: 17 passed.
- `npm run validate:rules` and `git diff --check`: passed.
- The broader TypeScript unused-code check still reports pre-existing errors; this change introduces no new diagnostics.
