### PR TITLE
feat(cli): add repair winre-status for Windows RE

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -93,10 +93,13 @@ kudu --cli programs list --json 2>/dev/null     # discard progress entirely
 ## Repair (Windows)
 
 ```bash
-kudu --cli repair gpu-restart   # soft-restart display adapters (admin required)
+kudu --cli repair gpu-restart             # soft-restart display adapters (admin required)
+kudu --cli repair winre-status            # Enabled / Disabled / Unknown (admin required)
+kudu --cli repair winre-status --verbose  # include location + BCD id
+kudu --cli repair winre-status --json
 ```
 
-Uses Disable/Enable-PnpDevice on class `Display` — not key injection of Win+Ctrl+Shift+B.
+`gpu-restart` uses Disable/Enable-PnpDevice on class `Display` — not key injection of Win+Ctrl+Shift+B.
 
 ## Prometheus Metrics
 

--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -584,6 +584,7 @@ Restore Points:
 
 Repair (Windows):
   repair gpu-restart           Soft-restart display adapters (needs admin)
+  repair winre-status [--verbose]  Windows Recovery Environment status (needs admin)
 
 Config Management:
   config get [key]             Show settings (e.g. config get cloud.apiKey)
@@ -1217,27 +1218,41 @@ async function handleRestorePoint(args: string[], ctx: CliContext): Promise<numb
   }
 }
 
+const REPAIR_USAGE = 'kudu --cli repair <gpu-restart|winre-status> [--verbose]'
+
 async function handleRepair(args: string[], ctx: CliContext): Promise<number | void> {
   const sub = args[0]
-  if (sub !== 'gpu-restart') {
-    cliUsage(ctx, 'kudu --cli repair gpu-restart')
+  const labels: Record<string, string> = {
+    'gpu-restart': 'GPU restart',
+    'winre-status': 'WinRE status',
+  }
+  const label = labels[sub ?? '']
+  if (!label) {
+    cliUsage(ctx, REPAIR_USAGE)
     return ExitCode.INVALID_ARGS
   }
   if (process.platform !== 'win32') {
-    const msg = 'GPU restart is only available on Windows'
+    const msg = `${label} is only available on Windows`
     if (ctx.json) cliOut(ctx, { error: 'unsupported_platform', message: msg })
     else cliLog(ctx, msg)
     return ExitCode.GENERAL_ERROR
   }
 
+  // Both subcommands need elevation: Disable/Enable-PnpDevice refuses without
+  // it, and reagentc would otherwise read as an "Unknown" status rather than
+  // a permissions problem.
   const { isAdmin } = await import('./services/elevation')
   if (!isAdmin()) {
-    const msg = 'GPU restart requires administrator privileges'
+    const msg = `${label} requires administrator privileges`
     if (ctx.json) cliOut(ctx, { error: 'permission_denied', message: msg })
     else cliLog(ctx, msg)
     return ExitCode.PERMISSION_DENIED
   }
 
+  return sub === 'gpu-restart' ? repairGpuRestart(ctx) : repairWinReStatus(args, ctx)
+}
+
+async function repairGpuRestart(ctx: CliContext): Promise<number | void> {
   cliLog(ctx, 'Restarting display adapters...')
   const { restartGpuDrivers } = await import('./platform/win32/gpu-restart')
   const result = await restartGpuDrivers()
@@ -1255,6 +1270,32 @@ async function handleRepair(args: string[], ctx: CliContext): Promise<number | v
 
   if (!result.ok) return ExitCode.GENERAL_ERROR
   if (result.devices.length === 0) return ExitCode.NOTHING_FOUND
+}
+
+async function repairWinReStatus(args: string[], ctx: CliContext): Promise<number | void> {
+  const { getWinReInfo } = await import('./platform/win32/winre-status')
+  const info = await getWinReInfo()
+  const verbose = args.includes('--verbose') || ctx.verbosity === 'verbose'
+
+  if (ctx.json) {
+    cliOut(ctx, verbose ? info : {
+      status: info.status,
+      ...(info.location ? { location: info.location } : {}),
+      ...(info.error ? { error: info.error } : {}),
+    })
+    return info.status === 'Unknown' ? ExitCode.GENERAL_ERROR : undefined
+  }
+
+  cliLog(ctx, `  WinRE: ${info.status}`)
+  if (info.error) cliLog(ctx, `  ${info.error}`)
+  if (verbose || info.location) {
+    if (info.location) cliLog(ctx, `  Location: ${info.location}`)
+    else if (verbose) cliLog(ctx, '  Location: (none)')
+  }
+  if (verbose && info.bcdIdentifier) {
+    cliLog(ctx, `  BCD id: ${info.bcdIdentifier}`)
+  }
+  if (info.status === 'Unknown') return ExitCode.GENERAL_ERROR
 }
 
 // ─── Config management ───────────────────────────────────────

--- a/src/main/platform/win32/winre-status.test.ts
+++ b/src/main/platform/win32/winre-status.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { parseWinReInfo } from './winre-status'
+
+const ENABLED = `
+Windows Recovery Environment (Windows RE) and system reset configuration
+Information:
+
+    Windows RE status:         Enabled
+    Windows RE location:       \\\\?\\GLOBALROOT\\device\\harddisk0\\partition4\\Recovery\\WindowsRE
+    Boot Configuration Data (BCD) identifier: 12345678-1234-1234-1234-123456789abc
+    Recovery image location:
+    Recovery image index:      0
+    Custom image location:
+    Custom image index:        0
+
+REAGENTC.EXE: Operation Successful.
+`.trim()
+
+const DISABLED = `
+Windows Recovery Environment (Windows RE) and system reset configuration
+Information:
+
+    Windows RE status:         Disabled
+    Windows RE location:
+    Boot Configuration Data (BCD) identifier: 00000000-0000-0000-0000-000000000000
+    Recovery image location:
+    Recovery image index:      0
+    Custom image location:
+    Custom image index:        0
+
+REAGENTC.EXE: Operation Successful.
+`.trim()
+
+describe('parseWinReInfo', () => {
+  it('parses Enabled status and location', () => {
+    expect(parseWinReInfo(ENABLED)).toEqual({
+      status: 'Enabled',
+      location: '\\\\?\\GLOBALROOT\\device\\harddisk0\\partition4\\Recovery\\WindowsRE',
+      bcdIdentifier: '12345678-1234-1234-1234-123456789abc',
+    })
+  })
+
+  it('parses Disabled status with empty location', () => {
+    expect(parseWinReInfo(DISABLED)).toEqual({
+      status: 'Disabled',
+      location: null,
+      bcdIdentifier: '00000000-0000-0000-0000-000000000000',
+    })
+  })
+
+  it('returns Unknown with a reason when the status line is absent', () => {
+    // Non-elevated shells get an access-denied line; localised Windows prints
+    // a translated label. Neither means WinRE is missing.
+    const info = parseWinReInfo('REAGENTC.EXE: Operation Successful.')
+    expect(info.status).toBe('Unknown')
+    expect(info.location).toBeNull()
+    expect(info.bcdIdentifier).toBeNull()
+    expect(info.error).toMatch(/elevated/i)
+  })
+
+  it('treats unrecognised status text as Unknown', () => {
+    expect(parseWinReInfo('Windows RE status:         Weird').status).toBe('Unknown')
+  })
+})

--- a/src/main/platform/win32/winre-status.ts
+++ b/src/main/platform/win32/winre-status.ts
@@ -1,0 +1,61 @@
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+
+const execFileAsync = promisify(execFile)
+
+/**
+ * `Unknown` means reagentc did not report a status we could read — it needs
+ * elevation, and its output is localised, so an unrecognised status line is
+ * not evidence that WinRE is absent. `error` says why.
+ */
+export type WinReStatus = 'Enabled' | 'Disabled' | 'Unknown'
+
+export interface WinReInfo {
+  status: WinReStatus
+  /** Partition / folder path when reported by reagentc; null if absent. */
+  location: string | null
+  bcdIdentifier: string | null
+  /** Set when status is Unknown. */
+  error?: string
+}
+
+const UNREADABLE = 'reagentc /info did not report a recognisable status (needs an elevated, English-locale shell)'
+
+/** Pure parser for `reagentc /info` stdout (#395). */
+export function parseWinReInfo(stdout: string): WinReInfo {
+  const statusMatch = stdout.match(/Windows RE status:\s*(\S+)/i)
+  const raw = statusMatch?.[1] ?? ''
+
+  const locationMatch = stdout.match(/Windows RE location:[ \t]*([^\r\n]*)/i)
+  const location = locationMatch?.[1]?.trim() || null
+
+  const bcdMatch = stdout.match(
+    /Boot Configuration Data \(BCD\) identifier:\s*([0-9a-fA-F-]{36})/i
+  )
+  const bcdIdentifier = bcdMatch?.[1] ?? null
+
+  if (raw === 'Enabled' || raw === 'Disabled') {
+    return { status: raw, location, bcdIdentifier }
+  }
+  return { status: 'Unknown', location, bcdIdentifier, error: UNREADABLE }
+}
+
+/** Run reagentc /info. Needs elevation; non-Windows callers should not invoke this. */
+export async function getWinReInfo(): Promise<WinReInfo> {
+  try {
+    const { stdout } = await execFileAsync('reagentc.exe', ['/info'], {
+      windowsHide: true,
+      timeout: 30_000,
+    })
+    return parseWinReInfo(stdout)
+  } catch (err: unknown) {
+    const e = err && typeof err === 'object' ? (err as { stdout?: unknown; stderr?: unknown; message?: unknown }) : {}
+    const stdout = String(e.stdout ?? '')
+    if (stdout.trim()) {
+      const parsed = parseWinReInfo(stdout)
+      if (parsed.status !== 'Unknown') return parsed
+    }
+    const detail = String(e.stderr ?? '').trim() || String(e.message ?? '').trim() || 'reagentc failed'
+    return { status: 'Unknown', location: null, bcdIdentifier: null, error: detail }
+  }
+}


### PR DESCRIPTION
﻿## Summary
- New `kudu --cli repair winre-status` (Windows only): prints Enabled / Disabled / Missing from `reagentc /info`.
- `--verbose` / `--json` include location and BCD id when present.
- Pure parser covered by unit tests (#395). GUI status indicator left for a follow-up.

## Test plan
- [x] `npx vitest run src/main/platform/win32/winre-status.test.ts`
- [x] `npm run validate:rules && npm test && npm run build`
- [ ] On Windows (admin if needed): `kudu --cli repair winre-status` and `--json` / `--verbose`

Closes #395
