### PR TITLE
fix(startup): stop attributing boot-trace entries to HKCU Run

### DIFF
--- a/src/main/ipc/startup-manager.ipc.test.ts
+++ b/src/main/ipc/startup-manager.ipc.test.ts
@@ -1530,3 +1530,21 @@ describe('error resilience', () => {
     expect(writeOrder.length).toBeGreaterThanOrEqual(2)
   })
 })
+
+describe('getBootTrace source attribution', () => {
+  it('does not claim an autostart location it cannot know', async () => {
+    // The boot-performance event log reports a process and a delay only. Every
+    // entry used to be stamped 'registry-hkcu', which reported a Run entry that
+    // need not exist — a VM launched by hand shortly after logon was presented
+    // as an autostart item.
+    mockExecFile.mockImplementation((_c: string, _a: string[], _o: object, cb: Function) => {
+      cb(null, [
+        'BOOT|15000|8000|2025-06-15T10:30:00.000Z',
+        'APP|SomeApp|5000|C:\Some\app.exe',
+      ].join('\n'), '')
+    })
+    const trace = await getBootTrace()
+    expect(trace.entries.length).toBe(1)
+    expect(trace.entries[0].source).toBeNull()
+  })
+})

--- a/src/main/ipc/startup-manager.ipc.ts
+++ b/src/main/ipc/startup-manager.ipc.ts
@@ -864,7 +864,10 @@ export async function getBootTrace(): Promise<StartupBootTrace> {
             name: appName,
             displayName: deriveDisplayName(appName, filePath),
             delayMs,
-            source: 'registry-hkcu',
+            // The event log gives a process and a delay, never an autostart
+            // location — claiming HKCU Run here reported a registry entry that
+            // may not exist.
+            source: null,
             impact: delayMs > 3000 ? 'high' : delayMs > 1000 ? 'medium' : 'low'
           })
         }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -209,7 +209,14 @@ export interface StartupBootEntry {
   name: string
   displayName: string
   delayMs: number
-  source: StartupItem['source']
+  /**
+   * Where the app is launched from, or null when it could not be determined.
+   *
+   * The Windows boot-performance event log records which processes ran during
+   * boot and how long they delayed it, but says nothing about the autostart
+   * mechanism behind them, so entries derived from it carry null.
+   */
+  source: StartupItem['source'] | null
   impact: StartupItem['impact']
 }
 


### PR DESCRIPTION
Closes #416

## Problem

`getBootTrace()` stamps every entry it parses out of the Windows boot-performance event log with a fixed source:

```ts
entries.push({
  name: appName,
  displayName: deriveDisplayName(appName, filePath),
  delayMs,
  source: 'registry-hkcu',   // <-- always
  impact: ...
})
```

That log records *which processes ran during boot and how long they delayed it*. It carries no autostart location, so the attribution is a guess presented as a fact.

It misleads in the obvious way. On my machine the trace listed:

```json
{ "name": "VirtualBoxVM.exe", "delayMs": 16946, "source": "registry-hkcu", "impact": "high" }
```

There is no such Run entry — not in `HKCU`/`HKLM` `Run` or `RunOnce`, not in `StartupApproved`, not in either Startup folder, not in Task Scheduler, and nothing matching in `Win32_StartupCommand`. The VM had simply been launched by hand shortly after logon on the boot being measured, so it landed in the window and got labelled. Acting on the report means hunting for a registry entry that was never there.

## Changes

- `StartupBootEntry.source` becomes `StartupItem['source'] | null`, documented as "null when it could not be determined".
- The boot-trace builder sets `null` instead of asserting HKCU Run.

No caller is affected: the renderer's `BootTracePanel` reads `displayName`, `delayMs`, `impact` and `name` only, never `source`.

## Scope

Only the attribution is wrong — the rest of the panel is sound. `lastBootDate` is populated and the UI already renders it (`bootTraceLastBoot`), so the age of the data is visible; the timings themselves come straight from the event log.

Resolving the real source would mean cross-referencing the enumerated startup items, which is a bigger change and not obviously wanted given nothing consumes the field today. Reporting "unknown" seemed better than reporting a wrong answer confidently — happy to do the lookup instead if you'd prefer that.

## Testing

- New case asserting a parsed entry carries `source: null`.
- `npm test` — 132 files / 2634 tests pass (2633 on `main`, +1).
- Typecheck: 204 (node) and 2 (web) errors before and after; both pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

