### PR TITLE
feat(settings): opt-in prefer elevated launch

### DIFF
--- a/src/main/services/ipc-validation.test.ts
+++ b/src/main/services/ipc-validation.test.ts
@@ -65,6 +65,16 @@ describe('validateSettingsPartial', () => {
     expect(validateSettingsPartial({ softwareUpdaterNotifications: 'off' })).toBeNull()
   })
 
+  it('accepts preferElevatedLaunch boolean', () => {
+    expect(validateSettingsPartial({ preferElevatedLaunch: true })).toEqual({
+      preferElevatedLaunch: true,
+    })
+  })
+
+  it('rejects non-boolean preferElevatedLaunch', () => {
+    expect(validateSettingsPartial({ preferElevatedLaunch: 1 })).toBeNull()
+  })
+
   it('accepts valid ignoredSoftwareUpdates array', () => {
     const input = { ignoredSoftwareUpdates: ['Google.Chrome', 'Mozilla.Firefox'] }
     expect(validateSettingsPartial(input)).toEqual(input)

--- a/src/main/services/ipc-validation.ts
+++ b/src/main/services/ipc-validation.ts
@@ -17,7 +17,7 @@ export function validateSettingsPartial(input: unknown): Record<string, unknown>
     'theme', 'language',
     'minimizeToTray', 'showNotificationOnComplete', 'showThreatNotifications',
     'runAtStartup', 'autoUpdate', 'autoRestart', 'updateCheckIntervalHours',
-    'softwareUpdaterNotifications',
+    'softwareUpdaterNotifications', 'preferElevatedLaunch',
     'cleaner', 'exclusions', 'ignoredSoftwareUpdates', 'backupPath', 'backupMode',
     'windowsPackageManager', 'windowsPackageManagers',
     'schedule', 'schedules', 'cloud', 'gameMode', 'registryIgnoredTweaks'
@@ -38,7 +38,7 @@ export function validateSettingsPartial(input: unknown): Record<string, unknown>
   }
 
   // Validate boolean fields have correct types
-  const boolKeys = ['minimizeToTray', 'showNotificationOnComplete', 'showThreatNotifications', 'runAtStartup', 'autoUpdate', 'autoRestart', 'softwareUpdaterNotifications'] as const
+  const boolKeys = ['minimizeToTray', 'showNotificationOnComplete', 'showThreatNotifications', 'runAtStartup', 'autoUpdate', 'autoRestart', 'softwareUpdaterNotifications', 'preferElevatedLaunch'] as const
   for (const bk of boolKeys) {
     if (bk in obj && obj[bk] !== undefined && typeof obj[bk] !== 'boolean') return null
   }

--- a/src/main/services/settings-store.ts
+++ b/src/main/services/settings-store.ts
@@ -47,6 +47,7 @@ const defaults: StoreData = {
     autoRestart: true,
     updateCheckIntervalHours: 4,
     softwareUpdaterNotifications: true,
+    preferElevatedLaunch: false,
     cleaner: {
       skipRecentMinutes: 60,
       secureDelete: false,

--- a/src/renderer/src/components/layout/AdminBanner.tsx
+++ b/src/renderer/src/components/layout/AdminBanner.tsx
@@ -1,19 +1,29 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ShieldAlert, X } from 'lucide-react'
 import { usePlatform } from '@/hooks/usePlatform'
+import { useSettingsStore } from '@/stores/settings-store'
 
 export function AdminBanner() {
   const { t } = useTranslation('common')
   const { platform } = usePlatform()
+  const loaded = useSettingsStore((s) => s.loaded)
+  const preferElevatedLaunch = useSettingsStore(
+    (s) => s.settings.preferElevatedLaunch ?? false
+  )
   const [visible, setVisible] = useState(false)
   const [dismissed, setDismissed] = useState(false)
+  const autoRelaunchTried = useRef(false)
 
   useEffect(() => {
     window.kudu.elevationCheck().then((elevated) => {
-      if (!elevated) setVisible(true)
+      if (elevated) return
+      setVisible(true)
+      if (!loaded || !preferElevatedLaunch || autoRelaunchTried.current) return
+      autoRelaunchTried.current = true
+      window.kudu.elevationRelaunch()
     })
-  }, [])
+  }, [loaded, preferElevatedLaunch])
 
   // On macOS the relaunch-as-admin flow doesn't work properly — hide the banner entirely
   if (platform === 'darwin') return null

--- a/src/renderer/src/locales/ar/settings.json
+++ b/src/renderer/src/locales/ar/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "مرة واحدة يوميًا",
   "softwareUpdaterNotificationsLabel": "تذكيرات محدّث البرامج",
   "softwareUpdaterNotificationsDesc": "التحقق من تحديثات تطبيقات الجهات الخارجية في الخلفية وإظهار عدد الشارات في الشريط الجانبي. لا يزال بإمكانك التحقق يدويًا من صفحة محدّث البرامج.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "مدير حزم Windows",
   "windowsPackageManagerDesc": "اختر مدير الحزم الذي تريد استخدامه لتحديثات البرامج",
   "sectionCloudDashboard": "السحابة",

--- a/src/renderer/src/locales/cs/settings.json
+++ b/src/renderer/src/locales/cs/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "Jednou denně",
   "softwareUpdaterNotificationsLabel": "Připomenutí aktualizací softwaru",
   "softwareUpdaterNotificationsDesc": "Na pozadí kontrolovat aktualizace aplikací třetích stran a zobrazovat počty na odznaku v postranním panelu. Kontrolu můžete stále spustit ručně na stránce Aktualizace softwaru.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Správce balíčků Windows",
   "windowsPackageManagerDesc": "Vyberte, který správce balíčků se má používat pro aktualizace softwaru",
   "sectionCloudDashboard": "Cloud",

--- a/src/renderer/src/locales/da/settings.json
+++ b/src/renderer/src/locales/da/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "Én gang om dagen",
   "softwareUpdaterNotificationsLabel": "Påmindelser om softwareopdatering",
   "softwareUpdaterNotificationsDesc": "Søg efter opdateringer til tredjepartsapps i baggrunden, og vis antal mærker i sidepanelet. Du kan stadig søge manuelt fra siden Softwareopdatering.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Windows-pakkehåndtering",
   "windowsPackageManagerDesc": "Vælg, hvilken pakkehåndtering der skal bruges til softwareopdateringer",
   "sectionCloudDashboard": "Cloud",

--- a/src/renderer/src/locales/de/settings.json
+++ b/src/renderer/src/locales/de/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "Einmal täglich",
   "softwareUpdaterNotificationsLabel": "Erinnerungen für Software-Updater",
   "softwareUpdaterNotificationsDesc": "Im Hintergrund nach Updates für Drittanbieter-Apps suchen und Anzahl-Badges in der Seitenleiste anzeigen. Sie können auf der Seite „Software-Updater“ weiterhin manuell prüfen.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Windows-Paketmanager",
   "windowsPackageManagerDesc": "Wählen Sie, welcher Paketmanager für Software-Updates verwendet werden soll",
   "sectionCloudDashboard": "Cloud",

--- a/src/renderer/src/locales/el/settings.json
+++ b/src/renderer/src/locales/el/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "Μία φορά την ημέρα",
   "softwareUpdaterNotificationsLabel": "Υπενθυμίσεις ενημέρωσης λογισμικού",
   "softwareUpdaterNotificationsDesc": "Έλεγχος για ενημερώσεις εφαρμογών τρίτων στο παρασκήνιο και εμφάνιση μετρητών σημάτων στην πλευρική γραμμή. Μπορείτε επίσης να κάνετε έλεγχο μη αυτόματα από τη σελίδα Ενημέρωση λογισμικού.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Διαχειριστής πακέτων Windows",
   "windowsPackageManagerDesc": "Επιλέξτε ποιος διαχειριστής πακέτων θα χρησιμοποιείται για ενημερώσεις λογισμικού",
   "sectionCloudDashboard": "Cloud",

--- a/src/renderer/src/locales/en/settings.json
+++ b/src/renderer/src/locales/en/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "Once a day",
   "softwareUpdaterNotificationsLabel": "Software updater reminders",
   "softwareUpdaterNotificationsDesc": "Check for third-party app updates in the background and show badge counts in the sidebar. You can still check manually from the Software Updater page.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Windows package manager",
   "windowsPackageManagerDesc": "Choose which package manager to use for software updates",
   "sectionCloudDashboard": "Cloud",

--- a/src/renderer/src/locales/es/settings.json
+++ b/src/renderer/src/locales/es/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "Una vez al día",
   "softwareUpdaterNotificationsLabel": "Recordatorios del actualizador de software",
   "softwareUpdaterNotificationsDesc": "Buscar actualizaciones de aplicaciones de terceros en segundo plano y mostrar recuentos de insignias en la barra lateral. También puede comprobarlas manualmente desde la página Actualizador de software.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Administrador de paquetes de Windows",
   "windowsPackageManagerDesc": "Elija qué administrador de paquetes usar para las actualizaciones de software",
   "sectionCloudDashboard": "Cloud",

--- a/src/renderer/src/locales/fi/settings.json
+++ b/src/renderer/src/locales/fi/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "Kerran päivässä",
   "softwareUpdaterNotificationsLabel": "Ohjelmistopäivittäjän muistutukset",
   "softwareUpdaterNotificationsDesc": "Tarkista kolmansien osapuolten sovelluspäivitykset taustalla ja näytä tunnusmäärät sivupalkissa. Voit silti tarkistaa päivitykset manuaalisesti Ohjelmistopäivittäjä-sivulta.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Windows-paketinhallinta",
   "windowsPackageManagerDesc": "Valitse, mitä paketinhallintaa käytetään ohjelmistopäivityksiin",
   "sectionCloudDashboard": "Pilvi",

--- a/src/renderer/src/locales/fr/settings.json
+++ b/src/renderer/src/locales/fr/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "Une fois par jour",
   "softwareUpdaterNotificationsLabel": "Rappels du programme de mise à jour des logiciels",
   "softwareUpdaterNotificationsDesc": "Rechercher les mises à jour des applications tierces en arrière-plan et afficher le nombre d’éléments dans la barre latérale. Vous pouvez toujours vérifier manuellement depuis la page Programme de mise à jour des logiciels.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Gestionnaire de paquets Windows",
   "windowsPackageManagerDesc": "Choisissez le gestionnaire de paquets à utiliser pour les mises à jour logicielles",
   "sectionCloudDashboard": "Cloud",

--- a/src/renderer/src/locales/he/settings.json
+++ b/src/renderer/src/locales/he/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "פעם ביום",
   "softwareUpdaterNotificationsLabel": "תזכורות לעדכון תוכנות",
   "softwareUpdaterNotificationsDesc": "בדוק עדכונים ליישומי צד שלישי ברקע והצג מוני תגים בסרגל הצד. עדיין ניתן לבדוק ידנית מדף עדכון התוכנות.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "מנהל החבילות של Windows",
   "windowsPackageManagerDesc": "בחר באיזה מנהל חבילות להשתמש לעדכוני תוכנה",
   "sectionCloudDashboard": "ענן",

--- a/src/renderer/src/locales/hi/settings.json
+++ b/src/renderer/src/locales/hi/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "दिन में एक बार",
   "softwareUpdaterNotificationsLabel": "सॉफ़्टवेयर अपडेटर अनुस्मारक",
   "softwareUpdaterNotificationsDesc": "पृष्ठभूमि में तृतीय-पक्ष ऐप अपडेट जाँचें और साइडबार में बैज संख्या दिखाएँ। आप फिर भी Software Updater पेज से मैन्युअल रूप से जाँच सकते हैं।",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Windows पैकेज प्रबंधक",
   "windowsPackageManagerDesc": "सॉफ़्टवेयर अपडेट के लिए कौन-सा पैकेज प्रबंधक उपयोग करना है, चुनें",
   "sectionCloudDashboard": "Cloud",

--- a/src/renderer/src/locales/hu/settings.json
+++ b/src/renderer/src/locales/hu/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "Naponta egyszer",
   "softwareUpdaterNotificationsLabel": "Szoftverfrissítő emlékeztetők",
   "softwareUpdaterNotificationsDesc": "A háttérben ellenőrzi a külső alkalmazások frissítéseit, és jelvényszámokat jelenít meg az oldalsávon. A Szoftverfrissítő oldalon továbbra is manuálisan is ellenőrizheti.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Windows csomagkezelő",
   "windowsPackageManagerDesc": "Válassza ki, melyik csomagkezelőt használja a szoftverfrissítésekhez",
   "sectionCloudDashboard": "Felhő",

--- a/src/renderer/src/locales/id/settings.json
+++ b/src/renderer/src/locales/id/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "Sekali sehari",
   "softwareUpdaterNotificationsLabel": "Pengingat pembaruan perangkat lunak",
   "softwareUpdaterNotificationsDesc": "Periksa pembaruan aplikasi pihak ketiga di latar belakang dan tampilkan jumlah lencana di bilah samping. Anda tetap dapat memeriksa secara manual dari halaman Software Updater.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Manajer paket Windows",
   "windowsPackageManagerDesc": "Pilih manajer paket yang akan digunakan untuk pembaruan perangkat lunak",
   "sectionCloudDashboard": "Cloud",

--- a/src/renderer/src/locales/it/settings.json
+++ b/src/renderer/src/locales/it/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "Una volta al giorno",
   "softwareUpdaterNotificationsLabel": "Promemoria aggiornamenti software",
   "softwareUpdaterNotificationsDesc": "Controlla in background gli aggiornamenti delle app di terze parti e mostra il conteggio dei badge nella barra laterale. Puoi comunque controllare manualmente dalla pagina Aggiornamento software.",
+  "preferElevatedLaunchLabel": "Preferisci amministratore all'avvio",
+  "preferElevatedLaunchDesc": "Chiede elevazione all'avvio se Kudu non ha diritti di amministratore (UAC su Windows, polkit su Linux). Disattivato di default.",
   "windowsPackageManagerLabel": "Gestore pacchetti di Windows",
   "windowsPackageManagerDesc": "Scegli quale gestore pacchetti usare per gli aggiornamenti software",
   "sectionCloudDashboard": "Cloud",

--- a/src/renderer/src/locales/ja/settings.json
+++ b/src/renderer/src/locales/ja/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "1 日 1 回",
   "softwareUpdaterNotificationsLabel": "ソフトウェア更新の通知",
   "softwareUpdaterNotificationsDesc": "バックグラウンドでサードパーティ製アプリの更新を確認し、サイドバーにバッジ数を表示します。手動で確認する場合は、ソフトウェア更新ページからいつでも実行できます。",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Windows パッケージ マネージャー",
   "windowsPackageManagerDesc": "ソフトウェア更新に使用するパッケージ マネージャーを選択します",
   "sectionCloudDashboard": "クラウド",

--- a/src/renderer/src/locales/ko/settings.json
+++ b/src/renderer/src/locales/ko/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "하루에 한 번",
   "softwareUpdaterNotificationsLabel": "소프트웨어 업데이트 알림",
   "softwareUpdaterNotificationsDesc": "백그라운드에서 타사 앱 업데이트를 확인하고 사이드바에 배지 개수를 표시합니다. 소프트웨어 업데이트 페이지에서 직접 수동으로 확인할 수도 있습니다.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Windows 패키지 관리자",
   "windowsPackageManagerDesc": "소프트웨어 업데이트에 사용할 패키지 관리자를 선택합니다",
   "sectionCloudDashboard": "클라우드",

--- a/src/renderer/src/locales/ms/settings.json
+++ b/src/renderer/src/locales/ms/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "Sekali sehari",
   "softwareUpdaterNotificationsLabel": "Peringatan pengemas kini perisian",
   "softwareUpdaterNotificationsDesc": "Semak kemas kini aplikasi pihak ketiga di latar belakang dan tunjukkan kiraan lencana dalam bar sisi. Anda masih boleh menyemak secara manual dari halaman Pengemas Kini Perisian.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Pengurus pakej Windows",
   "windowsPackageManagerDesc": "Pilih pengurus pakej yang hendak digunakan untuk kemas kini perisian",
   "sectionCloudDashboard": "Cloud",

--- a/src/renderer/src/locales/nl/settings.json
+++ b/src/renderer/src/locales/nl/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "Eén keer per dag",
   "softwareUpdaterNotificationsLabel": "Herinneringen voor software-updates",
   "softwareUpdaterNotificationsDesc": "Controleer op de achtergrond op updates voor apps van derden en toon aantallen badges in de zijbalk. U kunt nog steeds handmatig controleren vanaf de pagina Software Updater.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Windows-pakketbeheerder",
   "windowsPackageManagerDesc": "Kies welke pakketbeheerder moet worden gebruikt voor software-updates",
   "sectionCloudDashboard": "Cloud",

--- a/src/renderer/src/locales/no/settings.json
+++ b/src/renderer/src/locales/no/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "Én gang om dagen",
   "softwareUpdaterNotificationsLabel": "Påminnelser fra programvareoppdatering",
   "softwareUpdaterNotificationsDesc": "Se etter oppdateringer for tredjepartsapper i bakgrunnen og vis antall merker i sidefeltet. Du kan fortsatt se etter oppdateringer manuelt fra siden Programvareoppdatering.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Windows-pakkebehandler",
   "windowsPackageManagerDesc": "Velg hvilken pakkebehandler som skal brukes for programvareoppdateringer",
   "sectionCloudDashboard": "Sky",

--- a/src/renderer/src/locales/pl/settings.json
+++ b/src/renderer/src/locales/pl/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "Raz dziennie",
   "softwareUpdaterNotificationsLabel": "Przypomnienia aktualizacji oprogramowania",
   "softwareUpdaterNotificationsDesc": "Sprawdzaj w tle aktualizacje aplikacji innych firm i pokazuj liczbę dostępnych aktualizacji na pasku bocznym. Nadal możesz sprawdzać je ręcznie na stronie Aktualizator oprogramowania.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Menedżer pakietów Windows",
   "windowsPackageManagerDesc": "Wybierz menedżer pakietów używany do aktualizacji oprogramowania",
   "sectionCloudDashboard": "Chmura",

--- a/src/renderer/src/locales/pt/settings.json
+++ b/src/renderer/src/locales/pt/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "Uma vez por dia",
   "softwareUpdaterNotificationsLabel": "Lembretes do atualizador de software",
   "softwareUpdaterNotificationsDesc": "Verifique atualizações de aplicações de terceiros em segundo plano e mostre contagens de emblemas na barra lateral. Continua a poder verificar manualmente na página Atualizador de Software.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Gestor de pacotes do Windows",
   "windowsPackageManagerDesc": "Escolha qual o gestor de pacotes a utilizar para atualizações de software",
   "sectionCloudDashboard": "Cloud",

--- a/src/renderer/src/locales/ro/settings.json
+++ b/src/renderer/src/locales/ro/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "O dată pe zi",
   "softwareUpdaterNotificationsLabel": "Mementouri pentru actualizatorul de software",
   "softwareUpdaterNotificationsDesc": "Verificați în fundal actualizările pentru aplicațiile terțe și afișați numărul acestora în bara laterală. Puteți verifica în continuare manual din pagina Actualizator software.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Manager de pachete Windows",
   "windowsPackageManagerDesc": "Alegeți ce manager de pachete să fie utilizat pentru actualizările software",
   "sectionCloudDashboard": "Cloud",

--- a/src/renderer/src/locales/ru/settings.json
+++ b/src/renderer/src/locales/ru/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "Раз в день",
   "softwareUpdaterNotificationsLabel": "Напоминания об обновлении программ",
   "softwareUpdaterNotificationsDesc": "Проверять обновления сторонних приложений в фоновом режиме и показывать количество доступных обновлений на боковой панели. Вы по-прежнему можете выполнить проверку вручную на странице «Обновление программ».",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Диспетчер пакетов Windows",
   "windowsPackageManagerDesc": "Выберите диспетчер пакетов для обновления программ",
   "sectionCloudDashboard": "Облако",

--- a/src/renderer/src/locales/sv/settings.json
+++ b/src/renderer/src/locales/sv/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "En gång om dagen",
   "softwareUpdaterNotificationsLabel": "Påminnelser från programuppdateraren",
   "softwareUpdaterNotificationsDesc": "Sök efter uppdateringar för tredjepartsappar i bakgrunden och visa antal märken i sidofältet. Du kan fortfarande söka manuellt från sidan Programuppdaterare.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Windows-pakethanterare",
   "windowsPackageManagerDesc": "Välj vilken pakethanterare som ska användas för programuppdateringar",
   "sectionCloudDashboard": "Moln",

--- a/src/renderer/src/locales/th/settings.json
+++ b/src/renderer/src/locales/th/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "วันละครั้ง",
   "softwareUpdaterNotificationsLabel": "การแจ้งเตือนตัวอัปเดตซอฟต์แวร์",
   "softwareUpdaterNotificationsDesc": "ตรวจสอบการอัปเดตของแอปจากผู้พัฒนาภายนอกในเบื้องหลัง และแสดงจำนวนป้ายแจ้งเตือนในแถบด้านข้าง คุณยังคงตรวจสอบด้วยตนเองได้จากหน้าตัวอัปเดตซอฟต์แวร์",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "ตัวจัดการแพ็กเกจของ Windows",
   "windowsPackageManagerDesc": "เลือกตัวจัดการแพ็กเกจที่จะใช้สำหรับการอัปเดตซอฟต์แวร์",
   "sectionCloudDashboard": "Cloud",

--- a/src/renderer/src/locales/tr/settings.json
+++ b/src/renderer/src/locales/tr/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "Günde bir kez",
   "softwareUpdaterNotificationsLabel": "Yazılım güncelleyici hatırlatmaları",
   "softwareUpdaterNotificationsDesc": "Arka planda üçüncü taraf uygulama güncellemelerini denetleyin ve kenar çubuğunda rozet sayıları gösterin. Yine de Yazılım Güncelleyici sayfasından el ile denetleyebilirsiniz.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Windows paket yöneticisi",
   "windowsPackageManagerDesc": "Yazılım güncellemeleri için hangi paket yöneticisinin kullanılacağını seçin",
   "sectionCloudDashboard": "Bulut",

--- a/src/renderer/src/locales/uk/settings.json
+++ b/src/renderer/src/locales/uk/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "Раз на день",
   "softwareUpdaterNotificationsLabel": "Нагадування про оновлення програм",
   "softwareUpdaterNotificationsDesc": "Перевіряти у фоновому режимі оновлення сторонніх програм і показувати кількість у значку на бічній панелі. Ви також можете виконати перевірку вручну на сторінці оновлення програм.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Менеджер пакетів Windows",
   "windowsPackageManagerDesc": "Виберіть менеджер пакетів для оновлення програм",
   "sectionCloudDashboard": "Хмара",

--- a/src/renderer/src/locales/vi/settings.json
+++ b/src/renderer/src/locales/vi/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "Mỗi ngày một lần",
   "softwareUpdaterNotificationsLabel": "Nhắc nhở cập nhật phần mềm",
   "softwareUpdaterNotificationsDesc": "Kiểm tra bản cập nhật cho ứng dụng bên thứ ba trong nền và hiển thị số lượng huy hiệu trên thanh bên. Bạn vẫn có thể kiểm tra thủ công từ trang Trình cập nhật phần mềm.",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Trình quản lý gói của Windows",
   "windowsPackageManagerDesc": "Chọn trình quản lý gói sẽ dùng để cập nhật phần mềm",
   "sectionCloudDashboard": "Đám mây",

--- a/src/renderer/src/locales/zh-CN/settings.json
+++ b/src/renderer/src/locales/zh-CN/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "每天一次",
   "softwareUpdaterNotificationsLabel": "软件更新器提醒",
   "softwareUpdaterNotificationsDesc": "在后台检查第三方应用更新，并在侧边栏中显示徽章计数。您仍然可以在“软件更新器”页面手动检查。",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Windows 包管理器",
   "windowsPackageManagerDesc": "选择用于软件更新的包管理器",
   "sectionCloudDashboard": "云",

--- a/src/renderer/src/locales/zh-TW/settings.json
+++ b/src/renderer/src/locales/zh-TW/settings.json
@@ -24,6 +24,8 @@
   "updateCheckOnceADay": "每天一次",
   "softwareUpdaterNotificationsLabel": "軟體更新程式提醒",
   "softwareUpdaterNotificationsDesc": "在背景檢查第三方應用程式更新，並在側邊欄顯示徽章數量。您仍可從「軟體更新程式」頁面手動檢查。",
+  "preferElevatedLaunchLabel": "Prefer administrator on launch",
+  "preferElevatedLaunchDesc": "Prompt for elevation when Kudu starts without admin rights (UAC on Windows, polkit on Linux). Off by default.",
   "windowsPackageManagerLabel": "Windows 套件管理員",
   "windowsPackageManagerDesc": "選擇用於軟體更新的套件管理員",
   "sectionCloudDashboard": "雲端",

--- a/src/renderer/src/pages/SettingsPage.tsx
+++ b/src/renderer/src/pages/SettingsPage.tsx
@@ -122,12 +122,24 @@ export function SettingsPage() {
             <option value={24}>{t('updateCheckOnceADay')}</option>
           </select>
         </Row>
-        <Row label={t('softwareUpdaterNotificationsLabel')} desc={t('softwareUpdaterNotificationsDesc')} last>
+        <Row
+          label={t('softwareUpdaterNotificationsLabel')}
+          desc={t('softwareUpdaterNotificationsDesc')}
+          last={platform === 'darwin'}
+        >
           <Toggle
             checked={settings.softwareUpdaterNotifications ?? true}
             onChange={(v) => save({ softwareUpdaterNotifications: v })}
           />
         </Row>
+        {platform !== 'darwin' && (
+          <Row label={t('preferElevatedLaunchLabel')} desc={t('preferElevatedLaunchDesc')} last>
+            <Toggle
+              checked={settings.preferElevatedLaunch ?? false}
+              onChange={(v) => save({ preferElevatedLaunch: v })}
+            />
+          </Row>
+        )}
       </Section>
 
       <Section title={t('sectionCloudDashboard')}>

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -19,6 +19,7 @@ const defaultSettings: KuduSettings = {
   autoRestart: true,
   updateCheckIntervalHours: 4,
   softwareUpdaterNotifications: true,
+  preferElevatedLaunch: false,
   cleaner: {
     skipRecentMinutes: 60,
     secureDelete: false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -723,6 +723,11 @@ export interface KuduSettings {
    * sidebar badge counts. Manual checks from the Software Updater page still work.
    */
   softwareUpdaterNotifications: boolean
+  /**
+   * When true, prompt for elevation (UAC / pkexec) on launch if not already
+   * elevated. Opt-in — default stays unelevated (#390). Hidden on macOS.
+   */
+  preferElevatedLaunch: boolean
   cleaner: {
     skipRecentMinutes: number
     secureDelete: boolean


### PR DESCRIPTION
## Summary
- Adds Settings → **Prefer administrator on launch** (Windows/Linux; hidden on macOS).
- When enabled and the process is unelevated, `AdminBanner` triggers the existing UAC/pkexec relaunch once per session.
- Default remains off so elevation stays opt-in (#390).

## Test plan
- [x] `npm run validate:rules && npm test && npm run build`
- [ ] Linux: enable toggle → polkit prompt on next unelevated start; decline leaves app running + banner
- [ ] Windows portable: enable toggle → UAC prompt; NSIS install already elevated so toggle is a no-op
- [ ] macOS: toggle not shown

Closes #390