### PR TITLE
fix(build): ship Linux arm64 AppImage and deb on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,10 +57,20 @@ jobs:
         include:
           - os: windows-latest
             build-args: --win
+            publish: always
           - os: macos-latest
             build-args: --mac
+            publish: always
+          # Arch flags keep each Linux runner on its native CPU — building both
+          # arches on one host breaks better-sqlite3 / yara native rebuilds.
           - os: ubuntu-latest
-            build-args: --linux
+            build-args: --linux --x64
+            publish: always
+          # --publish always would overwrite latest-linux.yml and break x64
+          # AppImage auto-update. Arm artifacts are uploaded to the same tag only.
+          - os: ubuntu-24.04-arm
+            build-args: --linux --arm64
+            publish: never
 
     runs-on: ${{ matrix.os }}
 
@@ -108,6 +118,16 @@ jobs:
               -c.win.azureSignOptions.codeSigningAccountName="kudu-signing" \
               -c.win.azureSignOptions.certificateProfileName="kudu-sign" \
               -c.win.azureSignOptions.publisherName="Advent Development, Inc."
+          elif [ "${{ matrix.publish }}" = "never" ]; then
+            npx electron-builder ${{ matrix.build-args }} --publish never
+            shopt -s nullglob
+            assets=(dist/Kudu-*-arm64.AppImage dist/Kudu-*-arm64.deb dist/Kudu-*-arm64.AppImage.blockmap)
+            if [ ${#assets[@]} -eq 0 ]; then
+              echo "No arm64 Linux artifacts found under dist/" >&2
+              ls -la dist/ || true
+              exit 1
+            fi
+            gh release upload "${GITHUB_REF_NAME}" "${assets[@]}" --clobber
           else
             npx electron-builder ${{ matrix.build-args }} --publish always
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,8 @@ jobs:
           elif [ "${{ matrix.publish }}" = "never" ]; then
             npx electron-builder ${{ matrix.build-args }} --publish never
             shopt -s nullglob
-            assets=(dist/Kudu-*-arm64.AppImage dist/Kudu-*-arm64.deb dist/Kudu-*-arm64.AppImage.blockmap)
+            # Matches both Kudu-<ver>-arm64.* and the stable Kudu-arm64.* name (#404).
+            assets=(dist/Kudu-*arm64.AppImage dist/Kudu-*arm64.deb dist/Kudu-*arm64.AppImage.blockmap)
             if [ ${#assets[@]} -eq 0 ]; then
               echo "No arm64 Linux artifacts found under dist/" >&2
               ls -la dist/ || true

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Get the latest installer for your platform from [GitHub Releases](https://github
 |----------|--------|
 | Windows | `.exe` installer or portable (`Kudu-Portable-*.exe`) |
 | macOS | `.dmg` (Intel & Apple Silicon) |
-| Linux | `.AppImage` or `.deb` |
+| Linux | `.AppImage` or `.deb` (x64, arm64) |
 
 ## Why Kudu?
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -75,9 +75,11 @@ linux:
     - target: AppImage
       arch:
         - x64
+        - arm64
     - target: deb
       arch:
         - x64
+        - arm64
   icon: resources/icons/
   category: Utility
 

--- a/src/main/build-config.test.ts
+++ b/src/main/build-config.test.ts
@@ -70,4 +70,32 @@ describe('electron-builder.yml', () => {
   it('keeps versioned Linux deb artifact names', () => {
     expect(option('deb', 'artifactName')).toBe('Kudu-${version}-${arch}.${ext}')
   })
+
+  it('publishes Linux AppImage for x64 and arm64', () => {
+    // Release matrix builds each arch on a native runner; both must be listed
+    // here so --linux --arm64 actually emits an AppImage (#396).
+    const linux = block('linux')
+    const appImageStart = linux.findIndex((l) => l.includes('target: AppImage'))
+    expect(appImageStart).toBeGreaterThanOrEqual(0)
+    const nextTarget = linux.findIndex(
+      (l, i) => i > appImageStart && l.trimStart().startsWith('- target:')
+    )
+    const appImageBlock = linux.slice(
+      appImageStart,
+      nextTarget === -1 ? undefined : nextTarget
+    )
+    expect(appImageBlock.some((l) => l.trim() === '- x64')).toBe(true)
+    expect(appImageBlock.some((l) => l.trim() === '- arm64')).toBe(true)
+  })
+
+  it('documents arm64 Linux release publish mode in the workflow', () => {
+    // Guard the Critical invariant: arm64 must not --publish always or it
+    // clobbers latest-linux.yml and breaks x64 AppImage auto-update.
+    const release = readFileSync(
+      path.resolve(__dirname, '..', '..', '.github', 'workflows', 'release.yml'),
+      'utf-8'
+    )
+    expect(release).toMatch(/ubuntu-24\.04-arm[\s\S]*?publish:\s*never/)
+    expect(release).toMatch(/gh release upload/)
+  })
 })


### PR DESCRIPTION
## Summary
- Add `arm64` to Linux AppImage and deb targets in `electron-builder.yml` (#396).
- Release matrix: `ubuntu-24.04-arm` builds `--linux --arm64`; x64 job keeps `--linux --x64`.
- Arm job uses `--publish never` + `gh release upload` so it does not overwrite `latest-linux.yml` (would break x64 AppImage auto-update). Arm64 in-app auto-update is a follow-up.

## Test plan
- [x] `npx vitest run src/main/build-config.test.ts`
- [x] `npm run validate:rules && npm test && npm run build`
- [ ] Next tagged release uploads `Kudu-*-arm64.AppImage` (and `.deb`)
- [ ] Confirm x64 release still has a valid `latest-linux.yml` after both Linux jobs

Closes #396