### PR TITLE
fix(malware): avoid Tor Browser and Thunderbird heuristic false positives

### DIFF
--- a/src/main/ipc/malware-publisher-trust.ts
+++ b/src/main/ipc/malware-publisher-trust.ts
@@ -80,9 +80,9 @@ const TRUSTED_PATHS = [
 ]
 
 // These Mozilla-based applications trigger PE packing/import heuristics (#408).
-// Suppress only those heuristics, including under Program Files; their folder
-// names must not opt executables out of YARA/content signature scanning.
-const HEURISTIC_ONLY_PATHS = ['tor browser', 'mozilla thunderbird']
+// This exception is deliberately separate from publisher trust: directory names
+// must not suppress signature, shortcut, registry or scheduled-task checks.
+const PE_HEURISTIC_EXCEPTIONS = ['tor browser', 'mozilla thunderbird']
 
 // Dependency trees legitimately hold packed helper binaries but live anywhere on
 // disk, so they are matched as a path component without an installation root.
@@ -144,13 +144,29 @@ export function publisherTrust(
   const match = trustedRoots.find(({ root }) => normalized.startsWith(root + '/'))
   if (!match) return 'none'
 
-  const relativeDirs = normalized
+  const hasVendorDir = normalized
     .slice(match.root.length + 1)
     .split('/')
     .slice(0, -1)
-  if (relativeDirs.some((d) => HEURISTIC_ONLY_PATHS.includes(d))) return 'heuristics'
-  const hasVendorDir = relativeDirs.some((d) => TRUSTED_PATHS.includes(d))
+    .some((d) => TRUSTED_PATHS.includes(d))
   return hasVendorDir ? match.trust : 'none'
+}
+
+/** Only the PE detector may use this; it grants no publisher/command trust. */
+export function hasPEHeuristicException(
+  filePath: string,
+  trustedRoots: readonly TrustedRoot[]
+): boolean {
+  const normalized = normalizeForTrust(filePath)
+  const dirs = normalized.split('/').slice(0, -1)
+  if (dirs.some((d) => NEVER_TRUSTED_DIRS.includes(d))) return false
+  const root = trustedRoots.find(({ root }) => normalized.startsWith(root + '/'))
+  if (!root) return false
+  return normalized
+    .slice(root.root.length + 1)
+    .split('/')
+    .slice(0, -1)
+    .some((d) => PE_HEURISTIC_EXCEPTIONS.includes(d))
 }
 
 /** Registry Run / scheduled-task commands → bare executable path. */

--- a/src/main/ipc/malware-publisher-trust.ts
+++ b/src/main/ipc/malware-publisher-trust.ts
@@ -79,6 +79,11 @@ const TRUSTED_PATHS = [
   'seatools5'
 ]
 
+// These Mozilla-based applications trigger PE packing/import heuristics (#408).
+// Suppress only those heuristics, including under Program Files; their folder
+// names must not opt executables out of YARA/content signature scanning.
+const HEURISTIC_ONLY_PATHS = ['tor browser', 'mozilla thunderbird']
+
 // Dependency trees legitimately hold packed helper binaries but live anywhere on
 // disk, so they are matched as a path component without an installation root.
 // Only ever below a package directory (`node_modules/<pkg>/…`, `node_modules/.bin/…`):
@@ -139,11 +144,12 @@ export function publisherTrust(
   const match = trustedRoots.find(({ root }) => normalized.startsWith(root + '/'))
   if (!match) return 'none'
 
-  const hasVendorDir = normalized
+  const relativeDirs = normalized
     .slice(match.root.length + 1)
     .split('/')
     .slice(0, -1)
-    .some((d) => TRUSTED_PATHS.includes(d))
+  if (relativeDirs.some((d) => HEURISTIC_ONLY_PATHS.includes(d))) return 'heuristics'
+  const hasVendorDir = relativeDirs.some((d) => TRUSTED_PATHS.includes(d))
   return hasVendorDir ? match.trust : 'none'
 }
 

--- a/src/main/ipc/malware-scanner.ipc.ts
+++ b/src/main/ipc/malware-scanner.ipc.ts
@@ -45,6 +45,7 @@ import { CooperativeScheduler } from '../services/cooperative-scheduler'
 import { getMalwareScanCoverage } from './malware-scan-coverage'
 import {
   buildTrustedRoots,
+  hasPEHeuristicException,
   publisherTrust as matchPublisherTrust,
   toExecutablePath,
   type PublisherTrust,
@@ -1877,6 +1878,7 @@ export async function scanMalware(
       const needsBuffer =
         trust === 'none' &&
         ((shouldAnalyzePE &&
+          !hasPEHeuristicException(filePath, getTrustedRoots()) &&
           (ext === '.exe' ||
             ext === '.dll' ||
             ext === '.scr' ||

--- a/src/main/ipc/malware-scanner.test.ts
+++ b/src/main/ipc/malware-scanner.test.ts
@@ -1,6 +1,7 @@
 ﻿import { describe, it, expect } from 'vitest'
 import {
   buildTrustedRoots,
+  hasPEHeuristicException,
   publisherTrust as matchPublisherTrust,
   toExecutablePath
 } from './malware-publisher-trust'
@@ -405,7 +406,8 @@ describe('publisher trust level', () => {
   ])(
     'suppresses Mozilla PE false positives while retaining signature scanning: %s (#408)',
     (path) => {
-      expect(publisherTrust(path)).toBe('heuristics')
+      expect(hasPEHeuristicException(path, TRUSTED_ROOTS)).toBe(true)
+      expect(publisherTrust(path)).toBe('none')
     }
   )
 
@@ -421,6 +423,7 @@ describe('publisher trust level', () => {
   ])(
     'keeps lookalikes and scratch/unknown locations subject to all detectors: %s (#408)',
     (path) => {
+      expect(hasPEHeuristicException(path, TRUSTED_ROOTS)).toBe(false)
       expect(publisherTrust(path)).toBe('none')
     }
   )
@@ -450,6 +453,15 @@ describe('publisher trust level', () => {
 })
 
 describe('trusted command detection', () => {
+  it.each([
+    '"C:\\Users\\Test\\AppData\\Roaming\\Tor Browser\\powershell.exe" -EncodedCommand ZQB2AGkAbAA=',
+    '"C:\\Users\\Test\\AppData\\Local\\Mozilla Thunderbird\\mshta.exe" https://example.invalid/payload.hta',
+    '"C:\\Program Files\\Mozilla Thunderbird\\thunderbird.exe" --suspicious-arguments'
+  ])('never grants persistence trust through a PE-only exception: %s (#408)', (command) => {
+    expect(hasPEHeuristicException(toExecutablePath(command), TRUSTED_ROOTS)).toBe(true)
+    expect(isTrustedCommand(command)).toBe(false)
+  })
+
   it('unwraps quoted commands with arguments', () => {
     expect(isTrustedCommand('"C:\\Program Files\\Microsoft\\Teams\\teams.exe" --startup')).toBe(
       true

--- a/src/main/ipc/malware-scanner.test.ts
+++ b/src/main/ipc/malware-scanner.test.ts
@@ -394,6 +394,37 @@ describe('trusted path detection', () => {
 })
 
 describe('publisher trust level', () => {
+  it.each([
+    'C:\\Users\\Test\\AppData\\Roaming\\Tor Browser\\Browser\\firefox.exe',
+    'C:\\Users\\Test\\AppData\\Roaming\\Tor Browser\\Browser\\plugin-container.exe',
+    'C:\\Program Files\\Mozilla Thunderbird\\thunderbird.exe',
+    'C:\\Program Files (x86)\\Mozilla Thunderbird\\thunderbird.exe',
+    'C:/Users/Test/AppData/Local/Programs/Mozilla Thunderbird/thunderbird.exe',
+    'C:\\Program Files\\Tor Browser\\Browser\\firefox.exe',
+    'C:\\PROGRAM FILES\\MOZILLA THUNDERBIRD\\THUNDERBIRD.EXE'
+  ])(
+    'suppresses Mozilla PE false positives while retaining signature scanning: %s (#408)',
+    (path) => {
+      expect(publisherTrust(path)).toBe('heuristics')
+    }
+  )
+
+  it.each([
+    'C:\\Users\\Test\\Downloads\\Tor Browser\\Browser\\firefox.exe',
+    'C:\\Users\\Test\\Downloads\\Mozilla Thunderbird\\thunderbird.exe',
+    'C:\\Users\\Test\\AppData\\Local\\Temp\\Tor Browser\\Browser\\firefox.exe',
+    'C:\\Program Files\\Mozilla Thunderbird\\Cache\\payload.exe',
+    'C:\\Program Files\\Mozilla Thunderbird Fake\\thunderbird.exe',
+    'C:\\Program Files\\Tor Browser Fake\\firefox.exe',
+    'C:\\Program Files\\Mozilla Thunderbird.exe',
+    'D:\\Unknown\\Tor Browser\\Browser\\firefox.exe'
+  ])(
+    'keeps lookalikes and scratch/unknown locations subject to all detectors: %s (#408)',
+    (path) => {
+      expect(publisherTrust(path)).toBe('none')
+    }
+  )
+
   it('grants full trust under roots that need elevation to write', () => {
     expect(publisherTrust('C:\\Program Files\\Google\\Chrome\\chrome.exe')).toBe('full')
   })


### PR DESCRIPTION
﻿Fixes #408

The screenshot reports Tor Browser's `Browser/firefox.exe` and `Browser/plugin-container.exe` under AppData Roaming, plus `Mozilla Thunderbird/thunderbird.exe` under Program Files. Legitimate packed Mozilla binaries at those paths were sent through PE heuristics.

Add a PE-only exception for exact `tor browser` and `mozilla thunderbird` directory components beneath existing installation roots. The exception is used only in the PE buffer-read decision; it grants no publisher or command trust. YARA/content signatures, suspicious filenames, double extensions, shortcut analysis, registry persistence, and scheduled-task checks retain their existing behavior. Downloads, Temp, cache directories, unknown roots, and lookalike names remain excluded from the exception.

Validation: `npm run check` passed (137 test files / 2,706 tests; existing lint warnings, no errors), `npm run build` and `git diff --check` passed. Eighteen regression cases exercise the reported paths, x86/per-user installs, path case/separators, negative path boundaries, and persistence commands using the production matcher. The reporter's actual binaries were not available for an end-to-end rescan.
