### PR TITLE
fix(ci): allow macOS recovery uploads to existing releases

### DIFF
--- a/.github/workflows/rebuild-macos.yml
+++ b/.github/workflows/rebuild-macos.yml
@@ -76,6 +76,8 @@ jobs:
       - name: Build, sign, notarize, and upload macOS
         env:
           GH_TOKEN: ${{ github.token }}
+          # Recovery intentionally uploads to a release older than two hours.
+          EP_GH_IGNORE_TIME: 'true'
           CSC_LINK: ${{ secrets.MAC_CERTIFICATE_P12 }}
           CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTIFICATE_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}


### PR DESCRIPTION
The first v2.8.0 recovery run successfully signed and notarized both macOS architectures, but electron-builder silently skipped all uploads because the release was more than two hours old. The final asset check correctly failed.

Set electron-builder's EP_GH_IGNORE_TIME only in the manual recovery job so it can upload to the existing release. The existing latest-release, source-scope, and production-dependency guards remain in effect.

Validation: npm run check passed (137 files / 2,688 tests), plus git diff --check. The installed electron-publish source confirms this flag bypasses its two-hour publishing cutoff. Recovery will be rerun against the same v2.8.0 source commit.
