### PR TITLE
chore: point blame-ignore-revs at the squashed reformat commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,5 @@
 # Commits to skip in `git blame`. Use with:
 #   git config blame.ignoreRevsFile .git-blame-ignore-revs
 
-9338b0b8d3cf89cf344ffa9f01ff59317a807110  style: format codebase with prettier
+# style: format codebase with prettier (squashed into #420)
+c6a85e93


### PR DESCRIPTION
The SHA recorded in #420 was the pre-squash commit and no longer exists on main. Full SHA: c6a85e93d9e236c122195e4ea4fd80fe34308e52