### PR TITLE
fix(cloud): clarify signup opens browser and blank-page help

### DIFF
--- a/src/renderer/src/locales/ar/cloud.json
+++ b/src/renderer/src/locales/ar/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "البدء",
   "connectDescription": "أنشئ حسابًا أو الصق مفتاح API لربط هذا الجهاز.",
   "signUpFree": "إنشاء حساب",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "هل لديك حساب بالفعل؟ الصق مفتاح API أدناه.",
   "apiKeyPlaceholder": "الصق مفتاح API",
   "linking": "جارٍ الربط...",

--- a/src/renderer/src/locales/cs/cloud.json
+++ b/src/renderer/src/locales/cs/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "Začínáme",
   "connectDescription": "Vytvořte si účet nebo vložte svůj API klíč a propojte toto zařízení.",
   "signUpFree": "Vytvořit účet",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "Už máte účet? Níže vložte svůj API klíč.",
   "apiKeyPlaceholder": "Vložte svůj API klíč",
   "linking": "Propojování...",

--- a/src/renderer/src/locales/da/cloud.json
+++ b/src/renderer/src/locales/da/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "Kom i gang",
   "connectDescription": "Opret en konto, eller indsæt din API key for at tilknytte denne enhed.",
   "signUpFree": "Opret konto",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "Har du allerede en konto? Indsæt din API key nedenfor.",
   "apiKeyPlaceholder": "Indsæt din API key",
   "linking": "Tilknytter...",

--- a/src/renderer/src/locales/de/cloud.json
+++ b/src/renderer/src/locales/de/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "Erste Schritte",
   "connectDescription": "Erstellen Sie ein Konto oder fügen Sie Ihren API-Schlüssel ein, um dieses Gerät zu verknüpfen.",
   "signUpFree": "Konto erstellen",
+  "signUpOpensBrowser": "Öffnet cloud.usekudu.com in Ihrem Standardbrowser",
+  "signUpBlankPageHelp": "Wenn die Seite leer oder schwarz wirkt, deaktivieren Sie vorübergehend den Webschutz Ihrer Antivirus-Software und versuchen Sie es erneut. Die Registrierung läuft über WorkOS AuthKit im Browser, nicht in der Kudu-App.",
   "alreadyHaveAccount": "Sie haben bereits ein Konto? Fügen Sie unten Ihren API-Schlüssel ein.",
   "apiKeyPlaceholder": "API-Schlüssel einfügen",
   "linking": "Wird verknüpft...",

--- a/src/renderer/src/locales/el/cloud.json
+++ b/src/renderer/src/locales/el/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "Ξεκινήστε",
   "connectDescription": "Δημιουργήστε λογαριασμό ή επικολλήστε το κλειδί API σας για να συνδέσετε αυτή τη συσκευή.",
   "signUpFree": "Δημιουργία λογαριασμού",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "Έχετε ήδη λογαριασμό; Επικολλήστε το κλειδί API σας παρακάτω.",
   "apiKeyPlaceholder": "Επικολλήστε το κλειδί API σας",
   "linking": "Γίνεται σύνδεση...",

--- a/src/renderer/src/locales/en/cloud.json
+++ b/src/renderer/src/locales/en/cloud.json
@@ -7,14 +7,11 @@
   "subscriptionRequiredTitle": "Cloud subscription required",
   "subscriptionRequiredDesc": "This device is linked, but Cloud cannot connect without an active subscription. Choose or renew a plan to restore monitoring and remote features.",
   "subscriptionRequiredAction": "View plans",
-
   "heroTitle": "Supercharge your system security",
   "heroSubtitle": "From $5/month · Cancel anytime",
   "heroDescription": "Link this device to Kudu Cloud for real-time threat monitoring, AI-powered safety analysis, vulnerability scanning, and a single dashboard to manage every device from anywhere. Plans start at just $5/month — cancel anytime, no commitment.",
-
   "localFeaturesTitle": "Unlocked locally on this device",
   "localFeaturesSubtitle": "These features activate directly in your Kudu app once linked",
-
   "featureThreatMonitorTitle": "Threat Monitoring",
   "featureThreatMonitorDesc": "Tracks and alerts you if your computer communicates with ransomware command servers, criminal infrastructure, botnets, or other known-malicious endpoints in real time.",
   "featureVulnerabilityTitle": "Vulnerability Scanner (CVE)",
@@ -25,15 +22,11 @@
   "featureBreachMonitorDesc": "Add the email addresses you care about and Kudu checks them against known data breaches — showing which sites leaked, what data was exposed, and how many accounts were affected. Get alerted the moment your details appear in a new breach, and mark each one reviewed.",
   "featureHealthReportsTitle": "Security Health Reports",
   "featureHealthReportsDesc": "Automated posture checks covering antivirus, firewall, encryption, Windows Update, password policy, and more — sent to the dashboard every 30 minutes.",
-
   "localFeaturesNote": "Features marked Basic or Pro unlock on that plan or higher. Everything else is included on every plan.",
-
   "upgradeCalloutTitle": "Even on one device, Pro unlocks more",
   "upgradeCalloutDesc": "Basic gives you dashboards, alerts, compliance, AI safety analysis, and breach monitoring. Upgrading to Pro adds threat monitoring, vulnerability scanning, and automated remediation — features that protect you locally, not just in the cloud.",
-
   "cloudFeaturesTitle": "Cloud Dashboard",
   "cloudFeaturesSubtitle": "Manage and monitor all your devices from cloud.usekudu.com",
-
   "featureRemoteTitle": "Remote Management",
   "featureRemoteDesc": "Trigger scans, cleaning, software updates, and power control on any linked device from the web dashboard — no physical access needed.",
   "featureTelemetryTitle": "Live Telemetry",
@@ -42,10 +35,8 @@
   "featureComplianceDesc": "Automated security posture analysis covering antivirus, firewall, encryption, updates, and password policy. Build custom compliance rules.",
   "featureAlertsTitle": "Advanced Alerts",
   "featureAlertsDesc": "Configurable notifications for threats, compliance drift, system offline events, and new vulnerabilities. Integrate with email, Slack, and webhooks.",
-
   "plansTitle": "Simple pricing",
   "plansSubtitle": "From $5/month · Cancel anytime, no contract",
-
   "planBasicName": "Basic",
   "planBasicPrice": "$5",
   "planBasicPeriod": "/ device / month",
@@ -56,7 +47,6 @@
   "planBasicFeature5": "API access",
   "planBasicFeature6": "30-day data retention",
   "planPopularBadge": "Popular",
-
   "planProName": "Pro",
   "planProPrice": "$9",
   "planProPeriod": "/ device / month",
@@ -67,17 +57,17 @@
   "planProFeature5": "Advanced alerts & scheduled reports",
   "planProFeature6": "SSO, audit logs & priority support",
   "planProFeature7": "90-day data retention",
-
   "connectTitle": "Get started",
   "connectDescription": "Create an account or paste your API key to link this device.",
   "signUpFree": "Create account",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "Already have an account? Paste your API key below.",
   "apiKeyPlaceholder": "Paste your API key",
   "linking": "Linking...",
   "linkDevice": "Link Device",
   "telemetryDisclaimer": "Only CPU & memory usage, disk space, network stats, uptime, and periodic health reports ({{registryExtra}}updates, privacy, malware). No file paths or personal data.",
   "telemetryRegistryExtra": "registry, drivers, ",
-
   "deviceLinkedToast": "Device linked to cloud dashboard",
   "linkFailedToast": "Failed to link device",
   "linkFailedDefaultDesc": "Check your API key and try again",
@@ -86,7 +76,6 @@
   "unlinkFailedToast": "Failed to unlink device",
   "reconnectFailedToast": "Failed to reconnect",
   "reconnectFailedDesc": "Check your network connection and try again",
-
   "sectionStatus": "Connection",
   "statusLabel": "Status",
   "statusLoading": "Loading...",
@@ -99,7 +88,6 @@
   "lastHealthReportLabel": "Last health report",
   "lastHealthReportDescWindows": "Registry, drivers, updates, privacy, malware",
   "lastHealthReportDescOther": "Updates, privacy, malware",
-
   "sectionMonitoring": "Monitoring & Data Sharing",
   "shareDiskHealthLabel": "Share disk health",
   "shareDiskHealthDesc": "Include disk SMART data in telemetry",
@@ -119,7 +107,6 @@
   "cveLibrarySize": "{{count}} CVEs tracked",
   "cveNoFindings": "No vulnerabilities found",
   "cveNotScanned": "Not scanned yet",
-
   "sectionRemoteControl": "Remote Control",
   "remotePowerLabel": "Remote power control",
   "remotePowerDesc": "Allow cloud to shutdown or restart this device",
@@ -131,7 +118,6 @@
   "remoteInstallsDescOther": "Allow cloud to install software and system updates",
   "remoteConfigLabel": "Remote config changes",
   "remoteConfigDesc": "Allow cloud to toggle startup items, services, and privacy settings",
-
   "sectionAdvanced": "Advanced",
   "telemetryIntervalLabel": "Telemetry interval",
   "telemetryIntervalDesc": "How often system stats are sent",

--- a/src/renderer/src/locales/es/cloud.json
+++ b/src/renderer/src/locales/es/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "Comenzar",
   "connectDescription": "Cree una cuenta o pegue su clave de API para vincular este dispositivo.",
   "signUpFree": "Crear cuenta",
+  "signUpOpensBrowser": "Abre cloud.usekudu.com en tu navegador predeterminado",
+  "signUpBlankPageHelp": "Si la página se ve en blanco o negra, desactiva temporalmente el escudo web de tu antivirus e inténtalo de nuevo. El registro lo aloja WorkOS AuthKit en el navegador, no dentro de la app Kudu.",
   "alreadyHaveAccount": "¿Ya tiene una cuenta? Pegue su clave de API a continuación.",
   "apiKeyPlaceholder": "Pegue su clave de API",
   "linking": "Vinculando...",

--- a/src/renderer/src/locales/fi/cloud.json
+++ b/src/renderer/src/locales/fi/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "Aloita",
   "connectDescription": "Luo tili tai liitä API-avaimesi yhdistääksesi tämän laitteen.",
   "signUpFree": "Luo tili",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "Onko sinulla jo tili? Liitä API-avaimesi alle.",
   "apiKeyPlaceholder": "Liitä API-avaimesi",
   "linking": "Yhdistetään...",

--- a/src/renderer/src/locales/fr/cloud.json
+++ b/src/renderer/src/locales/fr/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "Commencer",
   "connectDescription": "Créez un compte ou collez votre clé API pour lier cet appareil.",
   "signUpFree": "Créer un compte",
+  "signUpOpensBrowser": "Ouvre cloud.usekudu.com dans votre navigateur par défaut",
+  "signUpBlankPageHelp": "Si la page est vide ou noire, désactivez temporairement le bouclier web de votre antivirus et réessayez. L’inscription est hébergée par WorkOS AuthKit dans le navigateur, pas dans l’application Kudu.",
   "alreadyHaveAccount": "Vous avez déjà un compte ? Collez votre clé API ci-dessous.",
   "apiKeyPlaceholder": "Collez votre clé API",
   "linking": "Liaison...",

--- a/src/renderer/src/locales/he/cloud.json
+++ b/src/renderer/src/locales/he/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "התחל",
   "connectDescription": "צור חשבון או הדבק את מפתח ה-API שלך כדי לקשר מכשיר זה.",
   "signUpFree": "צור חשבון",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "כבר יש לך חשבון? הדבק את מפתח ה-API שלך למטה.",
   "apiKeyPlaceholder": "הדבק את מפתח ה-API שלך",
   "linking": "מקשר...",

--- a/src/renderer/src/locales/hi/cloud.json
+++ b/src/renderer/src/locales/hi/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "शुरू करें",
   "connectDescription": "इस डिवाइस को लिंक करने के लिए खाता बनाएं या अपनी API key पेस्ट करें।",
   "signUpFree": "खाता बनाएं",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "क्या आपके पास पहले से खाता है? अपनी API key नीचे पेस्ट करें।",
   "apiKeyPlaceholder": "अपनी API key पेस्ट करें",
   "linking": "लिंक किया जा रहा है...",

--- a/src/renderer/src/locales/hu/cloud.json
+++ b/src/renderer/src/locales/hu/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "Első lépések",
   "connectDescription": "Hozzon létre egy fiókot, vagy illessze be az API-kulcsát az eszköz kapcsolásához.",
   "signUpFree": "Fiók létrehozása",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "Már van fiókja? Illessze be lent az API-kulcsát.",
   "apiKeyPlaceholder": "Illessze be az API-kulcsát",
   "linking": "Kapcsolás...",

--- a/src/renderer/src/locales/id/cloud.json
+++ b/src/renderer/src/locales/id/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "Mulai",
   "connectDescription": "Buat akun atau tempel kunci API Anda untuk menautkan perangkat ini.",
   "signUpFree": "Buat akun",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "Sudah punya akun? Tempel kunci API Anda di bawah.",
   "apiKeyPlaceholder": "Tempel kunci API Anda",
   "linking": "Menautkan...",

--- a/src/renderer/src/locales/it/cloud.json
+++ b/src/renderer/src/locales/it/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "Per iniziare",
   "connectDescription": "Crea un account o incolla la tua chiave API per collegare questo dispositivo.",
   "signUpFree": "Crea account",
+  "signUpOpensBrowser": "Apre cloud.usekudu.com nel browser predefinito",
+  "signUpBlankPageHelp": "Se la pagina è vuota o nera, disattiva temporaneamente lo scudo web dell’antivirus e riprova. La registrazione è ospitata da WorkOS AuthKit nel browser, non dentro l’app Kudu.",
   "alreadyHaveAccount": "Hai già un account? Incolla qui sotto la tua chiave API.",
   "apiKeyPlaceholder": "Incolla la tua chiave API",
   "linking": "Collegamento in corso...",

--- a/src/renderer/src/locales/ja/cloud.json
+++ b/src/renderer/src/locales/ja/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "はじめに",
   "connectDescription": "アカウントを作成するか、API キーを貼り付けてこのデバイスをリンクします。",
   "signUpFree": "アカウントを作成",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "すでにアカウントをお持ちですか？以下に API キーを貼り付けてください。",
   "apiKeyPlaceholder": "API キーを貼り付け",
   "linking": "リンク中...",

--- a/src/renderer/src/locales/ko/cloud.json
+++ b/src/renderer/src/locales/ko/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "시작하기",
   "connectDescription": "계정을 만들거나 API 키를 붙여넣어 이 장치를 연결하세요.",
   "signUpFree": "계정 만들기",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "이미 계정이 있으신가요? 아래에 API 키를 붙여넣으세요.",
   "apiKeyPlaceholder": "API 키 붙여넣기",
   "linking": "연결 중...",

--- a/src/renderer/src/locales/ms/cloud.json
+++ b/src/renderer/src/locales/ms/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "Mulakan",
   "connectDescription": "Cipta akaun atau tampal kunci API anda untuk memautkan peranti ini.",
   "signUpFree": "Cipta akaun",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "Sudah mempunyai akaun? Tampal kunci API anda di bawah.",
   "apiKeyPlaceholder": "Tampal kunci API anda",
   "linking": "Sedang memautkan...",

--- a/src/renderer/src/locales/nl/cloud.json
+++ b/src/renderer/src/locales/nl/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "Aan de slag",
   "connectDescription": "Maak een account aan of plak uw API-sleutel om dit apparaat te koppelen.",
   "signUpFree": "Account aanmaken",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "Hebt u al een account? Plak hieronder uw API-sleutel.",
   "apiKeyPlaceholder": "Plak uw API-sleutel",
   "linking": "Koppelen...",

--- a/src/renderer/src/locales/no/cloud.json
+++ b/src/renderer/src/locales/no/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "Kom i gang",
   "connectDescription": "Opprett en konto eller lim inn API-nøkkelen din for å koble til denne enheten.",
   "signUpFree": "Opprett konto",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "Har du allerede en konto? Lim inn API-nøkkelen din nedenfor.",
   "apiKeyPlaceholder": "Lim inn API-nøkkelen din",
   "linking": "Kobler til...",

--- a/src/renderer/src/locales/pl/cloud.json
+++ b/src/renderer/src/locales/pl/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "Rozpocznij",
   "connectDescription": "Utwórz konto lub wklej swój klucz API, aby połączyć to urządzenie.",
   "signUpFree": "Utwórz konto",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "Masz już konto? Wklej poniżej swój klucz API.",
   "apiKeyPlaceholder": "Wklej swój klucz API",
   "linking": "Łączenie...",

--- a/src/renderer/src/locales/pt/cloud.json
+++ b/src/renderer/src/locales/pt/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "Começar",
   "connectDescription": "Crie uma conta ou cole sua chave de API para vincular este dispositivo.",
   "signUpFree": "Criar conta",
+  "signUpOpensBrowser": "Abre cloud.usekudu.com no seu navegador padrão",
+  "signUpBlankPageHelp": "Se a página ficar em branco ou preta, desative temporariamente o escudo web do antivírus e tente novamente. O cadastro é hospedado pelo WorkOS AuthKit no navegador, não dentro do app Kudu.",
   "alreadyHaveAccount": "Já tem uma conta? Cole sua chave de API abaixo.",
   "apiKeyPlaceholder": "Cole sua chave de API",
   "linking": "Vinculando...",

--- a/src/renderer/src/locales/ro/cloud.json
+++ b/src/renderer/src/locales/ro/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "Începeți",
   "connectDescription": "Creați un cont sau lipiți cheia API pentru a conecta acest dispozitiv.",
   "signUpFree": "Creați cont",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "Aveți deja un cont? Lipiți mai jos cheia API.",
   "apiKeyPlaceholder": "Lipiți cheia API",
   "linking": "Se conectează...",

--- a/src/renderer/src/locales/ru/cloud.json
+++ b/src/renderer/src/locales/ru/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "Начало работы",
   "connectDescription": "Создайте учётную запись или вставьте свой API key, чтобы привязать это устройство.",
   "signUpFree": "Создать учётную запись",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "Уже есть учётная запись? Вставьте свой API key ниже.",
   "apiKeyPlaceholder": "Вставьте свой API key",
   "linking": "Привязка...",

--- a/src/renderer/src/locales/sv/cloud.json
+++ b/src/renderer/src/locales/sv/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "Kom igång",
   "connectDescription": "Skapa ett konto eller klistra in din API-nyckel för att länka den här enheten.",
   "signUpFree": "Skapa konto",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "Har du redan ett konto? Klistra in din API-nyckel nedan.",
   "apiKeyPlaceholder": "Klistra in din API-nyckel",
   "linking": "Länkar...",

--- a/src/renderer/src/locales/th/cloud.json
+++ b/src/renderer/src/locales/th/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "เริ่มต้นใช้งาน",
   "connectDescription": "สร้างบัญชีหรือวาง API key ของคุณเพื่อเชื่อมโยงอุปกรณ์นี้",
   "signUpFree": "สร้างบัญชี",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "มีบัญชีอยู่แล้วใช่หรือไม่ วาง API key ของคุณด้านล่าง",
   "apiKeyPlaceholder": "วาง API key ของคุณ",
   "linking": "กำลังเชื่อมโยง...",

--- a/src/renderer/src/locales/tr/cloud.json
+++ b/src/renderer/src/locales/tr/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "Başlayın",
   "connectDescription": "Bu cihazı bağlamak için bir hesap oluşturun veya API anahtarınızı yapıştırın.",
   "signUpFree": "Hesap oluştur",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "Zaten bir hesabınız var mı? API anahtarınızı aşağıya yapıştırın.",
   "apiKeyPlaceholder": "API anahtarınızı yapıştırın",
   "linking": "Bağlanıyor...",

--- a/src/renderer/src/locales/uk/cloud.json
+++ b/src/renderer/src/locales/uk/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "Початок роботи",
   "connectDescription": "Створіть обліковий запис або вставте свій API key, щоб прив’язати цей пристрій.",
   "signUpFree": "Створити обліковий запис",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "Уже маєте обліковий запис? Вставте свій API key нижче.",
   "apiKeyPlaceholder": "Вставте свій API key",
   "linking": "Прив’язування...",

--- a/src/renderer/src/locales/vi/cloud.json
+++ b/src/renderer/src/locales/vi/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "Bắt đầu",
   "connectDescription": "Tạo tài khoản hoặc dán API key của bạn để liên kết thiết bị này.",
   "signUpFree": "Tạo tài khoản",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "Đã có tài khoản? Hãy dán API key của bạn bên dưới.",
   "apiKeyPlaceholder": "Dán API key của bạn",
   "linking": "Đang liên kết...",

--- a/src/renderer/src/locales/zh-CN/cloud.json
+++ b/src/renderer/src/locales/zh-CN/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "开始使用",
   "connectDescription": "创建账户或粘贴您的 API 密钥以链接此设备。",
   "signUpFree": "创建账户",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "已有账户？请在下方粘贴您的 API 密钥。",
   "apiKeyPlaceholder": "粘贴您的 API 密钥",
   "linking": "正在链接...",

--- a/src/renderer/src/locales/zh-TW/cloud.json
+++ b/src/renderer/src/locales/zh-TW/cloud.json
@@ -60,6 +60,8 @@
   "connectTitle": "開始使用",
   "connectDescription": "建立帳戶或貼上您的 API 金鑰以連結此裝置。",
   "signUpFree": "建立帳戶",
+  "signUpOpensBrowser": "Opens cloud.usekudu.com in your default browser",
+  "signUpBlankPageHelp": "If the page looks blank or black, temporarily disable your antivirus web shield and try again. Account signup is hosted by WorkOS AuthKit in the browser, not inside the Kudu app.",
   "alreadyHaveAccount": "已經有帳戶了嗎？請在下方貼上您的 API 金鑰。",
   "apiKeyPlaceholder": "貼上您的 API 金鑰",
   "linking": "連結中...",

--- a/src/renderer/src/pages/CloudPage.tsx
+++ b/src/renderer/src/pages/CloudPage.tsx
@@ -28,6 +28,7 @@ import type { KuduSettings } from '@shared/types'
 
 const CLOUD_DASHBOARD_URL = 'https://cloud.usekudu.com'
 const CLOUD_BILLING_URL = 'https://cloud.usekudu.com/organisation/billing'
+const CLOUD_SIGNUP_URL = 'https://cloud.usekudu.com'
 
 function isSubscriptionError(error: string | null | undefined): boolean {
   const value = error?.toLowerCase() ?? ''
@@ -202,13 +203,15 @@ export function CloudPage() {
             {t('heroDescription')}
           </p>
           <button
-            onClick={() => window.open('https://cloud.usekudu.com', '_blank')}
+            onClick={() => window.open(CLOUD_SIGNUP_URL, '_blank')}
             className="flex items-center gap-2 rounded-xl px-5 py-2.5 text-[13px] font-medium transition-all"
             style={{ background: 'var(--accent)', color: 'var(--text-on-accent)' }}
           >
             <ExternalLink className="h-3.5 w-3.5" strokeWidth={1.8} />
             {t('signUpFree')}
           </button>
+          <p className="text-[11px] mt-2" style={{ color: 'var(--text-dim)' }}>{t('signUpOpensBrowser')}</p>
+          <p className="text-[11px] mt-1 max-w-xl leading-relaxed" style={{ color: 'var(--text-ghost)' }}>{t('signUpBlankPageHelp')}</p>
         </div>
       </div>
 
@@ -346,15 +349,17 @@ export function CloudPage() {
         <h3 className="text-[15px] font-semibold text-white mb-1">{t('connectTitle')}</h3>
         <p className="text-[12px] mb-5" style={{ color: 'var(--text-muted)' }}>{t('connectDescription')}</p>
 
-        <div className="flex gap-3 mb-4">
+        <div className="flex flex-col gap-1 mb-4">
           <button
-            onClick={() => window.open('https://cloud.usekudu.com', '_blank')}
-            className="flex items-center gap-2 rounded-xl px-5 py-3 text-[13px] font-medium transition-all"
+            onClick={() => window.open(CLOUD_SIGNUP_URL, '_blank')}
+            className="flex w-fit items-center gap-2 rounded-xl px-5 py-3 text-[13px] font-medium transition-all"
             style={{ background: 'var(--accent)', color: 'var(--text-on-accent)' }}
           >
             <ExternalLink className="h-3.5 w-3.5" strokeWidth={1.8} />
             {t('signUpFree')}
           </button>
+          <p className="text-[11px]" style={{ color: 'var(--text-dim)' }}>{t('signUpOpensBrowser')}</p>
+          <p className="text-[11px] max-w-xl leading-relaxed" style={{ color: 'var(--text-ghost)' }}>{t('signUpBlankPageHelp')}</p>
         </div>
 
         <p className="text-[13px] mb-3" style={{ color: 'var(--text-muted)' }}>{t('alreadyHaveAccount')}</p>


### PR DESCRIPTION
## Summary
- Signup already opens `cloud.usekudu.com` in the system browser (WorkOS AuthKit) — not an in-app page
- Add helper copy under Create account: opens in browser + what to try if the page is blank/black (common with AV web shields like F-Secure)

Related to #376 (documents workaround; does not fix AuthKit / AV blocking)
Close #376 
## Test plan
- [ ] Cloud page → Create account opens the default browser
- [ ] Helper text visible under both signup CTAs (EN + FR)
- [x] `npm run build` passes