### PR TITLE
fix(linux): keep AppImage updates on a stable filename

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -80,9 +80,15 @@ linux:
         - x64
   icon: resources/icons/
   category: Utility
-  artifactName: Kudu-${version}-${arch}.${ext}
+
+# Stable AppImage name so electron-updater overwrites in place (#401).
+# A versioned basename makes doInstall delete the old file and write a new
+# name, leaving desktop/menu Exec= paths pointing at a missing binary.
+appImage:
+  artifactName: Kudu-${arch}.${ext}
 
 deb:
+  artifactName: Kudu-${version}-${arch}.${ext}
   depends:
     - libgtk-3-0
     - libnss3

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -89,13 +89,21 @@ ok "Dependencies installed."
 log "Finding latest Kudu release..."
 RELEASE_JSON=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest")
 VERSION=$(echo "$RELEASE_JSON" | jq -r '.tag_name')
-ASSET_NAME="Kudu-${VERSION#v}-${ARCH_LABEL}.AppImage"
+# Prefer stable AppImage name (in-place auto-update). Fall back to legacy
+# versioned assets still present on older releases.
+ASSET_NAME="Kudu-${ARCH_LABEL}.AppImage"
 DOWNLOAD_URL=$(echo "$RELEASE_JSON" | jq -r \
   --arg name "$ASSET_NAME" \
   '.assets[] | select(.name == $name) | .browser_download_url')
+if [[ -z "$DOWNLOAD_URL" || "$DOWNLOAD_URL" == "null" ]]; then
+  ASSET_NAME="Kudu-${VERSION#v}-${ARCH_LABEL}.AppImage"
+  DOWNLOAD_URL=$(echo "$RELEASE_JSON" | jq -r \
+    --arg name "$ASSET_NAME" \
+    '.assets[] | select(.name == $name) | .browser_download_url')
+fi
 
 if [[ -z "$DOWNLOAD_URL" || "$DOWNLOAD_URL" == "null" ]]; then
-  err "Could not find AppImage asset: $ASSET_NAME"
+  err "Could not find AppImage asset (stable or versioned) for ${ARCH_LABEL}"
   err "Available assets:"
   echo "$RELEASE_JSON" | jq -r '.assets[].name' >&2
   exit 1

--- a/src/main/build-config.test.ts
+++ b/src/main/build-config.test.ts
@@ -59,4 +59,15 @@ describe('electron-builder.yml', () => {
     expect(block('win').some((l) => l.includes('target: portable'))).toBe(true)
     expect(option('portable', 'artifactName')).toBe('Kudu-Portable-${version}.${ext}')
   })
+
+  it('publishes a stable AppImage name for in-place Linux auto-update', () => {
+    // Versioned AppImage basenames make electron-updater write a new file and
+    // delete the old one, breaking desktop Exec= paths (#401).
+    expect(option('appImage', 'artifactName')).toBe('Kudu-${arch}.${ext}')
+    expect(option('appImage', 'artifactName')).not.toContain('${version}')
+  })
+
+  it('keeps versioned Linux deb artifact names', () => {
+    expect(option('deb', 'artifactName')).toBe('Kudu-${version}-${arch}.${ext}')
+  })
 })

--- a/src/main/services/appimage-launchers.test.ts
+++ b/src/main/services/appimage-launchers.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { rewriteDesktopExec } from './appimage-launchers'
+
+describe('rewriteDesktopExec', () => {
+  const oldPath = '/home/u/.local/bin/Kudu-2.7.0-x86_64.AppImage'
+  const newPath = '/home/u/.local/bin/Kudu-x86_64.AppImage'
+
+  it('rewrites Exec lines that reference the old AppImage path', () => {
+    const desktop = [
+      '[Desktop Entry]',
+      'Name=Kudu',
+      `Exec=${oldPath}`,
+      `TryExec=${oldPath}`,
+      'Type=Application',
+      '',
+    ].join('\n')
+    const next = rewriteDesktopExec(desktop, oldPath, newPath)
+    expect(next).toContain(`Exec=${newPath}`)
+    expect(next).toContain(`TryExec=${newPath}`)
+    expect(next).not.toContain(oldPath)
+  })
+
+  it('leaves unrelated lines and files alone', () => {
+    const desktop = ['[Desktop Entry]', 'Name=Other', 'Exec=/usr/bin/other', ''].join('\n')
+    expect(rewriteDesktopExec(desktop, oldPath, newPath)).toBe(desktop)
+  })
+
+  it('is a no-op when paths match or are empty', () => {
+    const desktop = `Exec=${oldPath}\n`
+    expect(rewriteDesktopExec(desktop, oldPath, oldPath)).toBe(desktop)
+    expect(rewriteDesktopExec(desktop, '', newPath)).toBe(desktop)
+  })
+})

--- a/src/main/services/appimage-launchers.ts
+++ b/src/main/services/appimage-launchers.ts
@@ -1,0 +1,55 @@
+import { readdirSync, readFileSync, writeFileSync } from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+
+/** Rewrite Exec= lines that still point at the old AppImage path (#401). */
+export function rewriteDesktopExec(content: string, oldPath: string, newPath: string): string {
+  if (!oldPath || !newPath || oldPath === newPath) return content
+  return content
+    .split('\n')
+    .map((line) => {
+      if (!line.startsWith('Exec=') && !line.startsWith('TryExec=')) return line
+      if (!line.includes(oldPath)) return line
+      return line.split(oldPath).join(newPath)
+    })
+    .join('\n')
+}
+
+/**
+ * After electron-updater renames a versioned AppImage, refresh XDG desktop
+ * entries that still Exec= the deleted path. Sync on purpose: this runs inside
+ * quitAndInstall before the process exits.
+ */
+export function retargetAppImageLaunchers(
+  oldPath: string,
+  newPath: string,
+  applicationsDir = join(homedir(), '.local', 'share', 'applications'),
+): number {
+  let updated = 0
+  let names: string[]
+  try {
+    names = readdirSync(applicationsDir)
+  } catch {
+    return 0
+  }
+
+  for (const name of names) {
+    if (!name.endsWith('.desktop')) continue
+    const filePath = join(applicationsDir, name)
+    let content: string
+    try {
+      content = readFileSync(filePath, 'utf-8')
+    } catch {
+      continue
+    }
+    const next = rewriteDesktopExec(content, oldPath, newPath)
+    if (next === content) continue
+    try {
+      writeFileSync(filePath, next, 'utf-8')
+      updated += 1
+    } catch {
+      /* best-effort — launcher may be root-owned */
+    }
+  }
+  return updated
+}

--- a/src/main/services/auto-updater.test.ts
+++ b/src/main/services/auto-updater.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const send = vi.fn()
+const checkForUpdatesMock = vi.fn()
+const onMock = vi.fn()
+
+vi.mock('electron', () => ({
+  app: { isPackaged: true },
+  BrowserWindow: {
+    getAllWindows: () => [{ isDestroyed: () => false, webContents: { send } }],
+  },
+}))
+
+vi.mock('electron-updater', () => ({
+  autoUpdater: {
+    autoDownload: false,
+    autoInstallOnAppQuit: false,
+    on: onMock,
+    checkForUpdates: checkForUpdatesMock,
+    downloadUpdate: vi.fn(),
+    quitAndInstall: vi.fn(),
+  },
+}))
+
+vi.mock('./settings-store', () => ({
+  getSettings: () => ({
+    autoUpdate: false,
+    autoRestart: false,
+    updateCheckIntervalHours: 0,
+  }),
+}))
+
+vi.mock('./appimage-launchers', () => ({
+  retargetAppImageLaunchers: vi.fn().mockReturnValue(0),
+}))
+
+describe('checkForUpdates UX', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    checkForUpdatesMock.mockResolvedValue(undefined)
+    delete process.env.APPIMAGE
+    delete process.env.PORTABLE_EXECUTABLE_DIR
+  })
+
+  it('broadcasts an error on Linux when not running as AppImage (silent no-op was the bug)', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+    const { checkForUpdates } = await import('./auto-updater')
+    await checkForUpdates()
+    expect(checkForUpdatesMock).not.toHaveBeenCalled()
+    expect(send).toHaveBeenCalledWith(
+      'updater:status',
+      expect.objectContaining({ state: 'error', error: expect.stringMatching(/AppImage/i) }),
+    )
+  })
+
+  it('runs electron-updater when APPIMAGE is set on Linux', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+    process.env.APPIMAGE = '/home/u/Kudu-x86_64.AppImage'
+    const { checkForUpdates } = await import('./auto-updater')
+    await checkForUpdates()
+    expect(checkForUpdatesMock).toHaveBeenCalled()
+  })
+})

--- a/src/main/services/auto-updater.ts
+++ b/src/main/services/auto-updater.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import { IPC } from '../../shared/channels'
 import { getSettings } from './settings-store'
+import { retargetAppImageLaunchers } from './appimage-launchers'
 import type { UpdateStatus } from '../../shared/types'
 
 let status: UpdateStatus = { state: 'idle' }
@@ -41,6 +42,17 @@ function shouldSkipUpdater(): boolean {
   // Portable builds set PORTABLE_EXECUTABLE_DIR; NSIS update flow would break.
   if (process.env.PORTABLE_EXECUTABLE_DIR) return true
   return false
+}
+
+function skipReason(): string {
+  if (!app.isPackaged) return 'Updates are unavailable in development builds'
+  if (process.platform === 'linux' && !process.env.APPIMAGE) {
+    return 'In-app updates require the AppImage build (deb/package installs use your package manager)'
+  }
+  if (process.env.PORTABLE_EXECUTABLE_DIR) {
+    return 'Portable builds do not support in-app updates'
+  }
+  return 'Updates are unavailable for this package format'
 }
 
 export function initAutoUpdater(opts: InitOptions = {}): void {
@@ -92,6 +104,19 @@ export function initAutoUpdater(opts: InitOptions = {}): void {
     broadcast({ state: 'error', error: err?.message || 'Update failed' })
   })
 
+  // Versioned → stable AppImage rename leaves .desktop Exec= on the deleted path (#401).
+  // Must stay sync: this fires inside quitAndInstall before the process exits.
+  autoUpdater.on('appimage-filename-updated', (newFile: string) => {
+    const oldFile = process.env.APPIMAGE
+    if (typeof newFile !== 'string' || !oldFile || oldFile === newFile) return
+    try {
+      retargetAppImageLaunchers(oldFile, newFile)
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.error('Auto-updater: failed to retarget desktop launchers:', message)
+    }
+  })
+
   // Check on startup
   autoUpdater.checkForUpdates().catch((err) => {
     console.error('Auto-updater check failed:', err?.message || err)
@@ -121,13 +146,27 @@ export function updateCheckInterval(hours: number): void {
 }
 
 export function checkForUpdates(): Promise<void> {
-  if (!app.isPackaged || shouldSkipUpdater()) return Promise.resolve()
-  return autoUpdater.checkForUpdates().then(() => {})
+  // About → Check for updates used to resolve with no status change when the
+  // package format is unsupported (common on Linux .deb), so the button looked dead.
+  if (!app.isPackaged || shouldSkipUpdater()) {
+    broadcast({ state: 'error', error: skipReason() })
+    return Promise.resolve()
+  }
+  return autoUpdater.checkForUpdates().then(() => {}).catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err)
+    broadcast({ state: 'error', error: message || 'Update check failed' })
+  })
 }
 
 export function downloadUpdate(): Promise<void> {
-  if (!app.isPackaged || shouldSkipUpdater()) return Promise.resolve()
-  return autoUpdater.downloadUpdate().then(() => {})
+  if (!app.isPackaged || shouldSkipUpdater()) {
+    broadcast({ state: 'error', error: skipReason() })
+    return Promise.resolve()
+  }
+  return autoUpdater.downloadUpdate().then(() => {}).catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err)
+    broadcast({ state: 'error', error: message || 'Update download failed' })
+  })
 }
 
 export function installUpdate(): void {


### PR DESCRIPTION
## Summary
- Publish AppImage as `Kudu-${arch}.AppImage` so electron-updater overwrites in place (#401). Versioned names deleted the old file and left desktop `Exec=` pointing at a missing path.
- On rename (legacy → stable), sync-rewrite `Exec=`/`TryExec=` under `~/.local/share/applications`.
- About → Check for updates no longer silently no-ops on Linux non-AppImage installs; shows why updates are unavailable.
- `install.sh` prefers the stable asset name, falls back to versioned releases.

## Test plan
- [x] `npx vitest run` for `appimage-launchers`, `auto-updater`, `build-config`
- [x] `npm run validate:rules && npm test && npm run build`
- [ ] Linux AppImage: About → check/download/install; launcher still opens after update
- [ ] Linux .deb: Check for updates shows AppImage/package-manager message (not a dead button)

Closes #401