### PR TITLE
fix(ipc): omit parent window for Linux folder dialogs

### DIFF
--- a/src/main/ipc/duplicate-finder.ipc.ts
+++ b/src/main/ipc/duplicate-finder.ipc.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, dialog, ipcMain, shell } from 'electron'
+import { BrowserWindow, ipcMain, shell } from 'electron'
 import { readdir, stat, rm } from 'fs/promises'
 import { createReadStream } from 'fs'
 import { createHash } from 'crypto'
@@ -14,6 +14,7 @@ import type {
   DuplicateDeleteResult
 } from '../../shared/types'
 import type { WindowGetter } from './index'
+import { showOpenDialog } from './open-dialog'
 
 let cancelled = false
 
@@ -268,16 +269,12 @@ async function findDuplicates(
 // ── IPC registration ──
 
 export function registerDuplicateFinderIpc(getWindow: WindowGetter): void {
-  // Directory picker — on macOS, avoid passing parent window so the dialog
-  // opens as a standalone panel instead of a sheet (sidebar items like Desktop
-  // are unresponsive in sheet mode).
+  // Directory picker — Linux/macOS omit parent (see open-dialog.ts).
   ipcMain.handle(IPC.DUPLICATES_SELECT_DIR, async () => {
     const win = getWindow()
     if (!win) return null
     const opts: Electron.OpenDialogOptions = { properties: ['openDirectory'] }
-    const result = process.platform === 'darwin'
-      ? await dialog.showOpenDialog(opts)
-      : await dialog.showOpenDialog(win, opts)
+    const result = await showOpenDialog(win, opts)
     if (result.canceled || !result.filePaths.length) return null
     return result.filePaths[0]
   })

--- a/src/main/ipc/empty-folder-cleaner.ipc.ts
+++ b/src/main/ipc/empty-folder-cleaner.ipc.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, dialog, ipcMain, shell } from 'electron'
+import { BrowserWindow, ipcMain, shell } from 'electron'
 import { readdir, rmdir } from 'fs/promises'
 import { join, isAbsolute, basename } from 'path'
 import { IPC } from '../../shared/channels'
@@ -10,6 +10,7 @@ import type {
   EmptyFolderDeleteResult
 } from '../../shared/types'
 import type { WindowGetter } from './index'
+import { showOpenDialog } from './open-dialog'
 
 let cancelled = false
 
@@ -157,16 +158,12 @@ async function findEmptyFolders(
 }
 
 export function registerEmptyFolderCleanerIpc(getWindow: WindowGetter): void {
-  // Directory picker — on macOS, avoid passing parent window so the dialog
-  // opens as a standalone panel instead of a sheet (sidebar items like Desktop
-  // are unresponsive in sheet mode).
+  // Directory picker — Linux/macOS omit parent (see open-dialog.ts).
   ipcMain.handle(IPC.EMPTY_FOLDERS_SELECT_DIR, async () => {
     const win = getWindow()
     if (!win) return null
     const opts: Electron.OpenDialogOptions = { properties: ['openDirectory'] }
-    const result = process.platform === 'darwin'
-      ? await dialog.showOpenDialog(opts)
-      : await dialog.showOpenDialog(win, opts)
+    const result = await showOpenDialog(win, opts)
     if (result.canceled || !result.filePaths.length) return null
     return result.filePaths[0]
   })

--- a/src/main/ipc/file-shredder.ipc.ts
+++ b/src/main/ipc/file-shredder.ipc.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, dialog, ipcMain, shell } from 'electron'
+import { BrowserWindow, ipcMain, shell } from 'electron'
 import { readdir, rmdir, stat, lstat, open, rm } from 'fs/promises'
 import { constants as fsConstants } from 'fs'
 import { join, isAbsolute, basename, resolve, normalize } from 'path'
@@ -10,6 +10,7 @@ import type {
   ShredderResult
 } from '../../shared/types'
 import type { WindowGetter } from './index'
+import { showOpenDialog } from './open-dialog'
 
 let cancelled = false
 
@@ -242,16 +243,12 @@ async function getEntrySize(entryPath: string, depth: number = 0): Promise<numbe
 }
 
 export function registerFileShredderIpc(getWindow: WindowGetter): void {
-  // File/folder pickers — on macOS, avoid passing parent window so the dialog
-  // opens as a standalone panel instead of a sheet (sidebar items like Desktop
-  // are unresponsive in sheet mode).
+  // File/folder pickers — Linux/macOS omit parent (see open-dialog.ts).
   ipcMain.handle(IPC.SHREDDER_SELECT_FILES, async () => {
     const win = getWindow()
     if (!win) return []
     const fileOpts: Electron.OpenDialogOptions = { properties: ['openFile', 'multiSelections'] }
-    const result = process.platform === 'darwin'
-      ? await dialog.showOpenDialog(fileOpts)
-      : await dialog.showOpenDialog(win, fileOpts)
+    const result = await showOpenDialog(win, fileOpts)
     if (result.canceled || !result.filePaths.length) return []
 
     const entries: ShredderEntry[] = []
@@ -273,9 +270,7 @@ export function registerFileShredderIpc(getWindow: WindowGetter): void {
     const win = getWindow()
     if (!win) return []
     const folderOpts: Electron.OpenDialogOptions = { properties: ['openDirectory', 'multiSelections'] }
-    const result = process.platform === 'darwin'
-      ? await dialog.showOpenDialog(folderOpts)
-      : await dialog.showOpenDialog(win, folderOpts)
+    const result = await showOpenDialog(win, folderOpts)
     if (result.canceled || !result.filePaths.length) return []
 
     const entries: ShredderEntry[] = []

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -28,6 +28,7 @@ import { registerFirewallAuditIpc } from './firewall-audit.ipc'
 import { registerSoftwareUpdaterIpc } from './software-updater.ipc'
 import { registerShortcutCleanerIpc } from './shortcut-cleaner.ipc'
 import { registerEnvironmentCleanerIpc } from './environment-cleaner.ipc'
+import { showOpenDialog } from './open-dialog'
 import { registerDatabaseOptimizerIpc } from './database-optimizer.ipc'
 import { registerCloudAgentIpc } from './cloud-agent.ipc'
 import { registerLargeFileFinderIpc } from './large-file-finder.ipc'
@@ -151,9 +152,7 @@ export function registerCleanerIpc(getWindow: WindowGetter): void {
       properties: ['openDirectory', 'createDirectory'],
       defaultPath: getBackupDir(),
     }
-    const result = process.platform === 'darwin' || !win
-      ? await dialog.showOpenDialog(opts)
-      : await dialog.showOpenDialog(win, opts)
+    const result = await showOpenDialog(win, opts)
     if (result.canceled || !result.filePaths.length) return null
     return result.filePaths[0]
   })

--- a/src/main/ipc/large-file-finder.ipc.ts
+++ b/src/main/ipc/large-file-finder.ipc.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, dialog, ipcMain, shell } from 'electron'
+import { BrowserWindow, ipcMain, shell } from 'electron'
 import { readdir, stat, rm } from 'fs/promises'
 import { join, extname, isAbsolute } from 'path'
 import { IPC } from '../../shared/channels'
@@ -11,6 +11,7 @@ import type {
   LargeFileDeleteResult
 } from '../../shared/types'
 import type { WindowGetter } from './index'
+import { showOpenDialog } from './open-dialog'
 
 let cancelled = false
 
@@ -86,16 +87,12 @@ async function walkDirectory(
 }
 
 export function registerLargeFileFinderIpc(getWindow: WindowGetter): void {
-  // Directory picker — on macOS, avoid passing parent window so the dialog
-  // opens as a standalone panel instead of a sheet (sidebar items like Desktop
-  // are unresponsive in sheet mode).
+  // Directory picker — Linux/macOS omit parent (see open-dialog.ts).
   ipcMain.handle(IPC.LARGE_FILES_SELECT_DIR, async () => {
     const win = getWindow()
     if (!win) return null
     const opts: Electron.OpenDialogOptions = { properties: ['openDirectory'] }
-    const result = process.platform === 'darwin'
-      ? await dialog.showOpenDialog(opts)
-      : await dialog.showOpenDialog(win, opts)
+    const result = await showOpenDialog(win, opts)
     if (result.canceled || !result.filePaths.length) return null
     return result.filePaths[0]
   })

--- a/src/main/ipc/open-dialog.test.ts
+++ b/src/main/ipc/open-dialog.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const mockShowOpenDialog = vi.fn()
+vi.mock('electron', () => ({
+  dialog: { showOpenDialog: (...args: unknown[]) => mockShowOpenDialog(...args) },
+}))
+
+const { showOpenDialog } = await import('./open-dialog')
+
+describe('showOpenDialog', () => {
+  const win = { id: 1 } as unknown as Electron.BrowserWindow
+  const opts: Electron.OpenDialogOptions = { properties: ['openDirectory'] }
+
+  beforeEach(() => {
+    mockShowOpenDialog.mockReset()
+    mockShowOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/tmp'] })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('passes parent window on Windows', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'win32' })
+    await showOpenDialog(win, opts)
+    expect(mockShowOpenDialog).toHaveBeenCalledWith(win, opts)
+  })
+
+  it('omits parent window on Linux', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'linux' })
+    await showOpenDialog(win, opts)
+    expect(mockShowOpenDialog).toHaveBeenCalledWith(opts)
+  })
+
+  it('omits parent window on macOS', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'darwin' })
+    await showOpenDialog(win, opts)
+    expect(mockShowOpenDialog).toHaveBeenCalledWith(opts)
+  })
+
+  it('omits parent when window is null on Windows', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'win32' })
+    await showOpenDialog(null, opts)
+    expect(mockShowOpenDialog).toHaveBeenCalledWith(opts)
+  })
+})

--- a/src/main/ipc/open-dialog.ts
+++ b/src/main/ipc/open-dialog.ts
@@ -1,0 +1,16 @@
+import { dialog, type BrowserWindow } from 'electron'
+
+/**
+ * Open a file/folder dialog. On Linux and macOS, omit the parent window —
+ * GTK portals can crash (CachyOS Duplicate Finder) and macOS sheets freeze
+ * sidebar items when parented.
+ */
+export function showOpenDialog(
+  win: BrowserWindow | null | undefined,
+  opts: Electron.OpenDialogOptions
+): Promise<Electron.OpenDialogReturnValue> {
+  if (process.platform === 'win32' && win) {
+    return dialog.showOpenDialog(win, opts)
+  }
+  return dialog.showOpenDialog(opts)
+}


### PR DESCRIPTION
## Summary
- On Linux (and macOS), open folder/file dialogs without a parent `BrowserWindow` — GTK portals can crash the app when parented (CachyOS Duplicate Finder: Select Directory closes the app)
- Shared `showOpenDialog` helper used by Duplicate Finder, Large Files, Empty Folders, File Shredder, and backup folder picker
- Unit tests for win32 / linux / darwin parent behavior

Closes #389

## Test plan
- [x] `npx vitest run src/main/ipc/open-dialog.test.ts src/main/ipc/file-shredder.ipc.test.ts`
- [x] `npm run validate:rules && npm test && npm run build`
- [ ] CachyOS: Duplicate Finder → Select Directory (without opening Settings first) stays open and returns a path
- [ ] Same for Large Files / Empty Folders if easy to check