### PR TITLE
fix(malware): stop pre-selecting advisory YARA hits for deletion

### DIFF
--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -22,7 +22,7 @@ import { validateStringArray } from '../services/ipc-validation'
 import { execNativeUtf8 } from '../services/exec-utf8'
 import { getSettings, getMalwareAllowlist, addMalwareAllowlistEntry, removeMalwareAllowlistEntry } from '../services/settings-store'
 import { isExcluded } from '../services/file-utils'
-import { createYaraEngine, yaraMatchToThreatFields, type YaraEngine } from '../services/yara-engine'
+import { createYaraEngine, yaraMatchToThreatFields, isAdvisoryDetection, type YaraEngine } from '../services/yara-engine'
 import { getAllRulePaths, getCachedRulePaths, getRulesMetadata, startPeriodicRuleChecks, fetchAndCacheRules, RULES_ENDPOINT } from '../services/yara-rules-store'
 import { CooperativeScheduler } from '../services/cooperative-scheduler'
 import { getMalwareScanCoverage } from './malware-scan-coverage'
@@ -1455,7 +1455,9 @@ export async function scanMalware(
             severity: fields.severity,
             source: 'signature',
             details: fields.details,
-            selected: true,
+            // Advisory rules — vulnerable drivers, obfuscator fingerprints — are
+            // reported but not pre-ticked. See isAdvisoryDetection.
+            selected: !isAdvisoryDetection(fields.detectionName),
           })
           sigThreatsCount++
         }

--- a/src/main/services/yara-engine.test.ts
+++ b/src/main/services/yara-engine.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { YaraEngine } from './yara-engine'
+import { YaraEngine, isAdvisoryDetection } from './yara-engine'
 
 // ─── Test pure conversion logic (replicated to avoid Electron imports) ───
 
@@ -262,5 +262,38 @@ describe('YaraEngine.scanFile', () => {
     release()
     expect(terminate).toHaveBeenCalledOnce()
     expect(engine.isReady()).toBe(false)
+  })
+})
+
+describe('isAdvisoryDetection', () => {
+  it('does not pre-select a vulnerable-driver hit', () => {
+    // A signed HyperX NGENUITY driver with a known CVE. Deleting it breaks the
+    // peripheral software; the remedy is a vendor update.
+    expect(isAdvisoryDetection('Windows.VulnDriver.Otipcibus64.7d564eba')).toBe(true)
+  })
+
+  it('does not pre-select an obfuscator fingerprint', () => {
+    // ConfuserEx is a commercial .NET obfuscator; this fired on all four files
+    // of a paid consumer application.
+    expect(isAdvisoryDetection('SUSP.NET.NAME.ConfuserEx')).toBe(true)
+  })
+
+  it('matches the underscore form rule names fall back to', () => {
+    expect(isAdvisoryDetection('SUSP_NET_NAME_ConfuserEx')).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    expect(isAdvisoryDetection('windows.vulndriver.something')).toBe(true)
+    expect(isAdvisoryDetection('susp.packer.upx')).toBe(true)
+  })
+
+  it('still pre-selects real malware families', () => {
+    expect(isAdvisoryDetection('Trojan.Win32.Emotet')).toBe(false)
+    expect(isAdvisoryDetection('Ransom.Wannacry')).toBe(false)
+    expect(isAdvisoryDetection('Backdoor.Generic')).toBe(false)
+  })
+
+  it('does not fire on an unrelated name that merely contains "susp"', () => {
+    expect(isAdvisoryDetection('Trojan.Suspenders')).toBe(false)
   })
 })

--- a/src/main/services/yara-engine.ts
+++ b/src/main/services/yara-engine.ts
@@ -507,6 +507,29 @@ export function createYaraEngine(): YaraEngine {
  */
 const VALID_SEVERITIES = new Set(['critical', 'high', 'medium', 'low'] as const)
 
+/**
+ * Whether a YARA hit should arrive pre-ticked for quarantine or deletion.
+ *
+ * Not every rule that fires means "this file is malware". Two families in the
+ * shipped set describe risk or provenance instead:
+ *
+ * - `Windows.VulnDriver.*` — a legitimate, signed driver carrying a known
+ *   vulnerability. It is normally a component of software the user installed
+ *   deliberately, so deleting it breaks that software rather than removing a
+ *   threat; the fix is a vendor update, not quarantine.
+ * - `SUSP.*` — packers, obfuscators and similar traits that legitimate
+ *   software uses too. `SUSP_NET_NAME_ConfuserEx` fires on ConfuserEx, a
+ *   commercial .NET obfuscator shipped inside paid consumer applications.
+ *
+ * Both are still reported at their stated severity. They simply require a
+ * decision rather than arriving already selected, so that one click on
+ * "Delete" cannot remove working software the user paid for.
+ */
+export function isAdvisoryDetection(detectionName: string): boolean {
+  const name = detectionName.toLowerCase()
+  return name.startsWith('susp.') || name.startsWith('susp_') || name.includes('vulndriver')
+}
+
 export function yaraMatchToThreatFields(match: YaraMatch): {
   detectionName: string
   severity: 'critical' | 'high' | 'medium' | 'low'


### PR DESCRIPTION
Closes #415

## Problem

Every YARA match is pushed with `selected: true`, so **"Select all" → "Delete permanently" is one click away from removing working software**.

Two rule families in the shipped set describe *risk* or *provenance* rather than malware:

- **`Windows.VulnDriver.*`** — a legitimate, vendor-signed driver carrying a known vulnerability (the BYOVD class). It is normally a component of software the user installed deliberately. Deleting it breaks that software without removing a threat; the remedy is a vendor update or blocklist policy.
- **`SUSP.*`** — packers, obfuscators and similar traits that legitimate software also uses.

A scan on my Windows 11 machine returned six hits. **Five arrived pre-selected:**

| Detection | File | What it actually is |
|---|---|---|
| `Windows.VulnDriver.Otipcibus64.7d564eba` | `otipcibus64.sys` | signed driver inside HyperX NGENUITY |
| `SUSP.NET.NAME.ConfuserEx` ×4 | `iCareFone Transfer.exe` + 3 DLLs | a paid consumer app, obfuscated with ConfuserEx |

The single genuinely suspicious file — `Heuristic.Suspicious.PE` with `CreateRemoteThread`, `VirtualAllocEx`, `WriteProcessMemory` and `GetClipboardData` imports — was the **only one not selected**, because the heuristic path already defaults to `false` (`malware-scanner.ipc.ts:1526`).

So the current defaults are inverted relative to risk: the findings that need a human decision are pre-ticked, and the one that warrants scrutiny is not.

## Changes

`isAdvisoryDetection(detectionName)` in `yara-engine.ts`, applied at the one YARA push site:

```ts
selected: !isAdvisoryDetection(fields.detectionName),
```

It matches on `detectionName`, which `yaraMatchToThreatFields` derives from rule metadata or the rule name with `_` → `.`, so both `SUSP.NET.NAME.ConfuserEx` and the raw `SUSP_NET_NAME_ConfuserEx` form are covered.

Nothing is hidden or downgraded: both families still appear in the results at their stated severity, and the user can still tick them. This only removes them from the default selection so that a single click cannot delete them.

## Testing

- 6 new cases in `yara-engine.test.ts` using the real detection names above, plus a guard that `Trojan.Suspenders` does not match on a bare `susp` substring, and that ordinary families (`Trojan.Win32.Emotet`, `Ransom.Wannacry`, `Backdoor.Generic`) stay pre-selected.
- `npm test` — 132 files / 2639 tests pass (2633 on `main`, +6).
- Typecheck: 204 errors before and after; the three in `yara-engine.*` are pre-existing on `main` and unrelated.

## Possible follow-up

If you would rather surface this in the UI than only in the default selection, an `advisory` flag on the threat would let the list group these as "review" separately from "remove". Happy to do that instead if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

