### PR TITLE
fix(tray): skip system tray when elevated on Linux

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -655,12 +655,11 @@ app.whenReady().then(() => {
 
 app.on('window-all-closed', () => {
   const settings = getSettings()
-  // Don't quit if minimize-to-tray or any schedule is enabled — unless the tray
-  // was skipped (elevated Linux), in which case staying alive would leave a
-  // headless process with no UI.
+  // Stay alive for schedules even without a tray (elevated Linux skips tray).
+  // Minimize-to-tray alone must not keep a headless process when tray is missing.
   const trayActive = tray != null
-  if (trayActive && (settings.minimizeToTray || settings.schedules.some((s) => s.enabled))) {
-    // Stay alive in tray
+  if ((trayActive && settings.minimizeToTray) || settings.schedules.some((s) => s.enabled)) {
+    // Stay alive for tray and/or background schedules
     return
   }
   if (process.platform !== 'darwin') {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -474,8 +474,9 @@ function createWindow(): void {
   attachRendererDiagnostics(mainWindow)
 
   mainWindow.on('ready-to-show', () => {
-    // If launched at startup with minimize-to-tray, stay hidden
-    if (isStartupLaunch && settings.minimizeToTray) {
+    // If launched at startup with minimize-to-tray, stay hidden — only when a
+    // tray exists to restore the window (elevated Linux skips the tray, #383).
+    if (isStartupLaunch && settings.minimizeToTray && tray) {
       // Don't show — just sit in tray
     } else {
       mainWindow?.show()
@@ -486,7 +487,7 @@ function createWindow(): void {
   mainWindow.on('close', (e) => {
     if (isQuitting) return
     const currentSettings = getSettings()
-    if (currentSettings.minimizeToTray && mainWindow && !mainWindow.isDestroyed()) {
+    if (currentSettings.minimizeToTray && tray && mainWindow && !mainWindow.isDestroyed()) {
       e.preventDefault()
       mainWindow.hide()
     }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -20,6 +20,7 @@ import { shouldDisableGpu, applyGpuFallbackSwitches, registerGpuCrashRecovery } 
 import { runCli } from './cli'
 import { runDaemon } from './daemon'
 import { createWindowsTrayIcon } from './tray-icon'
+import { isAdmin } from './services/elevation'
 
 // ─── Disable hardware acceleration ──────────────────────────
 // Must be called before app.whenReady().  On machines with incompatible
@@ -335,6 +336,9 @@ async function applyAutoLaunch(enabled: boolean): Promise<void> {
 
 function createTray(): void {
   if (tray) return
+  // Elevated Linux GUIs often fall back to XEmbed via xembedsniproxy, which
+  // triggers Plasma Wayland "Remote Control" prompts on every tray click (#383).
+  if (process.platform === 'linux' && isAdmin()) return
 
   tray = new Tray(createTrayIcon())
   tray.setToolTip(t('trayTooltip'))
@@ -650,8 +654,11 @@ app.whenReady().then(() => {
 
 app.on('window-all-closed', () => {
   const settings = getSettings()
-  // Don't quit if minimize-to-tray or any schedule is enabled
-  if (settings.minimizeToTray || settings.schedules.some((s) => s.enabled)) {
+  // Don't quit if minimize-to-tray or any schedule is enabled — unless the tray
+  // was skipped (elevated Linux), in which case staying alive would leave a
+  // headless process with no UI.
+  const trayActive = tray != null
+  if (trayActive && (settings.minimizeToTray || settings.schedules.some((s) => s.enabled))) {
     // Stay alive in tray
     return
   }


### PR DESCRIPTION
﻿## Summary
- When running as root on Linux (pkexec elevated GUI), do not create the system tray
- Avoids Plasma Wayland xembedsniproxy Remote Control / input-device prompts on tray Quit
- Window close no longer leaves a headless process when the tray was skipped

Closes #383

## Test plan
- [ ] CachyOS/Plasma Wayland as normal user: tray Quit still works
- [ ] As Administrator (elevated): no tray; Quit from window; no Remote Control dialog
- [ ] npm run build
