### PR TITLE
feat(cli): add repair gpu-restart for display adapters

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -90,6 +90,14 @@ kudu --cli programs list --json | jq '.count'   # stdout is pure JSON
 kudu --cli programs list --json 2>/dev/null     # discard progress entirely
 ```
 
+## Repair (Windows)
+
+```bash
+kudu --cli repair gpu-restart   # soft-restart display adapters (admin required)
+```
+
+Uses Disable/Enable-PnpDevice on class `Display` — not key injection of Win+Ctrl+Shift+B.
+
 ## Prometheus Metrics
 
 Print metrics in Prometheus text format (useful for `node_exporter` textfile collector):

--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -543,6 +543,9 @@ Scan History:
 Restore Points:
   restore-point create [description]   Create a system restore point
 
+Repair (Windows):
+  repair gpu-restart           Soft-restart display adapters (needs admin)
+
 Config Management:
   config get [key]             Show settings (e.g. config get cloud.apiKey)
   config set <key> <value>     Update a setting (e.g. config set cloud.apiKey my-key)
@@ -1172,6 +1175,46 @@ async function handleRestorePoint(args: string[], ctx: CliContext): Promise<numb
   }
 }
 
+async function handleRepair(args: string[], ctx: CliContext): Promise<number | void> {
+  const sub = args[0]
+  if (sub !== 'gpu-restart') {
+    cliUsage(ctx, 'kudu --cli repair gpu-restart')
+    return ExitCode.INVALID_ARGS
+  }
+  if (process.platform !== 'win32') {
+    const msg = 'GPU restart is only available on Windows'
+    if (ctx.json) cliOut(ctx, { error: 'unsupported_platform', message: msg })
+    else cliLog(ctx, msg)
+    return ExitCode.GENERAL_ERROR
+  }
+
+  const { isAdmin } = await import('./services/elevation')
+  if (!isAdmin()) {
+    const msg = 'GPU restart requires administrator privileges'
+    if (ctx.json) cliOut(ctx, { error: 'permission_denied', message: msg })
+    else cliLog(ctx, msg)
+    return ExitCode.PERMISSION_DENIED
+  }
+
+  cliLog(ctx, 'Restarting display adapters...')
+  const { restartGpuDrivers } = await import('./platform/win32/gpu-restart')
+  const result = await restartGpuDrivers()
+
+  if (ctx.json) {
+    cliOut(ctx, result)
+  } else if (!result.ok) {
+    cliLog(ctx, `  Failed: ${result.error ?? 'unknown error'}`)
+  } else if (result.devices.length === 0) {
+    cliLog(ctx, '  No active display adapters found.')
+  } else {
+    cliLog(ctx, `  Restarted ${result.devices.length} adapter(s):`)
+    for (const d of result.devices) cliLog(ctx, `    ${d.name}`)
+  }
+
+  if (!result.ok) return ExitCode.GENERAL_ERROR
+  if (result.devices.length === 0) return ExitCode.NOTHING_FOUND
+}
+
 // ─── Config management ───────────────────────────────────────
 
 async function handleConfig(args: string[], ctx: CliContext): Promise<number | void> {
@@ -1637,6 +1680,7 @@ export async function runCli(): Promise<void> {
       case 'leftovers': exitCode = await handleLeftovers(parsed.commandArgs, ctx); break
       case 'history': exitCode = await handleHistory(parsed.commandArgs, ctx); break
       case 'restore-point': exitCode = await handleRestorePoint(parsed.commandArgs, ctx); break
+      case 'repair': exitCode = await handleRepair(parsed.commandArgs, ctx); break
       case 'config': exitCode = await handleConfig(parsed.commandArgs, ctx); break
       case 'service': exitCode = await handleService(parsed.commandArgs, ctx); break
       case 'cve': exitCode = await handleCve(parsed.commandArgs, ctx); break

--- a/src/main/platform/win32/gpu-restart.test.ts
+++ b/src/main/platform/win32/gpu-restart.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const execFileMock = vi.fn()
+
+vi.mock('child_process', () => ({
+  execFile: execFileMock,
+}))
+
+vi.mock('util', () => ({
+  promisify: () => execFileMock,
+}))
+
+const { parseGpuRestartPayload, restartGpuDrivers } = await import('./gpu-restart')
+
+describe('parseGpuRestartPayload', () => {
+  it('parses a single device object', () => {
+    expect(
+      parseGpuRestartPayload(
+        JSON.stringify({ Name: 'NVIDIA GeForce', InstanceId: 'PCI\\VEN_10DE' })
+      )
+    ).toEqual([{ name: 'NVIDIA GeForce', instanceId: 'PCI\\VEN_10DE' }])
+  })
+
+  it('parses an array of devices', () => {
+    expect(
+      parseGpuRestartPayload(
+        JSON.stringify([
+          { Name: 'Intel UHD', InstanceId: 'PCI\\VEN_8086' },
+          { Name: 'NVIDIA', InstanceId: 'PCI\\VEN_10DE' },
+        ])
+      )
+    ).toEqual([
+      { name: 'Intel UHD', instanceId: 'PCI\\VEN_8086' },
+      { name: 'NVIDIA', instanceId: 'PCI\\VEN_10DE' },
+    ])
+  })
+
+  it('returns empty for blank or invalid JSON', () => {
+    expect(parseGpuRestartPayload('')).toEqual([])
+    expect(parseGpuRestartPayload('not-json')).toEqual([])
+  })
+})
+
+describe('restartGpuDrivers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns restarted devices from PowerShell', async () => {
+    execFileMock.mockResolvedValue({
+      stdout: JSON.stringify([{ Name: 'Basic Display', InstanceId: 'ROOT\\DISPLAY' }]),
+      stderr: '',
+    })
+    const result = await restartGpuDrivers()
+    expect(result.ok).toBe(true)
+    expect(result.devices).toEqual([{ name: 'Basic Display', instanceId: 'ROOT\\DISPLAY' }])
+    expect(execFileMock).toHaveBeenCalled()
+  })
+
+  it('returns ok:false when PowerShell fails', async () => {
+    execFileMock.mockRejectedValue(new Error('Access is denied'))
+    const result = await restartGpuDrivers()
+    expect(result.ok).toBe(false)
+    expect(result.devices).toEqual([])
+    expect(result.error).toMatch(/Access is denied/)
+  })
+})
+
+describe('restartGpuDrivers script safety', () => {
+  it('re-enables adapters in a finally block so a failure never leaves one disabled', async () => {
+    execFileMock.mockResolvedValue({ stdout: '[]', stderr: '' })
+    await restartGpuDrivers()
+    const script = execFileMock.mock.calls[0][1][3] as string
+    expect(script).toMatch(/try\s*\{[\s\S]*Disable-PnpDevice[\s\S]*\}\s*finally\s*\{[\s\S]*Enable-PnpDevice/)
+    expect(script.indexOf('Disable-PnpDevice')).toBeLessThan(script.indexOf('finally'))
+  })
+})

--- a/src/main/platform/win32/gpu-restart.ts
+++ b/src/main/platform/win32/gpu-restart.ts
@@ -1,0 +1,85 @@
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import { psUtf8 } from '../../services/exec-utf8'
+
+const execFileAsync = promisify(execFile)
+
+export interface GpuRestartDevice {
+  name: string
+  instanceId: string
+}
+
+export interface GpuRestartResult {
+  ok: boolean
+  devices: GpuRestartDevice[]
+  error?: string
+}
+
+/** Pure parser for the PowerShell ConvertTo-Json payload (#394). */
+export function parseGpuRestartPayload(stdout: string): GpuRestartDevice[] {
+  const trimmed = stdout.trim()
+  if (!trimmed) return []
+  try {
+    const raw = JSON.parse(trimmed) as
+      | { Name?: string; InstanceId?: string }
+      | Array<{ Name?: string; InstanceId?: string }>
+    const items = Array.isArray(raw) ? raw : [raw]
+    return items
+      .filter((d) => typeof d?.Name === 'string' && typeof d?.InstanceId === 'string')
+      .map((d) => ({ name: d.Name as string, instanceId: d.InstanceId as string }))
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Soft-restart display adapters via Disable/Enable-PnpDevice.
+ * Prefer this over key-injection of Win+Ctrl+Shift+B. Needs elevation.
+ */
+export async function restartGpuDrivers(): Promise<GpuRestartResult> {
+  const script = `
+$ErrorActionPreference = 'Stop'
+$devices = @(Get-PnpDevice -Class 'Display' -Status 'OK' -ErrorAction Stop)
+if ($devices.Count -eq 0) { '[]'; exit 0 }
+$restarted = @()
+$stuck = @()
+try {
+  foreach ($d in $devices) {
+    Disable-PnpDevice -InstanceId $d.InstanceId -Confirm:$false -ErrorAction Stop
+    Start-Sleep -Milliseconds 400
+    Enable-PnpDevice -InstanceId $d.InstanceId -Confirm:$false -ErrorAction Stop
+    $restarted += [pscustomobject]@{ Name = $d.FriendlyName; InstanceId = $d.InstanceId }
+  }
+} finally {
+  # Never leave an adapter disabled (black screen, safe-mode recovery): if
+  # anything above threw, re-enable whatever is still off before bailing.
+  Start-Sleep -Milliseconds 400
+  foreach ($d in $devices) {
+    $now = Get-PnpDevice -InstanceId $d.InstanceId -ErrorAction SilentlyContinue
+    if ($now -and $now.Status -ne 'OK') {
+      Enable-PnpDevice -InstanceId $d.InstanceId -Confirm:$false -ErrorAction SilentlyContinue
+      $again = Get-PnpDevice -InstanceId $d.InstanceId -ErrorAction SilentlyContinue
+      if ($again -and $again.Status -ne 'OK') { $stuck += $d.FriendlyName }
+    }
+  }
+}
+if ($stuck.Count -gt 0) {
+  Write-Error ('Display adapter(s) still disabled after restart: ' + ($stuck -join ', '))
+  exit 1
+}
+$restarted | ConvertTo-Json -Compress
+`.trim()
+
+  try {
+    const { stdout } = await execFileAsync(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', psUtf8(script)],
+      { timeout: 60_000, windowsHide: true, maxBuffer: 2 * 1024 * 1024 }
+    )
+    const devices = parseGpuRestartPayload(stdout)
+    return { ok: true, devices }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { ok: false, devices: [], error: message }
+  }
+}


### PR DESCRIPTION
## Summary
- `kudu --cli repair gpu-restart` soft-restarts class `Display` PnP devices (Disable then Enable).
- Requires administrator; exit code 3 when unelevated.
- No Win+Ctrl+Shift+B key injection (#394). GUI button left for a follow-up.

## Test plan
- [x] `npx vitest run src/main/platform/win32/gpu-restart.test.ts`
- [x] `npm run validate:rules && npm test && npm run build`
- [ ] Elevated Windows: run the command; screen may flicker briefly; adapters listed

Closes #394

Note: may conflict with #399 (`repair` surface) — rebase after that merges.
