### PR TITLE
feat(build): ship Windows portable exe alongside NSIS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           version="${{ steps.version.outputs.version }}"
-          gh release download "v$version" --repo AdventDevInc/kudu --pattern "Kudu-Setup-*.exe" --pattern "Kudu-*.dmg" --pattern "Kudu-*.AppImage" --pattern "Kudu-*.deb" --dir artifacts/
+          gh release download "v$version" --repo AdventDevInc/kudu --pattern "Kudu-Setup-*.exe" --pattern "Kudu-Portable-*.exe" --pattern "Kudu-*.dmg" --pattern "Kudu-*.AppImage" --pattern "Kudu-*.deb" --dir artifacts/
 
       - name: Scan with VirusTotal
         env:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Get the latest installer for your platform from [GitHub Releases](https://github
 
 | Platform | Format |
 |----------|--------|
-| Windows | `.exe` installer |
+| Windows | `.exe` installer or portable (`Kudu-Portable-*.exe`) |
 | macOS | `.dmg` (Intel & Apple Silicon) |
 | Linux | `.AppImage` or `.deb` |
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -28,6 +28,9 @@ win:
     - target: nsis
       arch:
         - x64
+    - target: portable
+      arch:
+        - x64
   icon: resources/icon.ico
   requestedExecutionLevel: requireAdministrator
 
@@ -45,6 +48,9 @@ nsis:
   deleteAppDataOnUninstall: false
   shortcutName: Kudu
   artifactName: Kudu-Setup-${version}.${ext}
+
+portable:
+  artifactName: Kudu-Portable-${version}.${ext}
 
 mac:
   target:

--- a/src/main/build-config.test.ts
+++ b/src/main/build-config.test.ts
@@ -54,4 +54,9 @@ describe('electron-builder.yml', () => {
     // elevates when applying an update.
     expect(option('nsis', 'oneClick')).toBe('true')
   })
+
+  it('publishes a Windows portable artifact alongside NSIS', () => {
+    expect(block('win').some((l) => l.includes('target: portable'))).toBe(true)
+    expect(option('portable', 'artifactName')).toBe('Kudu-Portable-${version}.${ext}')
+  })
 })

--- a/src/main/services/auto-updater.ts
+++ b/src/main/services/auto-updater.ts
@@ -45,6 +45,13 @@ export function initAutoUpdater(opts: InitOptions = {}): void {
     return
   }
 
+  // Windows portable builds set PORTABLE_EXECUTABLE_DIR; electron-updater's
+  // Windows path is NSIS-only and would error or try an installer flow.
+  if (process.env.PORTABLE_EXECUTABLE_DIR) {
+    console.log('Auto-updater: skipping on Windows portable build')
+    return
+  }
+
   daemonMode = opts.daemon === true
 
   const settings = getSettings()

--- a/src/main/services/auto-updater.ts
+++ b/src/main/services/auto-updater.ts
@@ -35,20 +35,19 @@ interface InitOptions {
   daemon?: boolean
 }
 
+/** electron-updater only supports AppImage on Linux and NSIS on Windows. */
+function shouldSkipUpdater(): boolean {
+  if (process.platform === 'linux' && !process.env.APPIMAGE) return true
+  // Portable builds set PORTABLE_EXECUTABLE_DIR; NSIS update flow would break.
+  if (process.env.PORTABLE_EXECUTABLE_DIR) return true
+  return false
+}
+
 export function initAutoUpdater(opts: InitOptions = {}): void {
   if (!app.isPackaged) return
 
-  // On Linux, electron-updater only supports AppImage.
-  // Skip if not running as an AppImage to avoid silent failures.
-  if (process.platform === 'linux' && !process.env.APPIMAGE) {
-    console.log('Auto-updater: skipping on Linux (not running as AppImage)')
-    return
-  }
-
-  // Windows portable builds set PORTABLE_EXECUTABLE_DIR; electron-updater's
-  // Windows path is NSIS-only and would error or try an installer flow.
-  if (process.env.PORTABLE_EXECUTABLE_DIR) {
-    console.log('Auto-updater: skipping on Windows portable build')
+  if (shouldSkipUpdater()) {
+    console.log('Auto-updater: skipping (unsupported package format)')
     return
   }
 
@@ -117,22 +116,22 @@ function startPeriodicChecks(intervalHours: number): void {
 
 /** Call when the user changes updateCheckIntervalHours at runtime */
 export function updateCheckInterval(hours: number): void {
-  if (!app.isPackaged) return
+  if (!app.isPackaged || shouldSkipUpdater()) return
   startPeriodicChecks(hours)
 }
 
 export function checkForUpdates(): Promise<void> {
-  if (!app.isPackaged) return Promise.resolve()
+  if (!app.isPackaged || shouldSkipUpdater()) return Promise.resolve()
   return autoUpdater.checkForUpdates().then(() => {})
 }
 
 export function downloadUpdate(): Promise<void> {
-  if (!app.isPackaged) return Promise.resolve()
+  if (!app.isPackaged || shouldSkipUpdater()) return Promise.resolve()
   return autoUpdater.downloadUpdate().then(() => {})
 }
 
 export function installUpdate(): void {
-  if (!app.isPackaged) return
+  if (!app.isPackaged || shouldSkipUpdater()) return
   autoUpdater.quitAndInstall(true, true)
 }
 
@@ -141,7 +140,6 @@ export function getUpdateStatus(): UpdateStatus {
 }
 
 export function setAutoDownload(enabled: boolean): void {
-  if (app.isPackaged) {
-    autoUpdater.autoDownload = enabled
-  }
+  if (!app.isPackaged || shouldSkipUpdater()) return
+  autoUpdater.autoDownload = enabled
 }


### PR DESCRIPTION
## Summary
- Add electron-builder `portable` Windows target (`Kudu-Portable-*.exe`) next to NSIS
- Skip electron-updater when `PORTABLE_EXECUTABLE_DIR` is set (NSIS-only update path)
- Include portable artifact in VirusTotal download patterns; README notes portable option

Closes #369

## Test plan
- [ ] `npx vitest run src/main/build-config.test.ts`
- [ ] `npm run package:win` produces both `Kudu-Setup-*.exe` and `Kudu-Portable-*.exe`
- [ ] Launch portable exe; confirm app starts and updater stays idle (no NSIS update attempt)