### PR TITLE
fix(privacy): make Linux Privacy Shield settings reversible

### DIFF
--- a/src/main/platform/config-utils.test.ts
+++ b/src/main/platform/config-utils.test.ts
@@ -110,6 +110,13 @@ describe('removeSysctlConfigParam', () => {
   it('returns empty when the only param is removed', () => {
     expect(removeSysctlConfigParam('kernel.sysrq = 0\n', 'kernel.sysrq')).toBe('')
   })
+
+  it('removes tab-separated assignments', () => {
+    const existing = 'kernel.sysrq\t=\t0\nnet.ipv4.ip_forward = 0\n'
+    const result = removeSysctlConfigParam(existing, 'kernel.sysrq')
+    expect(result).not.toMatch(/kernel\.sysrq/)
+    expect(result).toContain('net.ipv4.ip_forward = 0')
+  })
 })
 
 // ─── updateSshdConfig ───────────────────────────────────────

--- a/src/main/platform/config-utils.test.ts
+++ b/src/main/platform/config-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { updateSysctlConfig, updateSshdConfig } from './config-utils'
+import { updateSysctlConfig, updateSshdConfig, removeSysctlConfigParam } from './config-utils'
 
 // ─── updateSysctlConfig ─────────────────────────────────────
 
@@ -91,6 +91,24 @@ describe('updateSysctlConfig', () => {
     const first = updateSysctlConfig('', 'kernel.sysrq', '0', ' = ', header)
     const second = updateSysctlConfig(first, 'kernel.sysrq', '0', ' = ', header)
     expect(second).toBe(first)
+  })
+})
+
+describe('removeSysctlConfigParam', () => {
+  it('removes the matching param line and keeps others', () => {
+    const existing = [
+      '# header',
+      'kernel.sysrq = 0',
+      'net.ipv4.ip_forward = 0',
+      '',
+    ].join('\n')
+    const result = removeSysctlConfigParam(existing, 'kernel.sysrq')
+    expect(result).not.toContain('kernel.sysrq')
+    expect(result).toContain('net.ipv4.ip_forward = 0')
+  })
+
+  it('returns empty when the only param is removed', () => {
+    expect(removeSysctlConfigParam('kernel.sysrq = 0\n', 'kernel.sysrq')).toBe('')
   })
 })
 

--- a/src/main/platform/config-utils.ts
+++ b/src/main/platform/config-utils.ts
@@ -58,10 +58,9 @@ export function updateSysctlConfig(
  * Leaves other params and comments intact.
  */
 export function removeSysctlConfigParam(existing: string, param: string): string {
-  const lines = existing.split('\n').filter((line) => {
-    const trimmed = line.trimStart()
-    return !(trimmed.startsWith(`${param}=`) || trimmed.startsWith(`${param} =`))
-  })
+  const escaped = param.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const assignment = new RegExp(`^\\s*${escaped}\\s*=`)
+  const lines = existing.split('\n').filter((line) => !assignment.test(line))
   while (lines.length > 0 && lines[lines.length - 1].trim() === '') lines.pop()
   if (lines.length === 0) return ''
   return lines.join('\n') + '\n'

--- a/src/main/platform/config-utils.ts
+++ b/src/main/platform/config-utils.ts
@@ -53,6 +53,20 @@ export function updateSysctlConfig(
   return lines.join('\n') + '\n'
 }
 
+/**
+ * Remove every line that sets `param` from a sysctl drop-in file.
+ * Leaves other params and comments intact.
+ */
+export function removeSysctlConfigParam(existing: string, param: string): string {
+  const lines = existing.split('\n').filter((line) => {
+    const trimmed = line.trimStart()
+    return !(trimmed.startsWith(`${param}=`) || trimmed.startsWith(`${param} =`))
+  })
+  while (lines.length > 0 && lines[lines.length - 1].trim() === '') lines.pop()
+  if (lines.length === 0) return ''
+  return lines.join('\n') + '\n'
+}
+
 // ─── SSH config editing ─────────────────────────────────────
 
 /**

--- a/src/main/platform/linux/privacy.test.ts
+++ b/src/main/platform/linux/privacy.test.ts
@@ -161,7 +161,7 @@ describe('linux privacy', () => {
       }
     })
 
-    it('every setting has check and apply functions', () => {
+    it('every setting has check, apply, and revert functions', () => {
       process.env.XDG_CURRENT_DESKTOP = 'GNOME'
       const privacy = createLinuxPrivacy()
       const settings = privacy.getSettings()
@@ -169,6 +169,15 @@ describe('linux privacy', () => {
       for (const s of settings) {
         expect(typeof s.check).toBe('function')
         expect(typeof s.apply).toBe('function')
+        expect(typeof s.revert).toBe('function')
+      }
+    })
+
+    it('every KDE setting has a revert function', () => {
+      process.env.XDG_CURRENT_DESKTOP = 'KDE'
+      const privacy = createLinuxPrivacy()
+      for (const s of privacy.getSettings()) {
+        expect(typeof s.revert).toBe('function')
       }
     })
 

--- a/src/main/platform/linux/privacy.test.ts
+++ b/src/main/platform/linux/privacy.test.ts
@@ -177,17 +177,22 @@ describe('linux privacy', () => {
       }
     })
 
-    it('omits revert when soft would weaken a kernel default', () => {
+    it('omits revert when soft would open an attack path', () => {
       const privacy = createLinuxPrivacy()
       const byId = Object.fromEntries(privacy.getSettings().map((s) => [s.id, s]))
-      // Hardened equals common kernel default — no safe soft ≠ hardened.
       expect(byId['sysctl-aslr']?.revert).toBeUndefined()
       expect(byId['sysctl-tcp-syncookies']?.revert).toBeUndefined()
       expect(byId['sysctl-icmp-broadcast']?.revert).toBeUndefined()
-      // Soft '1' would enable source routing — omit revert.
       expect(byId['sysctl-source-route']?.revert).toBeUndefined()
-      // Soft below hardened still safe — revert present.
+      expect(byId['sysctl-accept-redirects']?.revert).toBeUndefined()
+      expect(byId['sysctl-ipv6-redirects']?.revert).toBeUndefined()
+      expect(byId['sysctl-rp-filter']?.revert).toBeUndefined()
+      expect(byId['sysctl-dmesg-restrict']?.revert).toBeUndefined()
+      expect(byId['sysctl-ptrace-scope']?.revert).toBeUndefined()
+      expect(byId['sysctl-unprivileged-bpf']?.revert).toBeUndefined()
+      // Soft 1 still hides pointers from non-root; audit-only softs stay reversible.
       expect(typeof byId['sysctl-kptr-restrict']?.revert).toBe('function')
+      expect(typeof byId['sysctl-log-martians']?.revert).toBe('function')
       expect(typeof byId['core-dump-disable']?.revert).toBe('function')
     })
 

--- a/src/main/platform/linux/privacy.test.ts
+++ b/src/main/platform/linux/privacy.test.ts
@@ -4,6 +4,7 @@ const mockExecFile = vi.fn()
 const mockReadFile = vi.fn()
 const mockWriteFile = vi.fn()
 const mockMkdir = vi.fn()
+const mockUnlink = vi.fn()
 
 vi.mock('child_process', () => ({
   execFile: (...args: any[]) => mockExecFile(...args),
@@ -15,6 +16,7 @@ vi.mock('fs/promises', () => ({
   readFile: (...args: any[]) => mockReadFile(...args),
   writeFile: (...args: any[]) => mockWriteFile(...args),
   mkdir: (...args: any[]) => mockMkdir(...args),
+  unlink: (...args: any[]) => mockUnlink(...args),
 }))
 
 const { createLinuxPrivacy } = await import('./privacy')
@@ -161,7 +163,7 @@ describe('linux privacy', () => {
       }
     })
 
-    it('every setting has check, apply, and revert functions', () => {
+    it('every setting has check and apply; revert is optional', () => {
       process.env.XDG_CURRENT_DESKTOP = 'GNOME'
       const privacy = createLinuxPrivacy()
       const settings = privacy.getSettings()
@@ -169,14 +171,30 @@ describe('linux privacy', () => {
       for (const s of settings) {
         expect(typeof s.check).toBe('function')
         expect(typeof s.apply).toBe('function')
-        expect(typeof s.revert).toBe('function')
+        if (s.revert !== undefined) {
+          expect(typeof s.revert).toBe('function')
+        }
       }
     })
 
-    it('every KDE setting has a revert function', () => {
+    it('omits revert when soft would weaken a kernel default', () => {
+      const privacy = createLinuxPrivacy()
+      const byId = Object.fromEntries(privacy.getSettings().map((s) => [s.id, s]))
+      // Hardened equals common kernel default — no safe soft ≠ hardened.
+      expect(byId['sysctl-aslr']?.revert).toBeUndefined()
+      expect(byId['sysctl-tcp-syncookies']?.revert).toBeUndefined()
+      expect(byId['sysctl-icmp-broadcast']?.revert).toBeUndefined()
+      // Soft '1' would enable source routing — omit revert.
+      expect(byId['sysctl-source-route']?.revert).toBeUndefined()
+      // Soft below hardened still safe — revert present.
+      expect(typeof byId['sysctl-kptr-restrict']?.revert).toBe('function')
+      expect(typeof byId['core-dump-disable']?.revert).toBe('function')
+    })
+
+    it('every KDE desktop setting has a revert function', () => {
       process.env.XDG_CURRENT_DESKTOP = 'KDE'
       const privacy = createLinuxPrivacy()
-      for (const s of privacy.getSettings()) {
+      for (const s of privacy.getSettings().filter((s) => s.id.startsWith('kde-'))) {
         expect(typeof s.revert).toBe('function')
       }
     })

--- a/src/main/platform/linux/privacy.ts
+++ b/src/main/platform/linux/privacy.ts
@@ -196,7 +196,9 @@ async function sysctlApply(param: string, value: string): Promise<void> {
 }
 
 async function sysctlRevert(param: string, softValue: string): Promise<void> {
+  // Live write may fail (e.g. irreversible bpf=1); still clear the drop-in.
   await execFileAsync('/usr/sbin/sysctl', ['-w', `${param}=${softValue}`], { timeout: 5_000 })
+    .catch(() => {})
   let existing = ''
   try {
     existing = await readFile(SYSCTL_CONF, 'utf8')
@@ -204,6 +206,14 @@ async function sysctlRevert(param: string, softValue: string): Promise<void> {
     return
   }
   const updated = removeSysctlConfigParam(existing, param)
+  const hasAssignment = updated.split('\n').some((line) => {
+    const t = line.trim()
+    return t.length > 0 && !t.startsWith('#') && t.includes('=')
+  })
+  if (!hasAssignment) {
+    await unlink(SYSCTL_CONF).catch(() => {})
+    return
+  }
   await writeFile(SYSCTL_CONF, updated, 'utf8')
 }
 
@@ -244,33 +254,35 @@ function sysctlSetting(
 // ─── Kernel Hardening (sysctl) ──────────────────────────────
 
 const SYSCTL_KERNEL_SETTINGS: PrivacySettingDef[] = [
-  // ASLR default is already 2 on most kernels — no safe soft ≠ hardened.
+  // Omit revert when soft opens an attack path or equals the common distro default.
   sysctlSetting(
     'sysctl-aslr', 'kernel.randomize_va_space', '2', null,
     'Address Space Randomization (ASLR)',
     'Enable full randomization of memory address layout to prevent exploitation',
     'kernel',
   ),
+  // Soft 1 still hides pointers from non-root (≠ hardened 2); soft 0 would expose them.
   sysctlSetting(
-    'sysctl-kptr-restrict', 'kernel.kptr_restrict', '2', '0',
+    'sysctl-kptr-restrict', 'kernel.kptr_restrict', '2', '1',
     'Kernel Pointer Restriction',
     'Hide kernel pointer addresses from all users to prevent information leaks',
     'kernel',
   ),
   sysctlSetting(
-    'sysctl-dmesg-restrict', 'kernel.dmesg_restrict', '1', '0',
+    'sysctl-dmesg-restrict', 'kernel.dmesg_restrict', '1', null,
     'Restrict dmesg Access',
     'Restrict kernel log (dmesg) access to root only',
     'kernel',
   ),
   sysctlSetting(
-    'sysctl-ptrace-scope', 'kernel.yama.ptrace_scope', '1', '0',
+    'sysctl-ptrace-scope', 'kernel.yama.ptrace_scope', '1', null,
     'Ptrace Scope Restriction',
     'Restrict process tracing to parent processes only (requires Yama LSM)',
     'kernel',
   ),
+  // Harden to 2 (reversible); value 1 cannot be cleared until reboot.
   sysctlSetting(
-    'sysctl-unprivileged-bpf', 'kernel.unprivileged_bpf_disabled', '1', '0',
+    'sysctl-unprivileged-bpf', 'kernel.unprivileged_bpf_disabled', '2', null,
     'Disable Unprivileged BPF',
     'Prevent unprivileged users from loading BPF programs',
     'kernel',
@@ -280,7 +292,6 @@ const SYSCTL_KERNEL_SETTINGS: PrivacySettingDef[] = [
 // ─── Network Hardening (sysctl) ─────────────────────────────
 
 const SYSCTL_NETWORK_SETTINGS: PrivacySettingDef[] = [
-  // tcp_syncookies / icmp_echo_ignore_broadcasts default to 1 — no safe soft.
   sysctlSetting(
     'sysctl-tcp-syncookies', 'net.ipv4.tcp_syncookies', '1', null,
     'TCP SYN Cookie Protection',
@@ -294,18 +305,18 @@ const SYSCTL_NETWORK_SETTINGS: PrivacySettingDef[] = [
     'network',
   ),
   sysctlSetting(
-    'sysctl-rp-filter', 'net.ipv4.conf.all.rp_filter', '1', '0',
+    'sysctl-rp-filter', 'net.ipv4.conf.all.rp_filter', '1', null,
     'Reverse Path Filtering',
     'Enable strict source address verification to prevent IP spoofing',
     'network',
   ),
+  // Soft 1 re-enables ICMP redirect MITM — same policy as source-route.
   sysctlSetting(
-    'sysctl-accept-redirects', 'net.ipv4.conf.all.accept_redirects', '0', '1',
+    'sysctl-accept-redirects', 'net.ipv4.conf.all.accept_redirects', '0', null,
     'Reject ICMP Redirects',
     'Reject ICMP redirect messages that could be used to alter routing tables',
     'network',
   ),
-  // Source routing defaults to off — reverting to 1 would open an attack path.
   sysctlSetting(
     'sysctl-source-route', 'net.ipv4.conf.all.accept_source_route', '0', null,
     'Reject Source-Routed Packets',
@@ -319,7 +330,7 @@ const SYSCTL_NETWORK_SETTINGS: PrivacySettingDef[] = [
     'network',
   ),
   sysctlSetting(
-    'sysctl-ipv6-redirects', 'net.ipv6.conf.all.accept_redirects', '0', '1',
+    'sysctl-ipv6-redirects', 'net.ipv6.conf.all.accept_redirects', '0', null,
     'Reject IPv6 ICMP Redirects',
     'Reject IPv6 ICMP redirect messages to prevent routing table manipulation',
     'network',

--- a/src/main/platform/linux/privacy.ts
+++ b/src/main/platform/linux/privacy.ts
@@ -1,7 +1,7 @@
 import { execFile } from 'child_process'
-import { readFile, writeFile, mkdir } from 'fs/promises'
+import { readFile, writeFile, mkdir, unlink } from 'fs/promises'
 import { promisify } from 'util'
-import { updateSshdConfig, updateSysctlConfig } from '../config-utils'
+import { updateSshdConfig, updateSysctlConfig, removeSysctlConfigParam } from '../config-utils'
 import type { PlatformPrivacy, PrivacySettingDef } from '../types'
 
 const execFileAsync = promisify(execFile)
@@ -51,6 +51,9 @@ const LINUX_PRIVACY_SETTINGS: PrivacySettingDef[] = [
     async apply() {
       await gsettingsSet('org.gnome.desktop.privacy', 'send-software-usage-stats', 'false')
     },
+    async revert() {
+      await gsettingsSet('org.gnome.desktop.privacy', 'send-software-usage-stats', 'true')
+    },
   },
   {
     id: 'gnome-recent-files',
@@ -66,6 +69,9 @@ const LINUX_PRIVACY_SETTINGS: PrivacySettingDef[] = [
     },
     async apply() {
       await gsettingsSet('org.gnome.desktop.privacy', 'remember-recent-files', 'false')
+    },
+    async revert() {
+      await gsettingsSet('org.gnome.desktop.privacy', 'remember-recent-files', 'true')
     },
   },
   {
@@ -83,6 +89,9 @@ const LINUX_PRIVACY_SETTINGS: PrivacySettingDef[] = [
     async apply() {
       await gsettingsSet('org.gnome.system.location', 'enabled', 'false')
     },
+    async revert() {
+      await gsettingsSet('org.gnome.system.location', 'enabled', 'true')
+    },
   },
   {
     id: 'gnome-crash-reporting',
@@ -98,6 +107,9 @@ const LINUX_PRIVACY_SETTINGS: PrivacySettingDef[] = [
     },
     async apply() {
       await gsettingsSet('com.ubuntu.update-notifier', 'show-apport-crashes', 'false')
+    },
+    async revert() {
+      await gsettingsSet('com.ubuntu.update-notifier', 'show-apport-crashes', 'true')
     },
   },
   {
@@ -126,6 +138,14 @@ const LINUX_PRIVACY_SETTINGS: PrivacySettingDef[] = [
         '/org/freedesktop/NetworkManager',
         'org.freedesktop.NetworkManager',
         'ConnectivityCheckEnabled', 'b', 'false',
+      ], { timeout: 5_000 })
+    },
+    async revert() {
+      await execFileAsync('/usr/bin/busctl', [
+        'set-property', 'org.freedesktop.NetworkManager',
+        '/org/freedesktop/NetworkManager',
+        'org.freedesktop.NetworkManager',
+        'ConnectivityCheckEnabled', 'b', 'true',
       ], { timeout: 5_000 })
     },
   },
@@ -175,10 +195,23 @@ async function sysctlApply(param: string, value: string): Promise<void> {
   await writeFile(SYSCTL_CONF, updated, 'utf8')
 }
 
+async function sysctlRevert(param: string, softValue: string): Promise<void> {
+  await execFileAsync('/usr/sbin/sysctl', ['-w', `${param}=${softValue}`], { timeout: 5_000 })
+  let existing = ''
+  try {
+    existing = await readFile(SYSCTL_CONF, 'utf8')
+  } catch {
+    return
+  }
+  const updated = removeSysctlConfigParam(existing, param)
+  await writeFile(SYSCTL_CONF, updated, 'utf8')
+}
+
 function sysctlSetting(
   id: string,
   param: string,
   hardenedValue: string,
+  softValue: string,
   label: string,
   description: string,
   category: 'kernel' | 'network',
@@ -197,6 +230,9 @@ function sysctlSetting(
     async apply() {
       await sysctlApply(param, hardenedValue)
     },
+    async revert() {
+      await sysctlRevert(param, softValue)
+    },
   }
 }
 
@@ -204,31 +240,31 @@ function sysctlSetting(
 
 const SYSCTL_KERNEL_SETTINGS: PrivacySettingDef[] = [
   sysctlSetting(
-    'sysctl-aslr', 'kernel.randomize_va_space', '2',
+    'sysctl-aslr', 'kernel.randomize_va_space', '2', '0',
     'Address Space Randomization (ASLR)',
     'Enable full randomization of memory address layout to prevent exploitation',
     'kernel',
   ),
   sysctlSetting(
-    'sysctl-kptr-restrict', 'kernel.kptr_restrict', '2',
+    'sysctl-kptr-restrict', 'kernel.kptr_restrict', '2', '0',
     'Kernel Pointer Restriction',
     'Hide kernel pointer addresses from all users to prevent information leaks',
     'kernel',
   ),
   sysctlSetting(
-    'sysctl-dmesg-restrict', 'kernel.dmesg_restrict', '1',
+    'sysctl-dmesg-restrict', 'kernel.dmesg_restrict', '1', '0',
     'Restrict dmesg Access',
     'Restrict kernel log (dmesg) access to root only',
     'kernel',
   ),
   sysctlSetting(
-    'sysctl-ptrace-scope', 'kernel.yama.ptrace_scope', '1',
+    'sysctl-ptrace-scope', 'kernel.yama.ptrace_scope', '1', '0',
     'Ptrace Scope Restriction',
     'Restrict process tracing to parent processes only (requires Yama LSM)',
     'kernel',
   ),
   sysctlSetting(
-    'sysctl-unprivileged-bpf', 'kernel.unprivileged_bpf_disabled', '1',
+    'sysctl-unprivileged-bpf', 'kernel.unprivileged_bpf_disabled', '1', '0',
     'Disable Unprivileged BPF',
     'Prevent unprivileged users from loading BPF programs',
     'kernel',
@@ -239,43 +275,43 @@ const SYSCTL_KERNEL_SETTINGS: PrivacySettingDef[] = [
 
 const SYSCTL_NETWORK_SETTINGS: PrivacySettingDef[] = [
   sysctlSetting(
-    'sysctl-tcp-syncookies', 'net.ipv4.tcp_syncookies', '1',
+    'sysctl-tcp-syncookies', 'net.ipv4.tcp_syncookies', '1', '0',
     'TCP SYN Cookie Protection',
     'Enable SYN cookies to protect against SYN flood denial-of-service attacks',
     'network',
   ),
   sysctlSetting(
-    'sysctl-icmp-broadcast', 'net.ipv4.icmp_echo_ignore_broadcasts', '1',
+    'sysctl-icmp-broadcast', 'net.ipv4.icmp_echo_ignore_broadcasts', '1', '0',
     'Ignore ICMP Broadcasts',
     'Ignore ICMP echo requests sent to broadcast addresses (Smurf attack defense)',
     'network',
   ),
   sysctlSetting(
-    'sysctl-rp-filter', 'net.ipv4.conf.all.rp_filter', '1',
+    'sysctl-rp-filter', 'net.ipv4.conf.all.rp_filter', '1', '0',
     'Reverse Path Filtering',
     'Enable strict source address verification to prevent IP spoofing',
     'network',
   ),
   sysctlSetting(
-    'sysctl-accept-redirects', 'net.ipv4.conf.all.accept_redirects', '0',
+    'sysctl-accept-redirects', 'net.ipv4.conf.all.accept_redirects', '0', '1',
     'Reject ICMP Redirects',
     'Reject ICMP redirect messages that could be used to alter routing tables',
     'network',
   ),
   sysctlSetting(
-    'sysctl-source-route', 'net.ipv4.conf.all.accept_source_route', '0',
+    'sysctl-source-route', 'net.ipv4.conf.all.accept_source_route', '0', '1',
     'Reject Source-Routed Packets',
     'Reject packets with source routing options that bypass normal routing',
     'network',
   ),
   sysctlSetting(
-    'sysctl-log-martians', 'net.ipv4.conf.all.log_martians', '1',
+    'sysctl-log-martians', 'net.ipv4.conf.all.log_martians', '1', '0',
     'Log Martian Packets',
     'Log packets arriving with impossible source addresses for security auditing',
     'network',
   ),
   sysctlSetting(
-    'sysctl-ipv6-redirects', 'net.ipv6.conf.all.accept_redirects', '0',
+    'sysctl-ipv6-redirects', 'net.ipv6.conf.all.accept_redirects', '0', '1',
     'Reject IPv6 ICMP Redirects',
     'Reject IPv6 ICMP redirect messages to prevent routing table manipulation',
     'network',
@@ -323,6 +359,10 @@ const ACCESS_CONTROL_SETTINGS: PrivacySettingDef[] = [
       await mkdir('/etc/security/limits.d', { recursive: true })
       await writeFile('/etc/security/limits.d/99-kudu.conf', '* hard core 0\n', 'utf8')
     },
+    async revert() {
+      await sysctlRevert('fs.suid_dumpable', '2')
+      await unlink('/etc/security/limits.d/99-kudu.conf').catch(() => {})
+    },
   },
   {
     id: 'ssh-root-login',
@@ -340,6 +380,9 @@ const ACCESS_CONTROL_SETTINGS: PrivacySettingDef[] = [
     async apply() {
       await applySshdDirective('PermitRootLogin', 'no')
     },
+    async revert() {
+      await applySshdDirective('PermitRootLogin', 'prohibit-password')
+    },
   },
   {
     id: 'ssh-password-auth',
@@ -355,6 +398,9 @@ const ACCESS_CONTROL_SETTINGS: PrivacySettingDef[] = [
     },
     async apply() {
       await applySshdDirective('PasswordAuthentication', 'no')
+    },
+    async revert() {
+      await applySshdDirective('PasswordAuthentication', 'yes')
     },
   },
 ]
@@ -375,6 +421,9 @@ const KDE_PRIVACY_SETTINGS: PrivacySettingDef[] = [
     async apply() {
       await kdeConfigWrite('PlasmaUserFeedback', 'Global', 'FeedbackLevel', '0')
     },
+    async revert() {
+      await kdeConfigWrite('PlasmaUserFeedback', 'Global', 'FeedbackLevel', '1')
+    },
   },
   {
     id: 'kde-recent-files',
@@ -390,6 +439,9 @@ const KDE_PRIVACY_SETTINGS: PrivacySettingDef[] = [
     },
     async apply() {
       await kdeConfigWrite('kactivitymanagerdrc', 'Plugins', 'org.kde.ActivityManager.ResourceScoringEnabled', 'false')
+    },
+    async revert() {
+      await kdeConfigWrite('kactivitymanagerdrc', 'Plugins', 'org.kde.ActivityManager.ResourceScoringEnabled', 'true')
     },
   },
   {
@@ -407,6 +459,9 @@ const KDE_PRIVACY_SETTINGS: PrivacySettingDef[] = [
     async apply() {
       await kdeConfigWrite('baloofilerc', 'Basic Settings', 'Indexing-Enabled', 'false')
     },
+    async revert() {
+      await kdeConfigWrite('baloofilerc', 'Basic Settings', 'Indexing-Enabled', 'true')
+    },
   },
   {
     id: 'kde-crash-reporting',
@@ -422,6 +477,9 @@ const KDE_PRIVACY_SETTINGS: PrivacySettingDef[] = [
     },
     async apply() {
       await kdeConfigWrite('drkonqirc', 'General', 'Enabled', 'false')
+    },
+    async revert() {
+      await kdeConfigWrite('drkonqirc', 'General', 'Enabled', 'true')
     },
   },
 ]

--- a/src/main/platform/linux/privacy.ts
+++ b/src/main/platform/linux/privacy.ts
@@ -211,12 +211,12 @@ function sysctlSetting(
   id: string,
   param: string,
   hardenedValue: string,
-  softValue: string,
+  softValue: string | null,
   label: string,
   description: string,
   category: 'kernel' | 'network',
 ): PrivacySettingDef {
-  return {
+  const setting: PrivacySettingDef = {
     id,
     category,
     label,
@@ -230,17 +230,23 @@ function sysctlSetting(
     async apply() {
       await sysctlApply(param, hardenedValue)
     },
-    async revert() {
-      await sysctlRevert(param, softValue)
-    },
   }
+  // Omit revert when soft would be below the kernel default or equal to hardened
+  // (toggle would either weaken security or leave check() stuck on).
+  if (softValue !== null) {
+    setting.revert = async () => {
+      await sysctlRevert(param, softValue)
+    }
+  }
+  return setting
 }
 
 // ─── Kernel Hardening (sysctl) ──────────────────────────────
 
 const SYSCTL_KERNEL_SETTINGS: PrivacySettingDef[] = [
+  // ASLR default is already 2 on most kernels — no safe soft ≠ hardened.
   sysctlSetting(
-    'sysctl-aslr', 'kernel.randomize_va_space', '2', '0',
+    'sysctl-aslr', 'kernel.randomize_va_space', '2', null,
     'Address Space Randomization (ASLR)',
     'Enable full randomization of memory address layout to prevent exploitation',
     'kernel',
@@ -274,14 +280,15 @@ const SYSCTL_KERNEL_SETTINGS: PrivacySettingDef[] = [
 // ─── Network Hardening (sysctl) ─────────────────────────────
 
 const SYSCTL_NETWORK_SETTINGS: PrivacySettingDef[] = [
+  // tcp_syncookies / icmp_echo_ignore_broadcasts default to 1 — no safe soft.
   sysctlSetting(
-    'sysctl-tcp-syncookies', 'net.ipv4.tcp_syncookies', '1', '0',
+    'sysctl-tcp-syncookies', 'net.ipv4.tcp_syncookies', '1', null,
     'TCP SYN Cookie Protection',
     'Enable SYN cookies to protect against SYN flood denial-of-service attacks',
     'network',
   ),
   sysctlSetting(
-    'sysctl-icmp-broadcast', 'net.ipv4.icmp_echo_ignore_broadcasts', '1', '0',
+    'sysctl-icmp-broadcast', 'net.ipv4.icmp_echo_ignore_broadcasts', '1', null,
     'Ignore ICMP Broadcasts',
     'Ignore ICMP echo requests sent to broadcast addresses (Smurf attack defense)',
     'network',
@@ -298,8 +305,9 @@ const SYSCTL_NETWORK_SETTINGS: PrivacySettingDef[] = [
     'Reject ICMP redirect messages that could be used to alter routing tables',
     'network',
   ),
+  // Source routing defaults to off — reverting to 1 would open an attack path.
   sysctlSetting(
-    'sysctl-source-route', 'net.ipv4.conf.all.accept_source_route', '0', '1',
+    'sysctl-source-route', 'net.ipv4.conf.all.accept_source_route', '0', null,
     'Reject Source-Routed Packets',
     'Reject packets with source routing options that bypass normal routing',
     'network',
@@ -360,7 +368,7 @@ const ACCESS_CONTROL_SETTINGS: PrivacySettingDef[] = [
       await writeFile('/etc/security/limits.d/99-kudu.conf', '* hard core 0\n', 'utf8')
     },
     async revert() {
-      await sysctlRevert('fs.suid_dumpable', '2')
+      await sysctlRevert('fs.suid_dumpable', '0')
       await unlink('/etc/security/limits.d/99-kudu.conf').catch(() => {})
     },
   },


### PR DESCRIPTION
﻿## Summary
- Linux Privacy Shield settings previously had apply but no revert, so the UI disabled toggles after enable (`enabled && !reversible`)
- Add `revert` for GNOME, KDE, sysctl, SSH, and core-dump settings so Administrators can turn items back off

Closes #382

## Test plan
- [x] `npx vitest run src/main/platform/linux/privacy.test.ts src/main/platform/config-utils.test.ts`
- [ ] CachyOS as admin: enable Privacy Shield suggestions, then toggle each item off successfully
