### PR TITLE
fix(cli): report failed operations through the exit code

### DIFF
--- a/src/main/cli.test.ts
+++ b/src/main/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { parseCliArgs, ExitCode, cliLog, cliVerbose } from './cli'
+import { parseCliArgs, ExitCode, cliLog, cliVerbose, exitCodeForCleanResult, exitCodeForRestorePoint, exitCodeForRegistryFix } from './cli'
 
 describe('parseCliArgs', () => {
   it('requires a separate explicit opt-in for performance cache resets', () => {
@@ -171,5 +171,67 @@ describe('JSON stdout purity', () => {
     cliVerbose({ json: false, verbosity: 'verbose' }, 'took 12ms')
     expect(out).toEqual(['  [verbose] took 12ms\n'])
     expect(err).toEqual([])
+  })
+})
+
+describe('exitCodeForCleanResult', () => {
+  it('succeeds when nothing failed', () => {
+    expect(exitCodeForCleanResult({ filesDeleted: 12, errors: [] })).toBe(ExitCode.SUCCESS)
+  })
+
+  it('reports a partial success when some files were deleted and some failed', () => {
+    expect(exitCodeForCleanResult({ filesDeleted: 1833, errors: [{ path: 'a', reason: 'in-use' }] }))
+      .toBe(ExitCode.PARTIAL_SUCCESS)
+  })
+
+  it('fails outright when every item was rejected', () => {
+    // The shape `leftovers clean` returns today: 44 found, 44 rejected, and it
+    // still exited 0 before this graded the result.
+    const allRejected = Array.from({ length: 44 }, () => ({ reason: 'scan-result-expired' }))
+    expect(exitCodeForCleanResult({ filesDeleted: 0, errors: allRejected }))
+      .toBe(ExitCode.GENERAL_ERROR)
+  })
+
+  it('prefers the elevation code over the others', () => {
+    expect(exitCodeForCleanResult({ filesDeleted: 5, errors: [{}], needsElevation: true }))
+      .toBe(ExitCode.PERMISSION_DENIED)
+  })
+})
+
+describe('exitCodeForRestorePoint', () => {
+  it('succeeds when the restore point was created', () => {
+    expect(exitCodeForRestorePoint({ success: true })).toBe(ExitCode.SUCCESS)
+  })
+
+  it('fails when System Restore is switched off', () => {
+    expect(exitCodeForRestorePoint({
+      success: false,
+      error: 'Cannot start the service because it is disabled'
+    })).toBe(ExitCode.GENERAL_ERROR)
+  })
+
+  it('reports missing elevation separately', () => {
+    expect(exitCodeForRestorePoint({
+      success: false,
+      error: 'Administrator privileges required to create a restore point.'
+    })).toBe(ExitCode.PERMISSION_DENIED)
+  })
+
+  it('still fails when no error text came back', () => {
+    expect(exitCodeForRestorePoint({ success: false })).toBe(ExitCode.GENERAL_ERROR)
+  })
+})
+
+describe('exitCodeForRegistryFix', () => {
+  it('succeeds when every entry was fixed', () => {
+    expect(exitCodeForRegistryFix({ fixed: 640, failed: 0 })).toBe(ExitCode.SUCCESS)
+  })
+
+  it('reports a partial success when one entry resisted', () => {
+    expect(exitCodeForRegistryFix({ fixed: 639, failed: 1 })).toBe(ExitCode.PARTIAL_SUCCESS)
+  })
+
+  it('fails when nothing could be fixed', () => {
+    expect(exitCodeForRegistryFix({ fixed: 0, failed: 7 })).toBe(ExitCode.GENERAL_ERROR)
   })
 })

--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -36,6 +36,45 @@ export const ExitCode = {
   SCAN_THREATS: 7,
 } as const
 
+/**
+ * Exit code for an operation that deleted files.
+ *
+ * A run that reports success while nothing was removed is worse than a loud
+ * failure: a scheduled task has no other signal to go on. `runLegacyScanClean`
+ * has always graded its result this way; sharing the rule keeps every delete
+ * path in agreement.
+ */
+export function exitCodeForCleanResult(result: {
+  filesDeleted: number
+  errors: readonly unknown[]
+  needsElevation?: boolean
+}): number {
+  if (result.errors.length === 0) return ExitCode.SUCCESS
+  if (result.needsElevation) return ExitCode.PERMISSION_DENIED
+  if (result.filesDeleted > 0) return ExitCode.PARTIAL_SUCCESS
+  return ExitCode.GENERAL_ERROR
+}
+
+/**
+ * Exit code for `restore-point create`.
+ *
+ * `createRestorePoint` resolves with `{ success: false }` instead of rejecting,
+ * so a failed restore point used to exit 0 — leaving the caller to believe the
+ * safety net it just asked for exists when it does not.
+ */
+export function exitCodeForRestorePoint(result: { success: boolean; error?: string }): number {
+  if (result.success) return ExitCode.SUCCESS
+  return /administrator|elevat|privileg/i.test(result.error ?? '')
+    ? ExitCode.PERMISSION_DENIED
+    : ExitCode.GENERAL_ERROR
+}
+
+/** Exit code for `registry fix`, which reports per-entry successes and failures. */
+export function exitCodeForRegistryFix(result: { fixed: number; failed: number }): number {
+  if (result.failed === 0) return ExitCode.SUCCESS
+  return result.fixed > 0 ? ExitCode.PARTIAL_SUCCESS : ExitCode.GENERAL_ERROR
+}
+
 export interface ParsedCliArgs {
   command: string | undefined
   commandArgs: string[]
@@ -628,6 +667,7 @@ async function handleRegistry(args: string[], ctx: CliContext): Promise<number |
     })
     if (showProgress(ctx)) log('')
     cliOut(ctx, result)
+    return exitCodeForRegistryFix(result)
   } else {
     cliUsage(ctx, 'kudu --cli registry <scan|fix> [--all] [--json]')
     return ExitCode.INVALID_ARGS
@@ -1060,6 +1100,7 @@ async function handleLeftovers(args: string[], ctx: CliContext): Promise<number 
       const itemIds = results.flatMap(r => r.items.map(i => i.id))
       const cleanResult = await cleanItems(itemIds, undefined, 'cli')
       cliOut(ctx, cleanResult)
+      return exitCodeForCleanResult(cleanResult)
     }
   } else {
     cliUsage(ctx, 'kudu --cli leftovers <scan|clean>')
@@ -1166,6 +1207,7 @@ async function handleRestorePoint(args: string[], ctx: CliContext): Promise<numb
     cliLog(ctx, `Creating restore point: ${description}...`)
     const result = await createRestorePoint(description)
     cliOut(ctx, result)
+    return exitCodeForRestorePoint(result)
   } else {
     cliUsage(ctx, 'kudu --cli restore-point create [description]')
     return ExitCode.INVALID_ARGS
@@ -1569,10 +1611,9 @@ async function runLegacyScanClean(categories: string[], doClean: boolean, ctx: C
   }
 
   // Determine exit code
-  if (cleanResult?.errors.length) {
-    if (cleanResult.needsElevation) return ExitCode.PERMISSION_DENIED
-    if (cleanResult.filesDeleted > 0) return ExitCode.PARTIAL_SUCCESS
-    return ExitCode.GENERAL_ERROR
+  if (cleanResult) {
+    const code = exitCodeForCleanResult(cleanResult)
+    if (code !== ExitCode.SUCCESS) return code
   }
   if (totalItems === 0) return ExitCode.NOTHING_FOUND
   return ExitCode.SUCCESS


### PR DESCRIPTION
Closes #413

## Problem

Three subcommands print a failure and then exit `0`. For a human at a terminal that is a cosmetic bug; for the scheduled-task and scripting use cases `CLI.md` explicitly advertises, it means a job can report success for months while doing nothing.

I hit all three while running a full pass on a real Windows 11 machine:

**`restore-point create`** — `createRestorePoint` resolves with `{ success: false, error }` instead of rejecting, and `handleRestorePoint` prints the result without grading it. System Restore was disabled on the machine, so the output was:

```
Creating restore point: Before Kudu full clean...
  success: false
  error: Cannot start the service because it is disabled ...
```

…and the process exited `0`. This is the worst of the three: the restore point is the safety net taken *before* cleaning, and the script that asked for it was told it exists.

**`leftovers clean`** — exits `0` after rejecting every item (`44` found, `44` rejected as `scan-result-expired`; see #405 for the cause).

**`registry fix`** — exits `0` whether it fixed 640 entries, 639 of 640, or none.

## Changes

`runLegacyScanClean` already graded its clean result correctly:

```ts
if (cleanResult?.errors.length) {
  if (cleanResult.needsElevation) return ExitCode.PERMISSION_DENIED
  if (cleanResult.filesDeleted > 0) return ExitCode.PARTIAL_SUCCESS
  return ExitCode.GENERAL_ERROR
}
```

So this lifts that rule into `exitCodeForCleanResult()` and reuses it rather than inventing a second convention — the legacy path now calls the shared helper, and `leftovers clean` gets the same grading. Two small siblings cover the other cases:

- `exitCodeForRestorePoint()` — `PERMISSION_DENIED` when the error names elevation, `GENERAL_ERROR` otherwise.
- `exitCodeForRegistryFix()` — `PARTIAL_SUCCESS` when some entries failed, `GENERAL_ERROR` when none were fixed.

No new exit codes: every value used here is already documented in `CLI.md`, including `4 = partial success`, which nothing was returning.

The helpers are pure and exported so they can be tested directly — the same approach already used for `parseCliArgs` and `cliLog`.

## Testing

- 11 new cases in `src/main/cli.test.ts`, written against the real shapes observed: 1833 deleted with in-use errors → partial, 44-of-44 rejected → error, System Restore disabled → error, missing elevation → permission denied.
- `npm test` — 132 files / 2644 tests pass.
- Typecheck: 204 errors before and after this branch, i.e. no new ones; none in `cli.ts`.

## Note

This does not change *whether* anything gets cleaned — only what the process reports. In particular `leftovers clean` will now exit non-zero until #405 is fixed, which is the honest signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

