### PR TITLE
fix(malware): trust Mozilla Firefox folders and vendor install dirs

### DIFF
--- a/src/main/ipc/malware-publisher-trust.ts
+++ b/src/main/ipc/malware-publisher-trust.ts
@@ -1,0 +1,108 @@
+/**
+ * Path-based publisher trust for the malware scanner.
+ *
+ * Vendor directory names only earn trust as a whole path component beneath a
+ * known installation root (see publisherTrust). Matching them as substrings of
+ * the full path would trust anything merely containing a vendor name —
+ * `Downloads\github-payload.exe`, or every file under a user profile named
+ * `git` — and Windows has no native-AV phase, so that would let a chosen name
+ * bypass the file detectors outright.
+ *
+ * Chromium-based browsers and vendor updaters are often packed and import
+ * injection-capable APIs, which trips PE heuristics (see #156, #231).
+ */
+
+export type PublisherTrust = 'none' | 'heuristics' | 'full'
+
+export type TrustedRoot = { root: string; trust: PublisherTrust }
+
+// Trusted publisher directories — skip signature/heuristic scans for known legit
+// software when they appear under an installation root.
+const TRUSTED_PATHS = [
+  'zoom', 'microsoft', 'google', 'mozilla', 'adobe', 'oracle',
+  'nvidia', 'amd', 'intel', 'steam', 'valve', 'epic games',
+  'discord', 'slack', 'spotify', 'dropbox', 'brave', 'opera',
+  'jetbrains', 'microsoft visual studio', 'microsoft vs code', 'vscode',
+  'github', 'git', 'python', 'java',
+  '1password', 'bitwarden', 'lastpass', 'keepass',
+  'obs-studio', 'vlc', 'gimp', 'blender', 'audacity',
+  'logitech', 'logioptionsplus', 'razer', 'corsair', 'steelseries',
+  // Chromium forks Kudu already cleans — Helium ships chrome.exe under imput/
+  'imput', 'helium', 'thorium', 'supermium', 'cromite', 'catsxp',
+  'vivaldi', 'chromium', 'arcsoft', 'librewolf', 'waterfox', 'floorp',
+  // Vendor install dirs that PE heuristics false-positive (#384) — path trust only
+  'mozilla firefox', 'ollama', 'zotero', 'seatools5',
+]
+
+// Dependency trees legitimately hold packed helper binaries but live anywhere on
+// disk, so they are matched as a path component without an installation root.
+// Only ever below a package directory (`node_modules/<pkg>/…`, `node_modules/.bin/…`):
+// nothing real ships an executable directly in `node_modules`, so requiring the
+// extra level costs nothing and denies `Desktop\node_modules\payload.exe`.
+const TRUSTED_ANYWHERE_DIRS = ['node_modules']
+
+// Scratch trees nested inside installation roots (%LOCALAPPDATA%\Temp above all)
+// are the drop locations Kudu scans hardest. Nothing below one is installed
+// software, so a vendor-named folder there — `…\Local\Temp\google\dropper.exe` —
+// must never buy its way out of the content scans.
+const NEVER_TRUSTED_DIRS = ['temp', 'tmp', 'downloads', 'cache', '$recycle.bin']
+
+export function normalizeForTrust(p: string): string {
+  return p.toLowerCase().replace(/\\/g, '/').replace(/\/{2,}/g, '/').replace(/\/$/, '')
+}
+
+/**
+ * Build the sorted root list used by publisherTrust.
+ * `full` is reserved for install roots that need elevation to write to.
+ * Writable roots (per-user installs, ProgramData) only reach `heuristics`.
+ */
+export function buildTrustedRoots(
+  installRoots: string[],
+  userRoots: string[],
+): TrustedRoot[] {
+  return [
+    ...installRoots.map(r => ({ root: normalizeForTrust(r), trust: 'full' as const })),
+    ...userRoots.map(r => ({ root: normalizeForTrust(r), trust: 'heuristics' as const })),
+  ]
+    // Longest first so the most specific root wins — otherwise a nested root
+    // such as `LocalAppData\Programs` would also expose `Programs` itself as a
+    // candidate publisher component.
+    .sort((a, b) => b.root.length - a.root.length)
+}
+
+/**
+ * Trust granted to a file path. A vendor name only counts as a whole directory
+ * component beneath a known installation root; requiring both is what keeps
+ * `Downloads\google\malware.exe` untrusted.
+ *
+ * Takes a plain path — call toExecutablePath first for registry/task values.
+ */
+export function publisherTrust(
+  filePath: string,
+  trustedRoots: readonly TrustedRoot[],
+): PublisherTrust {
+  const normalized = normalizeForTrust(filePath)
+  const dirs = normalized.split('/').slice(0, -1)
+  // Checked before anything else, so a scratch directory can't be dressed up as
+  // either a vendor install or a dependency tree.
+  if (dirs.some(d => NEVER_TRUSTED_DIRS.includes(d))) return 'none'
+  if (dirs.slice(0, -1).some(d => TRUSTED_ANYWHERE_DIRS.includes(d))) return 'heuristics'
+
+  const match = trustedRoots.find(({ root }) => normalized.startsWith(root + '/'))
+  if (!match) return 'none'
+
+  const hasVendorDir = normalized
+    .slice(match.root.length + 1)
+    .split('/')
+    .slice(0, -1)
+    .some((d) => TRUSTED_PATHS.includes(d))
+  return hasVendorDir ? match.trust : 'none'
+}
+
+/** Registry Run / scheduled-task commands → bare executable path. */
+export function toExecutablePath(command: string): string {
+  const trimmed = command.trim()
+  const quoted = trimmed.startsWith('"') ? trimmed.slice(1).split('"')[0] : null
+  const bare = quoted ?? (trimmed.match(/^(.*?\.(?:exe|com|scr|bat|cmd|ps1|dll))(?:\s|$)/i)?.[1] ?? trimmed.split(/\s+/)[0])
+  return bare.replace(/%([^%]+)%/g, (whole, name: string) => process.env[name] ?? whole)
+}

--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -125,7 +125,7 @@ const TRUSTED_PATHS = [
   'imput', 'helium', 'thorium', 'supermium', 'cromite', 'catsxp',
   'vivaldi', 'chromium', 'arcsoft', 'librewolf', 'waterfox', 'floorp',
   // Signed apps that PE heuristics false-positive (#384)
-  'mozilla firefox', 'ollama', 'zotero', 'seagate', 'seatools', 'seatools5',
+  'mozilla firefox', 'ollama', 'zotero', 'seatools5',
 ]
 
 // Dependency trees legitimately hold packed helper binaries but live anywhere on

--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -124,6 +124,8 @@ const TRUSTED_PATHS = [
   // Chromium forks Kudu already cleans — Helium ships chrome.exe under imput/
   'imput', 'helium', 'thorium', 'supermium', 'cromite', 'catsxp',
   'vivaldi', 'chromium', 'arcsoft', 'librewolf', 'waterfox', 'floorp',
+  // Signed apps that PE heuristics false-positive (#384)
+  'ollama', 'zotero', 'seagate', 'seatools', 'seatools5',
 ]
 
 // Dependency trees legitimately hold packed helper binaries but live anywhere on
@@ -138,6 +140,14 @@ const TRUSTED_ANYWHERE_DIRS = ['node_modules']
 // software, so a vendor-named folder there — `…\Local\Temp\google\dropper.exe` —
 // must never buy its way out of the content scans.
 const NEVER_TRUSTED_DIRS = ['temp', 'tmp', 'downloads', 'cache', '$recycle.bin']
+
+/**
+ * Whole path component: exact vendor token, or "Vendor Product Name"
+ * (e.g. `mozilla` matches `mozilla firefox`). Does not match `googleish`.
+ */
+function isTrustedVendorDir(dir: string): boolean {
+  return TRUSTED_PATHS.some((t) => dir === t || dir.startsWith(t + ' '))
+}
 
 /**
  * How much of the file scan a trusted location may suppress.
@@ -194,7 +204,7 @@ function publisherTrust(filePath: string): PublisherTrust {
     .slice(match.root.length + 1)
     .split('/')
     .slice(0, -1)
-    .some(d => TRUSTED_PATHS.includes(d))
+    .some((d) => isTrustedVendorDir(d))
   return hasVendorDir ? match.trust : 'none'
 }
 

--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -124,7 +124,7 @@ const TRUSTED_PATHS = [
   // Chromium forks Kudu already cleans — Helium ships chrome.exe under imput/
   'imput', 'helium', 'thorium', 'supermium', 'cromite', 'catsxp',
   'vivaldi', 'chromium', 'arcsoft', 'librewolf', 'waterfox', 'floorp',
-  // Signed apps that PE heuristics false-positive (#384)
+  // Vendor install dirs that PE heuristics false-positive (#384) — path trust only
   'mozilla firefox', 'ollama', 'zotero', 'seatools5',
 ]
 

--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -125,7 +125,7 @@ const TRUSTED_PATHS = [
   'imput', 'helium', 'thorium', 'supermium', 'cromite', 'catsxp',
   'vivaldi', 'chromium', 'arcsoft', 'librewolf', 'waterfox', 'floorp',
   // Signed apps that PE heuristics false-positive (#384)
-  'ollama', 'zotero', 'seagate', 'seatools', 'seatools5',
+  'mozilla firefox', 'ollama', 'zotero', 'seagate', 'seatools', 'seatools5',
 ]
 
 // Dependency trees legitimately hold packed helper binaries but live anywhere on
@@ -140,14 +140,6 @@ const TRUSTED_ANYWHERE_DIRS = ['node_modules']
 // software, so a vendor-named folder there — `…\Local\Temp\google\dropper.exe` —
 // must never buy its way out of the content scans.
 const NEVER_TRUSTED_DIRS = ['temp', 'tmp', 'downloads', 'cache', '$recycle.bin']
-
-/**
- * Whole path component: exact vendor token, or "Vendor Product Name"
- * (e.g. `mozilla` matches `mozilla firefox`). Does not match `googleish`.
- */
-function isTrustedVendorDir(dir: string): boolean {
-  return TRUSTED_PATHS.some((t) => dir === t || dir.startsWith(t + ' '))
-}
 
 /**
  * How much of the file scan a trusted location may suppress.
@@ -204,7 +196,7 @@ function publisherTrust(filePath: string): PublisherTrust {
     .slice(match.root.length + 1)
     .split('/')
     .slice(0, -1)
-    .some((d) => isTrustedVendorDir(d))
+    .some((d) => TRUSTED_PATHS.includes(d))
   return hasVendorDir ? match.trust : 'none'
 }
 

--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -25,6 +25,13 @@ import { isExcluded } from '../services/file-utils'
 import { createYaraEngine, yaraMatchToThreatFields, type YaraEngine } from '../services/yara-engine'
 import { getAllRulePaths, getCachedRulePaths, getRulesMetadata, startPeriodicRuleChecks, fetchAndCacheRules, RULES_ENDPOINT } from '../services/yara-rules-store'
 import { CooperativeScheduler } from '../services/cooperative-scheduler'
+import {
+  buildTrustedRoots,
+  publisherTrust as matchPublisherTrust,
+  toExecutablePath,
+  type PublisherTrust,
+  type TrustedRoot,
+} from './malware-publisher-trust'
 
 const execFileAsync = promisify(execFile)
 const CLOUD_SERVER_URL = 'https://cloud.usekudu.com'
@@ -103,110 +110,21 @@ function getSystemDirs(): string[] {
   return getPlatform().paths.malwareSystemDirs()
 }
 
-// Trusted publisher directories — skip signature/heuristic scans for known legit
-// software. Chromium-based browsers and vendor updaters are often packed and
-// import injection-capable APIs, which trips PE heuristics (see #156, #231).
-//
-// These names only earn trust as a whole path component *beneath an installation
-// root* (see publisherTrust). Matching them as substrings of the full path
-// would trust anything merely containing a vendor name — `Downloads\github-payload.exe`,
-// or every file under a user profile named `git` — and Windows has no native-AV
-// phase, so that would let a chosen name bypass the file detectors outright.
-const TRUSTED_PATHS = [
-  'zoom', 'microsoft', 'google', 'mozilla', 'adobe', 'oracle',
-  'nvidia', 'amd', 'intel', 'steam', 'valve', 'epic games',
-  'discord', 'slack', 'spotify', 'dropbox', 'brave', 'opera',
-  'jetbrains', 'microsoft visual studio', 'microsoft vs code', 'vscode',
-  'github', 'git', 'python', 'java',
-  '1password', 'bitwarden', 'lastpass', 'keepass',
-  'obs-studio', 'vlc', 'gimp', 'blender', 'audacity',
-  'logitech', 'logioptionsplus', 'razer', 'corsair', 'steelseries',
-  // Chromium forks Kudu already cleans — Helium ships chrome.exe under imput/
-  'imput', 'helium', 'thorium', 'supermium', 'cromite', 'catsxp',
-  'vivaldi', 'chromium', 'arcsoft', 'librewolf', 'waterfox', 'floorp',
-  // Vendor install dirs that PE heuristics false-positive (#384) — path trust only
-  'mozilla firefox', 'ollama', 'zotero', 'seatools5',
-]
-
-// Dependency trees legitimately hold packed helper binaries but live anywhere on
-// disk, so they are matched as a path component without an installation root.
-// Only ever below a package directory (`node_modules/<pkg>/…`, `node_modules/.bin/…`):
-// nothing real ships an executable directly in `node_modules`, so requiring the
-// extra level costs nothing and denies `Desktop\node_modules\payload.exe`.
-const TRUSTED_ANYWHERE_DIRS = ['node_modules']
-
-// Scratch trees nested inside installation roots (%LOCALAPPDATA%\Temp above all)
-// are the drop locations Kudu scans hardest. Nothing below one is installed
-// software, so a vendor-named folder there — `…\Local\Temp\google\dropper.exe` —
-// must never buy its way out of the content scans.
-const NEVER_TRUSTED_DIRS = ['temp', 'tmp', 'downloads', 'cache', '$recycle.bin']
-
-/**
- * How much of the file scan a trusted location may suppress.
- *
- * `full` is reserved for install roots that need elevation to write to, so a
- * trusted path there implies the vendor really did install it. Locations a
- * normal user process can write — `%LocalAppData%`, `node_modules` — only reach
- * `heuristics`: they skip the PE/LNK scoring that false-positives on packed
- * binaries (#156, #231), but signature matching still runs, so dropping a
- * payload beside a per-user install does not buy an attacker a YARA bypass.
- */
-type PublisherTrust = 'none' | 'heuristics' | 'full'
-
-function normalizeForTrust(p: string): string {
-  return p.toLowerCase().replace(/\\/g, '/').replace(/\/{2,}/g, '/').replace(/\/$/, '')
-}
-
 // Resolved once — this runs for every discovered file during a scan.
-let _trustedRoots: { root: string; trust: PublisherTrust }[] | null = null
-function getTrustedRoots(): { root: string; trust: PublisherTrust }[] {
+let _trustedRoots: TrustedRoot[] | null = null
+function getTrustedRoots(): TrustedRoot[] {
   if (!_trustedRoots) {
     const paths = getPlatform().paths
-    _trustedRoots = [
-      ...paths.malwareTrustedInstallRoots().map(r => ({ root: normalizeForTrust(r), trust: 'full' as const })),
-      ...paths.malwareTrustedUserInstallRoots().map(r => ({ root: normalizeForTrust(r), trust: 'heuristics' as const })),
-    ]
-      // Longest first so the most specific root wins — otherwise a nested root
-      // such as `LocalAppData\Programs` would also expose `Programs` itself as a
-      // candidate publisher component.
-      .sort((a, b) => b.root.length - a.root.length)
+    _trustedRoots = buildTrustedRoots(
+      paths.malwareTrustedInstallRoots(),
+      paths.malwareTrustedUserInstallRoots(),
+    )
   }
   return _trustedRoots
 }
 
-/**
- * Trust granted to a file path. A vendor name only counts as a whole directory
- * component beneath a known installation root; requiring both is what keeps
- * `Downloads\google\malware.exe` untrusted.
- *
- * Takes a plain path — call publisherTrustForCommand for registry/task values.
- */
 function publisherTrust(filePath: string): PublisherTrust {
-  const normalized = normalizeForTrust(filePath)
-  const dirs = normalized.split('/').slice(0, -1)
-  // Checked before anything else, so a scratch directory can't be dressed up as
-  // either a vendor install or a dependency tree.
-  if (dirs.some(d => NEVER_TRUSTED_DIRS.includes(d))) return 'none'
-  if (dirs.slice(0, -1).some(d => TRUSTED_ANYWHERE_DIRS.includes(d))) return 'heuristics'
-
-  const match = getTrustedRoots().find(({ root }) => normalized.startsWith(root + '/'))
-  if (!match) return 'none'
-
-  const hasVendorDir = normalized
-    .slice(match.root.length + 1)
-    .split('/')
-    .slice(0, -1)
-    .some((d) => TRUSTED_PATHS.includes(d))
-  return hasVendorDir ? match.trust : 'none'
-}
-
-// Registry Run values and scheduled-task commands hold `"C:\...\app.exe" --flag`
-// and unexpanded %ENV% references; reduce them to a bare path before matching.
-function toExecutablePath(command: string): string {
-  const trimmed = command.trim()
-  const quoted = trimmed.startsWith('"') ? trimmed.slice(1).split('"')[0] : null
-  const bare = quoted ?? (trimmed.match(/^(.*?\.(?:exe|com|scr|bat|cmd|ps1|dll))(?:\s|$)/i)?.[1] ?? trimmed.split(/\s+/)[0])
-  return bare.replace(/%([^%]+)%/g, (whole, name: string) => process.env[name] ?? whole)
+  return matchPublisherTrust(filePath, getTrustedRoots())
 }
 
 function isTrustedPublisherCommand(command: string): boolean {

--- a/src/main/ipc/malware-scanner.test.ts
+++ b/src/main/ipc/malware-scanner.test.ts
@@ -226,7 +226,7 @@ const TRUSTED_PATHS = [
   'spotify', 'github', 'git', 'python', 'java',
   '1password', 'bitwarden', 'imput', 'helium', 'logioptionsplus',
   'microsoft visual studio', 'microsoft vs code',
-  'mozilla firefox', 'ollama', 'zotero', 'seagate', 'seatools', 'seatools5',
+  'mozilla firefox', 'ollama', 'zotero', 'seatools5',
 ]
 
 const TRUSTED_ANYWHERE_DIRS = ['node_modules']

--- a/src/main/ipc/malware-scanner.test.ts
+++ b/src/main/ipc/malware-scanner.test.ts
@@ -235,12 +235,12 @@ const NEVER_TRUSTED_DIRS = ['temp', 'tmp', 'downloads', 'cache', '$recycle.bin']
 
 type PublisherTrust = 'none' | 'heuristics' | 'full'
 
-// Roots needing elevation to write to grant full trust; per-user install roots
+// Roots needing elevation grant full trust; writable roots (incl. ProgramData)
 // only suppress heuristics.
 const TRUSTED_ROOTS: { root: string; trust: PublisherTrust }[] = [
   { root: 'C:\\Program Files', trust: 'full' },
   { root: 'C:\\Program Files (x86)', trust: 'full' },
-  { root: 'C:\\ProgramData', trust: 'full' },
+  { root: 'C:\\ProgramData', trust: 'heuristics' },
   { root: 'C:\\Users\\Test\\AppData\\Local\\Programs', trust: 'heuristics' },
   { root: 'C:\\Users\\Test\\AppData\\Local', trust: 'heuristics' },
   { root: 'C:\\Users\\Test\\AppData\\Roaming', trust: 'heuristics' },
@@ -384,6 +384,11 @@ describe('publisher trust level', () => {
 
   it('does not let a user-writable vendor directory suppress signature scans', () => {
     expect(publisherTrust('C:\\Users\\Test\\AppData\\Local\\Google\\payload.exe')).not.toBe('full')
+  })
+
+  it('does not grant full trust under ProgramData (#385)', () => {
+    expect(publisherTrust('C:\\ProgramData\\Zotero\\payload.exe')).toBe('heuristics')
+    expect(publisherTrust('C:\\ProgramData\\Zotero\\payload.exe')).not.toBe('full')
   })
 })
 

--- a/src/main/ipc/malware-scanner.test.ts
+++ b/src/main/ipc/malware-scanner.test.ts
@@ -226,6 +226,7 @@ const TRUSTED_PATHS = [
   'spotify', 'github', 'git', 'python', 'java',
   '1password', 'bitwarden', 'imput', 'helium', 'logioptionsplus',
   'microsoft visual studio', 'microsoft vs code',
+  'ollama', 'zotero', 'seagate', 'seatools', 'seatools5',
 ]
 
 const TRUSTED_ANYWHERE_DIRS = ['node_modules']
@@ -233,6 +234,10 @@ const TRUSTED_ANYWHERE_DIRS = ['node_modules']
 const NEVER_TRUSTED_DIRS = ['temp', 'tmp', 'downloads', 'cache', '$recycle.bin']
 
 type PublisherTrust = 'none' | 'heuristics' | 'full'
+
+function isTrustedVendorDir(dir: string): boolean {
+  return TRUSTED_PATHS.some((t) => dir === t || dir.startsWith(t + ' '))
+}
 
 // Roots needing elevation to write to grant full trust; per-user install roots
 // only suppress heuristics.
@@ -270,7 +275,7 @@ function publisherTrust(filePath: string): PublisherTrust {
     .slice(match.root.length + 1)
     .split('/')
     .slice(0, -1)
-    .some((d) => TRUSTED_PATHS.includes(d))
+    .some((d) => isTrustedVendorDir(d))
   return hasVendorDir ? match.trust : 'none'
 }
 
@@ -317,6 +322,24 @@ describe('trusted path detection', () => {
 
   it('does not trust a vendor name as a partial directory component', () => {
     expect(isTrustedPath('C:\\Program Files\\googleish\\malware.exe')).toBe(false)
+  })
+
+  it('trusts Mozilla Firefox Program Files folder (#384)', () => {
+    expect(publisherTrust('C:\\Program Files\\Mozilla Firefox\\firefox.exe')).toBe('full')
+  })
+
+  it('trusts Ollama per-user Programs install (#384)', () => {
+    expect(publisherTrust('C:\\Users\\Test\\AppData\\Local\\Programs\\Ollama\\ollama app.exe'))
+      .toBe('heuristics')
+  })
+
+  it('trusts Zotero and SeaTools under Program Files (#384)', () => {
+    expect(publisherTrust('C:\\Program Files\\Zotero\\zotero.exe')).toBe('full')
+    expect(publisherTrust('C:\\Program Files\\SeaTools5\\uninstall.exe')).toBe('full')
+  })
+
+  it('still refuses Downloads even with a trusted vendor folder name (#384)', () => {
+    expect(publisherTrust('C:\\Users\\Test\\Downloads\\Mozilla Firefox\\dropper.exe')).toBe('none')
   })
 
   it('does not trust a payload dropped directly in an installation root', () => {

--- a/src/main/ipc/malware-scanner.test.ts
+++ b/src/main/ipc/malware-scanner.test.ts
@@ -1,10 +1,16 @@
 ﻿import { describe, it, expect } from 'vitest'
+import {
+  buildTrustedRoots,
+  publisherTrust as matchPublisherTrust,
+  toExecutablePath,
+} from './malware-publisher-trust'
 
 // â”€â”€â”€ Test the exported-by-value constants and pure functions â”€â”€â”€â”€â”€
 // The malware-scanner.ipc.ts file doesn't export its helpers directly,
 // so we replicate the pure logic here to test correctness of the algorithms.
 // This avoids importing the Electron-dependent module while still ensuring
 // the core detection logic is correct.
+// Publisher trust uses the production matcher from malware-publisher-trust.ts.
 
 // â”€â”€â”€ calculateEntropy (replica) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
@@ -218,61 +224,22 @@ describe('suspicious filename detection', () => {
   })
 })
 
-// â”€â”€â”€ TRUSTED_PATHS check â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// --- publisher trust (production matcher) ---
+// Fixture roots mirror win32 install vs writable roots; the vendor list and
+// matching rules come from malware-publisher-trust.ts.
 
-const TRUSTED_PATHS = [
-  'zoom', 'microsoft', 'google', 'mozilla', 'adobe', 'oracle',
-  'nvidia', 'amd', 'intel', 'steam', 'valve', 'discord', 'slack',
-  'spotify', 'github', 'git', 'python', 'java',
-  '1password', 'bitwarden', 'imput', 'helium', 'logioptionsplus',
-  'microsoft visual studio', 'microsoft vs code',
-  'mozilla firefox', 'ollama', 'zotero', 'seatools5',
-]
+const TRUSTED_ROOTS = buildTrustedRoots(
+  ['C:\\Program Files', 'C:\\Program Files (x86)'],
+  [
+    'C:\\ProgramData',
+    'C:\\Users\\Test\\AppData\\Local\\Programs',
+    'C:\\Users\\Test\\AppData\\Local',
+    'C:\\Users\\Test\\AppData\\Roaming',
+  ],
+)
 
-const TRUSTED_ANYWHERE_DIRS = ['node_modules']
-
-const NEVER_TRUSTED_DIRS = ['temp', 'tmp', 'downloads', 'cache', '$recycle.bin']
-
-type PublisherTrust = 'none' | 'heuristics' | 'full'
-
-// Roots needing elevation grant full trust; writable roots (incl. ProgramData)
-// only suppress heuristics.
-const TRUSTED_ROOTS: { root: string; trust: PublisherTrust }[] = [
-  { root: 'C:\\Program Files', trust: 'full' },
-  { root: 'C:\\Program Files (x86)', trust: 'full' },
-  { root: 'C:\\ProgramData', trust: 'heuristics' },
-  { root: 'C:\\Users\\Test\\AppData\\Local\\Programs', trust: 'heuristics' },
-  { root: 'C:\\Users\\Test\\AppData\\Local', trust: 'heuristics' },
-  { root: 'C:\\Users\\Test\\AppData\\Roaming', trust: 'heuristics' },
-]
-
-function normalizeForTrust(p: string): string {
-  return p.toLowerCase().replace(/\\/g, '/').replace(/\/{2,}/g, '/').replace(/\/$/, '')
-}
-
-function toExecutablePath(command: string): string {
-  const trimmed = command.trim()
-  const quoted = trimmed.startsWith('"') ? trimmed.slice(1).split('"')[0] : null
-  return quoted ?? (trimmed.match(/^(.*?\.(?:exe|com|scr|bat|cmd|ps1|dll))(?:\s|$)/i)?.[1] ?? trimmed.split(/\s+/)[0])
-}
-
-function publisherTrust(filePath: string): PublisherTrust {
-  const normalized = normalizeForTrust(filePath)
-  const dirs = normalized.split('/').slice(0, -1)
-  if (dirs.some((d) => NEVER_TRUSTED_DIRS.includes(d))) return 'none'
-  if (dirs.slice(0, -1).some((d) => TRUSTED_ANYWHERE_DIRS.includes(d))) return 'heuristics'
-
-  const match = TRUSTED_ROOTS.map((r) => ({ ...r, root: normalizeForTrust(r.root) }))
-    .sort((a, b) => b.root.length - a.root.length)
-    .find((r) => normalized.startsWith(r.root + '/'))
-  if (!match) return 'none'
-
-  const hasVendorDir = normalized
-    .slice(match.root.length + 1)
-    .split('/')
-    .slice(0, -1)
-    .some((d) => TRUSTED_PATHS.includes(d))
-  return hasVendorDir ? match.trust : 'none'
+function publisherTrust(filePath: string) {
+  return matchPublisherTrust(filePath, TRUSTED_ROOTS)
 }
 
 function isTrustedPath(filePath: string): boolean {

--- a/src/main/ipc/malware-scanner.test.ts
+++ b/src/main/ipc/malware-scanner.test.ts
@@ -226,7 +226,7 @@ const TRUSTED_PATHS = [
   'spotify', 'github', 'git', 'python', 'java',
   '1password', 'bitwarden', 'imput', 'helium', 'logioptionsplus',
   'microsoft visual studio', 'microsoft vs code',
-  'ollama', 'zotero', 'seagate', 'seatools', 'seatools5',
+  'mozilla firefox', 'ollama', 'zotero', 'seagate', 'seatools', 'seatools5',
 ]
 
 const TRUSTED_ANYWHERE_DIRS = ['node_modules']
@@ -234,10 +234,6 @@ const TRUSTED_ANYWHERE_DIRS = ['node_modules']
 const NEVER_TRUSTED_DIRS = ['temp', 'tmp', 'downloads', 'cache', '$recycle.bin']
 
 type PublisherTrust = 'none' | 'heuristics' | 'full'
-
-function isTrustedVendorDir(dir: string): boolean {
-  return TRUSTED_PATHS.some((t) => dir === t || dir.startsWith(t + ' '))
-}
 
 // Roots needing elevation to write to grant full trust; per-user install roots
 // only suppress heuristics.
@@ -275,7 +271,7 @@ function publisherTrust(filePath: string): PublisherTrust {
     .slice(match.root.length + 1)
     .split('/')
     .slice(0, -1)
-    .some((d) => isTrustedVendorDir(d))
+    .some((d) => TRUSTED_PATHS.includes(d))
   return hasVendorDir ? match.trust : 'none'
 }
 
@@ -340,6 +336,10 @@ describe('trusted path detection', () => {
 
   it('still refuses Downloads even with a trusted vendor folder name (#384)', () => {
     expect(publisherTrust('C:\\Users\\Test\\Downloads\\Mozilla Firefox\\dropper.exe')).toBe('none')
+  })
+
+  it('does not trust a space-suffix folder that is not an exact vendor entry (#384)', () => {
+    expect(publisherTrust('C:\\Program Files\\git evil\\payload.exe')).toBe('none')
   })
 
   it('does not trust a payload dropped directly in an installation root', () => {

--- a/src/main/platform/types.ts
+++ b/src/main/platform/types.ts
@@ -162,7 +162,7 @@ export interface PlatformPaths {
   malwareTrustedInstallRoots(): string[]
 
   /**
-   * Installation roots any user process can write to (per-user app installs).
+   * Installation roots writable without elevation (per-user installs, ProgramData).
    * A trusted-publisher directory here only suppresses heuristics, never
    * signature matching.
    */

--- a/src/main/platform/win32/paths.test.ts
+++ b/src/main/platform/win32/paths.test.ts
@@ -287,6 +287,7 @@ describe('win32 paths', () => {
     it('holds only roots that need elevation to write to', () => {
       expect(roots.some((r) => r.includes('AppData'))).toBe(false)
       expect(roots.some((r) => r.includes('Downloads'))).toBe(false)
+      expect(roots.some((r) => /ProgramData$/i.test(r))).toBe(false)
     })
   })
 
@@ -295,6 +296,10 @@ describe('win32 paths', () => {
 
     it('includes the per-user install locations', () => {
       expect(roots.some((r) => r.includes('AppData'))).toBe(true)
+    })
+
+    it('includes ProgramData at heuristics trust (#385)', () => {
+      expect(roots.some((r) => /ProgramData$/i.test(r))).toBe(true)
     })
 
     it('does not include user drop locations like Downloads', () => {

--- a/src/main/platform/win32/paths.ts
+++ b/src/main/platform/win32/paths.ts
@@ -73,20 +73,20 @@ export function createWin32Paths(): PlatformPaths {
     },
 
     malwareTrustedInstallRoots(): string[] {
+      // Elevation-required only — ProgramData is often writable by standard users.
       return [
         PROGRAMFILES,
         PROGRAMFILES_X86,
-        PROGRAMDATA,
       ]
     },
 
     malwareTrustedUserInstallRoots(): string[] {
-      // Per-user installs — Chromium forks and vendor updaters live here, but so
-      // can anything the user runs, hence the reduced trust.
+      // Writable without elevation — heuristics only, never skip YARA.
       return [
         join(LOCALAPPDATA, 'Programs'),
         LOCALAPPDATA,
         APPDATA,
+        PROGRAMDATA,
       ]
     },
 


### PR DESCRIPTION
## Summary
- Exact `TRUSTED_PATHS` entries for Mozilla Firefox, Ollama, Zotero, and SeaTools5 (no prefix matching)
- ProgramData vendor dirs get `heuristics` trust only (still run YARA; skip PE heuristics) — not `full`
- Keeps Downloads / googleish refusals intact; regression test for `git evil` and ProgramData

Closes #384

## Test plan
- [x] `npx vitest run src/main/ipc/malware-scanner.test.ts src/main/platform/win32/paths.test.ts`
- [ ] Scan with Firefox/Ollama/Zotero/SeaTools installed → no `Heuristic.Suspicious.PE` for those install paths